### PR TITLE
Upstream changes: Add ability to use local jinja template for html em…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,5 +79,7 @@ celerybeat-schedule
 /scripts/run_my_tests.sh
 .vscode
 
+jinja_templates/
+
 # Terraform
 .terraform

--- a/README.md
+++ b/README.md
@@ -141,6 +141,24 @@ make freeze-requirements
 
 `requirements.txt` should be committed alongside `requirements-app.txt` changes.
 
+## Using Local Jinja for testing template changes
+
+Jinja templates used in this repo: `email_template.jinja2`
+
+Jinja templates are pulled in from the [notification-utils](https://github.com/cds-snc/notification-utils) repo. To test jinja changes locally (without needing to update the upstream), follow this procedure:
+
+1. Create a `jinja_templates` folder in the project root directory. This folder name is already gitignored and won't be tracked.
+
+2. Copy the jinja template files from [notification-utils](https://github.com/cds-snc/notification-utils) into the `jinja_templates` folder created in step 1
+
+3. Set a new .ENV variable: `USE_LOCAL_JINJA_TEMPLATES=True`
+
+4. Make markup changes, and see them locally!
+
+5. When finished, copy any changed jinja files back to notification-utils, and push up the PR for your changes in that repo.
+
+6. Remove `USE_LOCAL_JINJA_TEMPLATES=True` from your .env file, and delete any jinja in `jinja_templates`. Deleting the folder and jinja files is not required, but recommended. Make sure you're pulling up-to-date jinja from notification-utils the next time you need to make changes.
+
 ## Frequent problems
 
 __Problem__ : `E999 SyntaxError: invalid syntax` when running `flake8`

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import os
 import urllib.request
 import magic
 import re
@@ -134,9 +135,16 @@ def send_email_to_provider(notification):
 
         template_dict = dao_get_template_by_id(notification.template_id, notification.template_version).__dict__
 
+        # Local Jinja support - Add USE_LOCAL_JINJA_TEMPLATES=True to .env
+        # Add a folder to the project root called 'jinja_templates'
+        # with a copy of 'email_template.jinja2' from notification-utils repo
+        debug_template_path = (os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+                               if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') == 'True' else None)
+
         html_email = HTMLEmailTemplate(
             template_dict,
             values=personalisation_data,
+            jinja_path=debug_template_path,
             **get_html_email_options(service)
         )
 

--- a/application.py
+++ b/application.py
@@ -23,3 +23,13 @@ sentry_sdk.init(
 application = Flask('app')
 application.wsgi_app = ProxyFix(application.wsgi_app)
 create_app(application)
+
+if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') == 'True':
+    print('')
+    print('========================================================')
+    print('')
+    print('WARNING: USING LOCAL JINJA from /jinja_templates FOLDER!')
+    print('.env USE_LOCAL_JINJA_TEMPLATES=True')
+    print('')
+    print('========================================================')
+    print('')

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -43,7 +43,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@40.0.2#egg=notifications-utils==40.0.2
+git+https://github.com/cds-snc/notifier-utils.git@41.0.0#egg=notifications-utils==41.0.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@40.0.2#egg=notifications-utils==40.0.2
+git+https://github.com/cds-snc/notifier-utils.git@41.0.0#egg=notifications-utils==41.0.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 


### PR DESCRIPTION
Upstream changes: Add ability to use local jinja template for html emails (#796)

original commit: 5e709e7e Bethany Dunfield <bethany.dunfield@cds-snc.ca> on 4/27/20 at 9:17 AM

This seems quite useful for working on email template changes.