### PR TITLE
Use html_body when sending emails via Granicus.

### DIFF
--- a/app/clients/email/govdelivery_client.py
+++ b/app/clients/email/govdelivery_client.py
@@ -44,7 +44,7 @@ class GovdeliveryClient(EmailClient):
                    to_addresses,
                    subject,
                    body,
-                   html_body='',
+                   html_body,
                    reply_to_address=None,
                    attachments=[]):
         try:
@@ -62,7 +62,7 @@ class GovdeliveryClient(EmailClient):
 
             payload = {
                 "subject": subject,
-                "body": body,
+                "body": html_body,
                 "recipients": recipients,
                 "from_email": source
             }


### PR DESCRIPTION
Granicus will automatically extract plaintext version from html and send a mime/multipart message.

#88 