### PR TITLE
Do not load AWS SNS client. Refactor tests to not rely on SNS client

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,7 +25,6 @@ from app.clients.email.sendgrid_client import SendGridClient
 from app.clients.sms.firetext import FiretextClient
 from app.clients.sms.loadtesting import LoadtestingClient
 from app.clients.sms.mmg import MMGClient
-from app.clients.sms.aws_sns import AwsSnsClient
 from app.clients.sms.twilio import TwilioSMSClient
 from app.clients.performance_platform.performance_platform_client import PerformancePlatformClient
 from app.encryption import Encryption
@@ -58,7 +57,6 @@ mmg_client = MMGClient()
 aws_ses_client = AwsSesClient()
 govdelivery_client = GovdeliveryClient()
 send_grid_client = SendGridClient()
-aws_sns_client = AwsSnsClient()
 twilio_sms_client = TwilioSMSClient(
     account_sid=os.getenv('TWILIO_ACCOUNT_SID'),
     auth_token=os.getenv('TWILIO_AUTH_TOKEN'),
@@ -96,7 +94,7 @@ def create_app(application):
     firetext_client.init_app(application, statsd_client=statsd_client)
     loadtest_client.init_app(application, statsd_client=statsd_client)
     mmg_client.init_app(application, statsd_client=statsd_client)
-    aws_sns_client.init_app(application, statsd_client=statsd_client)
+    # aws_sns_client.init_app(application, statsd_client=statsd_client)
     aws_ses_client.init_app(application.config['AWS_REGION'], statsd_client=statsd_client)
     send_grid_client.init_app(application.config['SENDGRID_API_KEY'], statsd_client=statsd_client)
     govdelivery_client.init_app(application.config['GRANICUS_TOKEN'], statsd_client)
@@ -110,7 +108,7 @@ def create_app(application):
     performance_platform_client.init_app(application)
     document_download_client.init_app(application)
     clients.init_app(
-        sms_clients=[firetext_client, mmg_client, aws_sns_client, loadtest_client, twilio_sms_client],
+        sms_clients=[firetext_client, mmg_client, loadtest_client, twilio_sms_client],
         email_clients=[aws_ses_client, send_grid_client, govdelivery_client]
     )
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1292,5 +1292,41 @@ def mocked_provider_stats(sample_user, mocker):
     ]
 
 
+@pytest.fixture(scope='function')
+def setup_sms_providers(db_session):
+    db_session.query(ProviderRates).delete()
+    db_session.query(ProviderDetails).delete()
+    db_session.query(ProviderDetailsHistory).delete()
+
+    providers = [
+        ProviderDetails(**{
+            'display_name': 'foo',
+            'identifier': 'foo',
+            'priority': 10,
+            'notification_type': 'sms',
+            'active': False,
+            'supports_international': False,
+        }),
+        ProviderDetails(**{
+            'display_name': 'bar',
+            'identifier': 'bar',
+            'priority': 20,
+            'notification_type': 'sms',
+            'active': True,
+            'supports_international': False,
+        }),
+        ProviderDetails(**{
+            'display_name': 'baz',
+            'identifier': 'baz',
+            'priority': 30,
+            'notification_type': 'sms',
+            'active': True,
+            'supports_international': False,
+        })
+    ]
+    db_session.add_all(providers)
+    return providers
+
+
 def datetime_in_past(days=0, seconds=0):
     return datetime.now(tz=pytz.utc) - timedelta(days=days, seconds=seconds)


### PR DESCRIPTION
This PR refactor tests to not rely on SNS client being loaded and configured by the app.
It also disables the client.