### PR TITLE
Map failed status to permanent failure. Log granicus error_message

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,7 +20,6 @@ from app.celery.celery import NotifyCelery
 from app.clients import Clients
 from app.clients.document_download import DocumentDownloadClient
 from app.clients.email.aws_ses import AwsSesClient
-from app.clients.email.govdelivery_client import GovdeliveryClient
 from app.clients.email.sendgrid_client import SendGridClient
 from app.clients.sms.firetext import FiretextClient
 from app.clients.sms.loadtesting import LoadtestingClient
@@ -59,6 +58,8 @@ firetext_client = FiretextClient()
 loadtest_client = LoadtestingClient()
 mmg_client = MMGClient()
 aws_ses_client = AwsSesClient()
+
+from app.clients.email.govdelivery_client import GovdeliveryClient  # noqa
 govdelivery_client = GovdeliveryClient()
 send_grid_client = SendGridClient()
 aws_sns_client = AwsSnsClient()

--- a/app/clients/email/govdelivery_client.py
+++ b/app/clients/email/govdelivery_client.py
@@ -1,3 +1,5 @@
+from app.models import (NOTIFICATION_CANCELLED, NOTIFICATION_DELIVERED, NOTIFICATION_PERMANENT_FAILURE,
+                        NOTIFICATION_SENDING, NOTIFICATION_TEMPORARY_FAILURE)
 from time import monotonic
 
 import requests
@@ -8,17 +10,13 @@ from requests import HTTPError
 from app.clients.email import EmailClient, EmailClientException
 
 govdelivery_status_map = {
-    'sending': 'sending',
-    'sent': 'delivered',
-    'blacklisted': 'permanent-failure',
-    'canceled': 'cancelled',
-    'failed': 'failed',
-    'inconclusive': 'temporary-failure',
+    'sending': NOTIFICATION_SENDING,
+    'sent': NOTIFICATION_DELIVERED,
+    'blacklisted': NOTIFICATION_PERMANENT_FAILURE,
+    'canceled': NOTIFICATION_CANCELLED,
+    'failed': NOTIFICATION_PERMANENT_FAILURE,
+    'inconclusive': NOTIFICATION_TEMPORARY_FAILURE,
 }
-
-
-def map_govdelivery_status_to_notify_status(govdelivery_status):
-    return govdelivery_status_map[govdelivery_status]
 
 
 class GovdeliveryClientException(EmailClientException):

--- a/app/notifications/govelivery_schema.py
+++ b/app/notifications/govelivery_schema.py
@@ -11,7 +11,8 @@ govdelivery_webhook_schema = {
         "recipient_url": {"type": "string", "format": "uri"},
         "status": {"enum": govdelivery_status_map.keys()},
         "message_type": {"enum": ["sms", "email"]},
-        "completed_at": {"type": "string"}
+        "completed_at": {"type": "string"},
+        "error_message": {"type": "string"}
     },
     "required": ["message_url", "status", "sid", "message_type"]
 }

--- a/tests/app/clients/test_govdelivery_client.py
+++ b/tests/app/clients/test_govdelivery_client.py
@@ -5,10 +5,7 @@ import requests
 import requests_mock
 from notifications_utils.recipients import InvalidEmailError
 
-from app.clients.email.govdelivery_client import GovdeliveryClient, GovdeliveryClientException, \
-    map_govdelivery_status_to_notify_status
-from app.models import NOTIFICATION_DELIVERED, NOTIFICATION_SENDING, NOTIFICATION_CANCELLED, NOTIFICATION_FAILED, \
-    NOTIFICATION_PERMANENT_FAILURE, NOTIFICATION_TEMPORARY_FAILURE
+from app.clients.email.govdelivery_client import GovdeliveryClient, GovdeliveryClientException
 
 
 @pytest.fixture(scope='function')
@@ -155,15 +152,3 @@ def test_should_return_message_id(client):
         response = client.send_email("source", "recipient@email.com", "subject", "body", "html body")
 
     assert response == message_id
-
-
-@pytest.mark.parametrize('govdelivery_status, notify_status', [
-    ('sending', NOTIFICATION_SENDING),
-    ('sent', NOTIFICATION_DELIVERED),
-    ('blacklisted', NOTIFICATION_PERMANENT_FAILURE),
-    ('canceled', NOTIFICATION_CANCELLED),
-    ('failed', NOTIFICATION_FAILED),
-    ('inconclusive', NOTIFICATION_TEMPORARY_FAILURE)
-])
-def test_should_map_status(govdelivery_status, notify_status):
-    assert map_govdelivery_status_to_notify_status(govdelivery_status) == notify_status


### PR DESCRIPTION
Changes mapping for Granicus failed status to permanent_failure to be consistent with how we handle statuses from SES.

When reviewing Granicus documentation I found that in webhook for a failed message they provide error_message:
https://developer.govdelivery.com/api/tms/tutorial/deliver-report/

I added a log statement for that.