### PR TITLE
Update the containers to python:3.8-alpine3.15

### DIFF
--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -33,10 +33,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.6.9
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6.9
+          python-version: 3.8
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - run: make check-vulnerabilities
 
   dependency-scan:
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - run: make check-dependencies
 
   build-and-push:

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.6-alpine
+# Alpine Linux 3.15 is supported until 1 November 2023.
+FROM python:3.8-alpine3.15
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
@@ -23,7 +24,7 @@ RUN apk add --no-cache --virtual .build-deps \
     musl-dev \
     rust \
     cargo \
-  && python -m pip install --upgrade pip==21.3.1 \
+  && python -m pip install --upgrade pip==22.0.4 \
   && python -m pip install wheel \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del --no-cache .build-deps

--- a/ci/Dockerfile.local
+++ b/ci/Dockerfile.local
@@ -1,4 +1,5 @@
-FROM python:3.6-alpine
+# Alpine Linux 3.15 is supported until 1 November 2023.
+FROM python:3.8-alpine3.15
 
 ENV PYTHONDONTWRITEBYTECODE 1
 
@@ -15,7 +16,7 @@ RUN apk add --no-cache --virtual .build-deps \
     musl-dev \
     rust \
     cargo \
-  && python -m pip install --upgrade pip==21.3.1 \
+  && python -m pip install --upgrade pip==22.0.4 \
   && python -m pip install wheel \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del --no-cache .build-deps

--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -1,4 +1,5 @@
-FROM python:3.6-alpine
+# Alpine Linux 3.15 is supported until 1 November 2023.
+FROM python:3.8-alpine3.15
 
 ENV PYTHONDONTWRITEBYTECODE 1
 
@@ -14,7 +15,7 @@ RUN apk add --no-cache --virtual .build-deps \
     musl-dev \
     rust \
     cargo \
-  && python -m pip install --upgrade pip==21.0.1 \
+  && python -m pip install --upgrade pip==22.0.4 \
   && python -m pip install wheel \
   && pip install --no-cache-dir -r requirements_for_test.txt \
   && apk del .build-deps

--- a/ci/Dockerfile.userflow
+++ b/ci/Dockerfile.userflow
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.8-slim
 
 RUN apt-get update && apt-get install -y make
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,6 @@ charset-normalizer==2.0.9
 click==8.0.3
 colorama==0.4.3
 cryptography==36.0.0
-dataclasses==0.8
 Deprecated==1.2.13
 dnspython==1.16.0
 docutils==0.15.2

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,21 +1,21 @@
 -r requirements.txt
 flake8==3.7.7
 bandit==1.6.2
-moto==2.0.11
-pytest==6.1.2
+moto==3.0.7
+pytest==7.0.1
 pytest-env==0.6.2
-pytest-mock==3.6.1
+pytest-mock==3.7.0
 pytest-cov==2.10.1
 pytest-flask-sqlalchemy==1.0.2
 coveralls==2.1.2
-pytest-xdist==2.1.0
-freezegun==0.3.11
-requests-mock==1.8.0
+pytest-xdist==2.5.0
+freezegun==1.2.0
+requests-mock==1.9.3
 # optional requirements for jsonschema
 strict-rfc3339==0.7
 rfc3987==1.3.8
 # used for creating manifest file locally
-jinja2-cli[yaml]==0.6.0
+jinja2-cli[yaml]==0.8.1
 
 # used for testing nightly_stats_bigquery_upload_lambda
-google-cloud-bigquery==2.31.0
+google-cloud-bigquery==2.34.2


### PR DESCRIPTION
Update the containers to python:3.8-alpine3.15.  I also updated the version of `pip` used to install the Python dependencies.

All unit tests pass locally.  I'm not sure what other testing, if any, is appropriate.  I updated the test framework dependencies to the latest versions.  Without the change, running the tests yielded errors.

I removed the `dataclasses` package from the app dependencies because it is a backport for Python version 3.6 that is not available for installation in later versions.  The functionality is in Python core from 3.7 onward.

Tests were failing without the changes in models.py.  I'm not sure why the tests would pass with Python 3.6 but not 3.8 when I didn't update the app (not test) dependencies.