### PR TITLE
Reduce Docker images sizes by uninstalling build dependencies

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -2,8 +2,12 @@
 # Alpine Linux 3.15 is supported until 1 November 2023.
 FROM python:3.8-alpine3.15
 
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+ARG GIT_SHA
+
+ENV PYTHONDONTWRITEBYTECODE 1 \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+    PORT=6011 \
+    GIT_SHA ${GIT_SHA}
 
 COPY ./certs/VA-Internal-S2-RCA1-v1.crt /usr/local/share/ca-certificates/VA-Internal-S2-RCA1-v1.crt
 COPY ./certs/VA-Internal-S2-ICA4.crt /usr/local/share/ca-certificates/VA-Internal-S2-ICA4.crt
@@ -12,31 +16,30 @@ RUN apk add --no-cache ca-certificates \
   && update-ca-certificates \
   && apk del --no-cache ca-certificates
 
-RUN apk add --no-cache bash build-base git postgresql-dev g++ make libffi-dev libmagic libcurl python3-dev openssl-dev curl-dev
-
 RUN adduser -h /app -D vanotify
-
 WORKDIR /app
 
-COPY --chown=vanotify requirements.txt /app/requirements.txt
+COPY --chown=vanotify requirements.txt .
 
-RUN apk add --no-cache --virtual .build-deps \
-    gcc \
-    musl-dev \
-    rust \
-    cargo \
+RUN apk add --no-cache bash build-base postgresql-dev libffi-dev libmagic libcurl python3-dev openssl-dev curl-dev \
+  && apk add --no-cache --virtual .build-deps musl-dev rust cargo git \
   && python -m pip install --upgrade pip==22.0.4 \
   && python -m pip install wheel \
   && pip install --no-cache-dir -r requirements.txt \
+  # Remove build dependencies.
+  && rm requirements.txt \
   && apk del --no-cache .build-deps
 
-USER vanotify
+# Copy the host's build context directory (notification-api/) to the image's working directory (/app).
+COPY --chown=vanotify . .
 
-COPY --chown=vanotify . /app
-RUN make generate-version-file
-ENV PORT=6011
-ARG GIT_SHA
-ENV GIT_SHA ${GIT_SHA}
+# Generate the version file, app/version.py.  This overwrites the default file needed file local development.
+RUN apk add --no-cache make \
+  && make generate-version-file \
+  # Remove build dependencies.
+  && apk del --no-cache make
+
+USER vanotify
 
 ENTRYPOINT ["./scripts/save_certificate.sh"]
 CMD ["sh", "-c", "gunicorn -c gunicorn_config.py application"]

--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -4,21 +4,18 @@ FROM python:3.8-alpine3.15
 
 ENV PYTHONDONTWRITEBYTECODE 1
 
-RUN apk add --no-cache bash build-base git postgresql-dev g++ make libffi-dev libmagic libcurl python3-dev openssl-dev curl-dev
-RUN set -ex && mkdir /app
-
-COPY requirements_for_test.txt /app/requirements_for_test.txt
-COPY requirements.txt /app/requirements.txt
 WORKDIR /app
+COPY requirements.txt requirements_for_test.txt /app/
 
-RUN apk add --no-cache --virtual .build-deps \
-    gcc \
-    musl-dev \
-    rust \
-    cargo \
+RUN apk add --no-cache bash build-base postgresql-dev make libffi-dev libmagic libcurl python3-dev openssl-dev curl-dev git \
+  && apk add --no-cache --virtual .build-deps musl-dev rust cargo \
+  && set -ex \
   && python -m pip install --upgrade pip==22.0.4 \
   && python -m pip install wheel \
+  # This installs both requirements files.
   && pip install --no-cache-dir -r requirements_for_test.txt \
+  # Remove build dependencies.
+  && rm requirements.txt requirements_for_test.txt \
   && apk del .build-deps
 
 COPY . /app

--- a/ci/Dockerfile.userflow
+++ b/ci/Dockerfile.userflow
@@ -9,6 +9,7 @@ RUN set -ex && mkdir /app
 COPY requirements_for_user_flows.txt /app/requirements_for_user_flows.txt
 WORKDIR /app
 RUN pip install -r requirements_for_user_flows.txt
+  && rm requirements_for_user_flows.txt
 
 COPY . /app
 CMD ["sh", "-c", "make user_flows"]


### PR DESCRIPTION
The scope of changes has narrowed since I opened the underlying issue because it turns out the existing Dockerfiles do delete some of their build dependencies.  The syntax . . .

`apk add --no-cache --virtual .build-deps musl-dev rust cargo git`

. . . creates a "virtual package" named ".build-deps" that includes the packages musl-dev, rust, cargo, and git.  The subsequent delete instruction, `apk del --no-cache .build-deps`, deleted this virtual package, which deletes all the member packages.

I haven't modified Dockerfile.local for this issue because I made the relevant changes for #601.  (They are outstanding in PR 608.)

## Testing

I tested as follows:
1. Ensured I can build Dockerfile and Dockerfile.userflow.
2. Ran all unit tests.  This also verifies that Dockerfile.test builds.