### PR TITLE
Reduce Docker images sizes by uninstalling build dependencies (revision 1)

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -4,10 +4,10 @@ FROM python:3.8-alpine3.15
 
 ARG GIT_SHA
 
-ENV PYTHONDONTWRITEBYTECODE 1 \
+ENV PYTHONDONTWRITEBYTECODE=1 \
     REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
     PORT=6011 \
-    GIT_SHA ${GIT_SHA}
+    GIT_SHA=${GIT_SHA}
 
 COPY ./certs/VA-Internal-S2-RCA1-v1.crt /usr/local/share/ca-certificates/VA-Internal-S2-RCA1-v1.crt
 COPY ./certs/VA-Internal-S2-ICA4.crt /usr/local/share/ca-certificates/VA-Internal-S2-ICA4.crt
@@ -33,7 +33,7 @@ RUN apk add --no-cache bash build-base postgresql-dev libffi-dev libmagic libcur
 # Copy the host's build context directory (notification-api/) to the image's working directory (/app).
 COPY --chown=vanotify . .
 
-# Generate the version file, app/version.py.  This overwrites the default file needed file local development.
+# Generate the version file, app/version.py.  This overwrites the default file needed for local development.
 RUN apk add --no-cache make \
   && make generate-version-file \
   # Remove build dependencies.

--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -2,7 +2,7 @@
 # Alpine Linux 3.15 is supported until 1 November 2023.
 FROM python:3.8-alpine3.15
 
-ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONDONTWRITEBYTECODE=1
 
 WORKDIR /app
 COPY requirements.txt requirements_for_test.txt /app/

--- a/ci/Dockerfile.userflow
+++ b/ci/Dockerfile.userflow
@@ -3,7 +3,7 @@ FROM python:3.8-slim
 
 RUN apt-get update && apt-get install -y make
 
-ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONDONTWRITEBYTECODE=1
 RUN set -ex && mkdir /app
 
 COPY requirements_for_user_flows.txt /app/requirements_for_user_flows.txt


### PR DESCRIPTION
I had a syntax error in Dockerfile.  I verified by running `docker inspect` on the image and by running the docker-compose for production.  This clears the PORT error and yields a lot of expected Twillio errors.