### PR TITLE
Add the onsite_notification column to templates

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -815,9 +815,11 @@ class TemplateBase(db.Model):
     content = db.Column(db.Text, nullable=False)
     archived = db.Column(db.Boolean, nullable=False, default=False)
     hidden = db.Column(db.Boolean, nullable=False, default=False)
+    onsite_notification = db.Column(db.Boolean, nullable=False, default=False)
     subject = db.Column(db.Text)
     postage = db.Column(db.String, nullable=True)
     reply_to_email = db.Column(db.String(254), nullable=True)
+
     CheckConstraint("""
         CASE WHEN template_type = 'letter' THEN
             postage is not null and postage in ('first', 'second')

--- a/migrations/versions/0344_add_onsite_notification.py
+++ b/migrations/versions/0344_add_onsite_notification.py
@@ -1,0 +1,25 @@
+"""
+Revision ID: 0344_add_onsite_notification
+Revises: 0343_create_VAProfileLocalCache
+Create Date: 2022-04-20 15:17:14.050637
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0344_add_onsite_notification'
+down_revision = '0343_create_VAProfileLocalCache'
+
+
+def upgrade():
+    # Without the "server_default" parameter, this migration causes a database integrity error.
+    #   https://github.com/miguelgrinberg/Flask-Migrate/issues/254
+    op.add_column('templates', sa.Column('onsite_notification', sa.Boolean(), nullable=False, server_default='0'))
+    op.add_column('templates_history', sa.Column('onsite_notification', sa.Boolean(), nullable=False, server_default='0'))
+
+
+def downgrade():
+    op.drop_column('templates_history', 'onsite_notification')
+    op.drop_column('templates', 'onsite_notification')
+


### PR DESCRIPTION
Add the onsite_notification column to the tables derived from the TemplateBase class, which are "templates" and "templates_history".  I used pgAdmin3 to connect to the running Postgres container and verified that the new columns are present.