### PR TITLE
Altered the VAProfileLocalCache class

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2134,4 +2134,5 @@ class VAProfileLocalCache(db.Model):
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     mpi_icn = db.Column(db.String(29), nullable=False)
     va_profile_id = db.Column(db.Integer, nullable=False)
-    va_profile_item_id = db.Column(db.Integer, nullable=False)
+    communication_item_id = db.Column(db.Integer, nullable=False)
+    communication_channel_name = db.Column(db.String(255), nullable=False)

--- a/migrations/versions/0345_alter_VAProfileLocalCache.py
+++ b/migrations/versions/0345_alter_VAProfileLocalCache.py
@@ -1,0 +1,23 @@
+"""
+Revision ID: 0345_alter_VAProfileLocalCache
+Revises: 0344_add_onsite_notification
+Create Date: 2022-04-20 17.48:14.050637
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0345_alter_VAProfileLocalCache'
+down_revision = '0344_add_onsite_notification'
+
+
+def upgrade():
+    op.add_column('va_profile_local_cache', sa.Column('communication_channel_name', sa.String(length=255), nullable=False))
+    op.alter_column('va_profile_local_cache', 'va_profile_item_id', new_column_name='communication_item_id')
+
+
+def downgrade():
+    op.alter_column('va_profile_local_cache', 'communication_item_id', new_column_name='va_profile_item_id')
+    op.drop_column('va_profile_local_cache', 'communication_channel_name')
+


### PR DESCRIPTION
This is a straight-forward schema alteration for #632.  When I attempted to create the associated migration using the method described in the README, I encountered this error:
```
db_1          | 2022-04-20 18:34:42.026 UTC [74] ERROR:  duplicate key value violates unique constraint "pg_type_typname_nsp_index"
db_1          | 2022-04-20 18:34:42.026 UTC [74] DETAIL:  Key (typname, typnamespace)=(alembic_version, 2200) already exists.
db_1          | 2022-04-20 18:34:42.026 UTC [74] STATEMENT:  
db_1          | 	CREATE TABLE alembic_version (
db_1          | 		version_num VARCHAR(32) NOT NULL, 
db_1          | 		CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
db_1          | 	)
```
Eventually, I worked around the error by manually creating the migration script.  Upgrading alembic to the latest version didn't fix the problem.

Unit tests pass.  I manually verified the migration by connecting to the local database container with pgAdmin3.