### PR TITLE
Remove permissions on JWT token and add it in separate endpoint

### DIFF
--- a/app/oauth/jwt_manager.py
+++ b/app/oauth/jwt_manager.py
@@ -12,7 +12,6 @@ def transform_user_to_identity_for_jwt(user: User):
         'id': user.id,
         'name': user.name,
         'email_address': user.email_address,
-        'permissions': user.get_permissions()
     }
 
 

--- a/app/oauth/rest.py
+++ b/app/oauth/rest.py
@@ -75,7 +75,7 @@ def authorize():
     _assert_toggle_enabled(FeatureFlag.GITHUB_LOGIN_ENABLED)
     try:
         github_token = oauth_registry.github.authorize_access_token()
-        # make_github_get_request('/user/memberships/orgs/department-of-veterans-affairs', github_token)
+        make_github_get_request('/user/memberships/orgs/department-of-veterans-affairs', github_token)
         email_resp = make_github_get_request('/user/emails', github_token)
         user_resp = make_github_get_request('/user', github_token)
         verified_email, verified_user_id, verified_name = _extract_github_user_info(email_resp, user_resp)

--- a/app/oauth/rest.py
+++ b/app/oauth/rest.py
@@ -119,15 +119,15 @@ def get_services_by_user(user_id):
     services = dao_fetch_all_services_by_user(user_id, only_active)
     permissions = permission_dao.get_permissions_by_user_id(user_id)
 
-    retval = {}
-    for x in permissions:
-        service_id = str(x.service_id)
-        if service_id not in retval:
-            retval[service_id] = []
-        retval[service_id].append(x.permission)
+    permissions_by_service = {}
+    for user_permission in permissions:
+        service_id = str(user_permission.service_id)
+        if service_id not in permissions_by_service:
+            permissions_by_service[service_id] = []
+        permissions_by_service[service_id].append(user_permission.permission)
     data = {
         "services": service_schema.dump(services, many=True).data,
-        "permissions": retval
+        "permissions": permissions_by_service
     }
     return jsonify(data=data)
 

--- a/app/oauth/rest.py
+++ b/app/oauth/rest.py
@@ -9,7 +9,6 @@ from flask_jwt_extended import create_access_token, verify_jwt_in_request
 from requests import Response as RequestsResponse
 from requests.exceptions import HTTPError
 from sqlalchemy.orm.exc import NoResultFound
-from yaml import serialize
 
 from app import statsd_client
 from app.dao.permissions_dao import permission_dao

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -424,6 +424,7 @@ class TestRequiresUserInService:
 
         user = create_user()
         service = create_service(service_name='some-service')
+        # The requires_user_in_service_or_admin middleware requires this.
         dao_add_user_to_service(
             service,
             user,

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -424,6 +424,11 @@ class TestRequiresUserInService:
 
         user = create_user()
         service = create_service(service_name='some-service')
+        dao_add_user_to_service(
+            service,
+            user,
+            permissions=[Permission(service=service, user=user, permission='manage_users')]
+        )
 
         token = create_access_token(identity=user)
         mocker.patch("app.authentication.auth.verify_jwt_in_request", side_effect=ExpiredSignatureError)


### PR DESCRIPTION
There is a login issue for users who has been involved over 20 services because permissions data increase the size of jwt tokens. 
![Screen Shot 2022-05-04 at 8 01 13 AM](https://user-images.githubusercontent.com/25709133/166677335-3a2ded20-302e-4904-bc78-fcf1f743d805.png)


So I took out the `permissions` in jwt token to prevent overflowing and add permissions data in `/my-services/{user-id}` endpoint which has been created [before](https://github.com/department-of-veterans-affairs/notification-api/pull/619). 
