### PR TITLE
Include the 'eventlet' extras with Gunicorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,12 @@ To update the images, change the `FROM` directive at the top of Dockerfiles and 
 
 The Docker image used in local development, ci/Dockerfile.local, builds with the Python packages given by requirements-app.txt, which specifies only the top level dependencies.  This ensures that the local image always builds with the most recent sub-dependencies, and developers only need to keep track of the top level dependencies.
 
-The Docker image used in production, ci/Dockerfile, builds with the Python packages given by requirements.txt, which freezes all dependencies.  **Prior to any deployment to AWS beyond the "development" environment, update requirements.txt as follows**:
+The Docker image used in production, ci/Dockerfile, builds with the Python packages given by requirements.txt, which freezes all dependencies.  **Prior to any deployment to AWS, update requirements.txt as follows**:
 
 1. If necessary, build the notification_api Docker image using the docker-compose command given in [Local Development](#local-development).
 2. Run `docker run --rm -i notification_api pip freeze > requirements.txt`.
 3. Open requirements.txt, and manually remove any warning messages at the start of the file.
+4. Assuming all unit tests are passing, note any top level dependency updates.  Update requirements-app.txt to make their minimum version equal to the version actually installed according to requirements.txt.
 
 ### Deploy using Github Actions
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -28,11 +28,11 @@ git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd
 
 # The production image defined by Dockerfile uses Gunicorn.  The development image defined by Dockerfile.local
 # runs the application with the Flask development server by default.
-gunicorn>=20.1.0
+gunicorn[eventlet]>=20.1.0
 
 iso8601>=1.0.2
 itsdangerous>=1.1.0
-jsonschema>=4.4.0
+jsonschema>=4.5.1
 
 # 5 May 2022: Celery depends on this package, and the Docker image build failed with the newest version.
 # Ignoring security vulnerability 42497 in Makefile.  The vulnerability is fixed in kombu>=5.2.1.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,13 +5,13 @@ asn1crypto==1.5.1
 async-timeout==4.0.2
 attrs==21.4.0
 Authlib==1.0.1
-awscli==1.23.7
+awscli==1.23.8
 bcrypt==3.2.2
 billiard==3.6.4.0
 bleach==5.0.0
 blinker==1.4
-boto3==1.22.7
-botocore==1.25.7
+boto3==1.22.8
+botocore==1.25.8
 cachelib==0.6.0
 celery==4.4.7
 certifi==2021.10.8
@@ -22,8 +22,10 @@ click-datetime==0.2
 colorama==0.4.4
 cryptography==37.0.2
 Deprecated==1.2.13
+dnspython==2.2.1
 docopt==0.6.2
 docutils==0.15.2
+eventlet==0.33.0
 fido2==0.9.3
 Flask==1.1.4
 Flask-Bcrypt==0.7.1
@@ -35,6 +37,7 @@ flask-redis==0.4.0
 Flask-SQLAlchemy @ git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262
 flupy==1.1.9
 future==0.18.2
+greenlet==1.1.2
 gunicorn==20.1.0
 idna==3.3
 importlib-metadata==4.11.3
@@ -43,7 +46,7 @@ iso8601==1.0.2
 itsdangerous==1.1.0
 Jinja2==2.11.3
 jmespath==1.0.0
-jsonschema==4.4.0
+jsonschema==4.5.1
 kombu==4.6.11
 Mako==1.2.0
 MarkupSafe==2.0.1


### PR DESCRIPTION
#644

This is required in the AWS environment.
https://github.com/benoitc/gunicorn/blob/cf55d2cec277f220ebd605989ce78ad1bb553c46/docs/source/install.rst#async-workers

I rebuilt the Docker images to test this change and picked up multiple package upgrades released within the last 24 hours!