### PR TITLE
Pinned eventlet to version 0.30.2

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -14,8 +14,8 @@ click-datetime>=0.2
 
 docopt>=0.6.2
 
-# 9 May 2022: Gunicorn raises ImportError with newer versions.
-eventlet < 0.31.0
+# 10 May 2022: Newer versions--even 0.30.3--cause import errors.
+eventlet==0.30.2
 
 fido2>=0.9.3
 Flask < 2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ Deprecated==1.2.13
 dnspython==1.16.0
 docopt==0.6.2
 docutils==0.18.1
-eventlet==0.30.3
+eventlet==0.30.2
 fido2==0.9.3
 Flask==1.1.4
 Flask-Bcrypt==0.7.1


### PR DESCRIPTION
With this change, the requirements for Gunicorn and eventlet are in the last known working configuration.  Anything newer causes runtime errors in AWS.  #644