### PR TITLE
Va notify 371/generate template preview admin

### DIFF
--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -250,6 +250,22 @@ def generate_html_preview_for_content(service_id):
 
     return str(html_email), 200, {'Content-Type': 'text/html; charset=utf-8'}
 
+@template_blueprint.route("/generate-preview", methods=['POST'])
+@requires_admin_auth_or_user_in_service(required_permission='manage_templates')
+def generate_html_preview_for_template_content(service_id):
+    data = request.get_json()
+
+    html_email = HTMLEmailTemplate(
+        {
+            'content': data['content'],
+            'subject': ''
+        },
+        values={},
+        preview_mode=True
+    )
+
+    return str(html_email), 200, {'Content-Type': 'text/html; charset=utf-8'}
+
 
 @template_blueprint.route('/<uuid:template_id>/version/<int:version>')
 @requires_admin_auth_or_user_in_service(required_permission='manage_templates')

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -250,6 +250,7 @@ def generate_html_preview_for_content(service_id):
 
     return str(html_email), 200, {'Content-Type': 'text/html; charset=utf-8'}
 
+
 @template_blueprint.route("/generate-preview", methods=['POST'])
 @requires_admin_auth_or_user_in_service(required_permission='manage_templates')
 def generate_html_preview_for_template_content(service_id):

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1717,6 +1717,35 @@ class TestGenerateHtmlPreviewForContent:
         assert response.data.decode('utf-8') == str(expected_preview_html)
         assert response.headers['Content-type'] == 'text/html; charset=utf-8'
 
+class TestGenerateHtmlPreviewForTemplateContent:
+
+    def test_should_generate_html_preview_for_template_content(self, client, sample_service):
+        user = create_user(platform_admin=True)
+        token = create_access_token(user)
+
+        response = client.post(
+            url_for('template.generate_html_preview_for_template_content', service_id=sample_service.id),
+            data=json.dumps({
+                'content': 'Foo'
+            }),
+            headers=[
+                ('Content-Type', 'application/json'),
+                ('Authorization', f'Bearer {token}')
+            ]
+        )
+
+        expected_preview_html = HTMLEmailTemplate(
+            {
+                'content': 'Foo',
+                'subject': ''
+            },
+            values={},
+            preview_mode=True
+        )
+
+        assert response.data.decode('utf-8') == str(expected_preview_html)
+        assert response.headers['Content-type'] == 'text/html; charset=utf-8'
+
 
 class TestTemplateNameAlreadyExists:
     def test_create_template_should_return_400_if_template_name_already_exists_on_service(

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1717,6 +1717,7 @@ class TestGenerateHtmlPreviewForContent:
         assert response.data.decode('utf-8') == str(expected_preview_html)
         assert response.headers['Content-type'] == 'text/html; charset=utf-8'
 
+
 class TestGenerateHtmlPreviewForTemplateContent:
 
     def test_should_generate_html_preview_for_template_content(self, client, sample_service):


### PR DESCRIPTION
# Description
* Create new endpoint in notification-api to preview unsaved template content that admin auth can access.
* Create tests for new route

Related Ticket: https://app.zenhub.com/workspaces/forms-strike-team-620c2914e703390013c4b414/issues/department-of-veterans-affairs/vanotify-team/371
