### PR TITLE
Write unit tests for the VA Profile integration lambda, and fix problems exposed by the tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ celerybeat-schedule
 
 # AWS Lambda function outfile
 user_flows_exit_code.txt
+
+# This gets written in the notification_api directory if you run bash commands on a container with read-write access.
+.bash_history

--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ OSX users can run `brew bundle` and then `pre-commit install` to register the gi
 
 ### Run the local Docker containers
 
-To run the app, and its ecosystem, locally, run: `docker-compose -f ci/docker-compose-local.yml up`.  This also applies all migrations to the database container, ci_db_1.
+To run the app, and its ecosystem, locally, run:
 
-To see useful flags that you might want to use with the `up` subcommand, run `docker-compose up --help`.  This docker-compose command creates the container ci_app_1, among others.
+```docker-compose -f ci/docker-compose-local.yml up```
+
+This also applies all migrations to the database container, ci_db_1.  To see useful flags that you might want to use with the `up` subcommand, run `docker-compose up --help`.  This docker-compose command creates the container ci_app_1, among others.
 
 If AWS SES is enabled as a provider, you may need to run the following command to give the (simulated) SES permission to (pretend to) send e-mails:
 
@@ -103,9 +105,7 @@ To run all unit tests:
 docker-compose -f ci/docker-compose-test.yml up --abort-on-container-exit
 ```
 
-The Github workflow also runs these tests when you push code.
-
-TODO - How to run individual tests?
+The Github workflow also runs these tests when you push code.  Instructions for running a subset of tests are located in tests/README.md.
 
 ### Building the production application container
 

--- a/app/db.py
+++ b/app/db.py
@@ -1,3 +1,4 @@
+# https://flask-sqlalchemy.palletsprojects.com/en/2.x/api/#flask_sqlalchemy.SQLAlchemy
 from flask_sqlalchemy import SQLAlchemy as _SQLAlchemy
 
 

--- a/ci/docker-compose-test.yml
+++ b/ci/docker-compose-test.yml
@@ -8,7 +8,8 @@ services:
       # Write access is necessary because the test runner writes output.
       # Running "make test" includes deleting that output.
       - "../:/app:rw"
-    environment: 
+    environment:
+      # If any of these values change, update tests/env_vars.  See tests/README.md for details.
       - SQLALCHEMY_DATABASE_URI=postgresql://postgres:LocalPassword@db:5432/test_notification_api
       - NOTIFY_ENVIRONMENT=test
       - AWS_ACCESS_KEY_IDtest
@@ -16,6 +17,7 @@ services:
       - AWS_SESSION_TOKEN=test
       - AWS_SECURITY_TOKEN=test
       - AWS_REGION=us-east-1
+      - VA_PROFILE_DOMAIN=int.vaprofile.va.gov
     depends_on:
       - db
   db:

--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -1,46 +1,70 @@
-# Tutorial: Configuring a Lambda function to access Amazon RDS in an Amazon VPC
-#   https://docs.aws.amazon.com/lambda/latest/dg/services-rds-tutorial.html
-# https://www.psycopg.org/docs/usage.html
+"""
+Tutorial: Configuring a Lambda function to access Amazon RDS in an Amazon VPC
+   https://docs.aws.amazon.com/lambda/latest/dg/services-rds-tutorial.html
+
+https://www.psycopg.org/docs/usage.html
+
+This code makes use of module variables (db_connection & PEM) for runtime efficiency.
+"""
 
 import boto3
 import logging
 import os
 import psycopg2
 import sys
-from http.client import ConnectionError, HTTPSConnection
+from http.client import HTTPSConnection
 from json import dumps
 from ssl import SSLContext, SSLError
 
 
 OPT_IN_OUT_QUERY = """SELECT va_profile_opt_in_out(%s, %s, %s, %s, %s);"""
-NOTIFY_ENVIRONMENT = os.getenv("notify_environment")
-NOTIFICATION_API_DB_URI = os.getenv("notification_api_db_uri")
+NOTIFY_ENVIRONMENT = os.getenv("NOTIFY_ENVIRONMENT")
 PEM = None
-VA_PROFILE_DOMAIN = os.getenv("va_profile_domain")
+SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI")
+VA_PROFILE_DOMAIN = os.getenv("VA_PROFILE_DOMAIN")
 VA_PROFILE_PATH_BASE = "/communication-hub/communication/v1/status/changelog/"
 
 
-if NOTIFICATION_API_DB_URI is None:
+if SQLALCHEMY_DATABASE_URI is None:
     logging.error("The database URI is not set.")
     sys.exit("Couldn't connect to the database.")
 
-if NOTIFY_ENVIRONMENT is None:
-    logging.error("Couldn't get the Notify environment.  This is necessary to retrieve the .pem file.")
-else:
-    # Read a .pem file from AWS Parameter Store.
 
-    ssm_client = boto3.client("ssm")
+def get_pem():
+    """
+    Read a .pem file from AWS Parameter Store.
+
+    AWS_REGION is set during unit testing.  In a deployment environment,
+    region_name=None will result in boto using the "default session".
+      https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/boto3.html?highlight=boto3.client#boto3.client
+    """
+
+    ssm_client = boto3.client("ssm", region_name=os.getenv("AWS_REGION"))
 
     response = ssm_client.get_parameter(
         Name=f"/{NOTIFY_ENVIRONMENT}/notification-api/profile-integration-pem",
         WithDecryption=True
     )
 
-    PEM = response.get("Parameter", {}).get("Value", None)
+    pem = response.get("Parameter", {}).get("Value", None)
+
+    if pem is None:
+        logging.debug(response)
+
+    return pem
+
+
+PEM = None
+
+
+if NOTIFY_ENVIRONMENT is None:
+    logging.error("Couldn't get the Notify environment.  This is necessary to retrieve the .pem file.")
+elif NOTIFY_ENVIRONMENT != "test":
+    PEM = get_pem()
 
     if PEM is None:
-        logging.error("Couldn't get the .pem file from SSM.")
-        logging.debug(response)
+        logging.error("Couldn't get the .pem chain from SSM.")
+
 
 if VA_PROFILE_DOMAIN is None:
     logging.error("Could not get the domain for VA Profile.")
@@ -49,13 +73,15 @@ if VA_PROFILE_DOMAIN is None:
 def make_connection():
     """
     Return a connection to the database, or return None.
+
+    https://www.psycopg.org/docs/module.html#psycopg2.connect
+    https://www.psycopg.org/docs/module.html#exceptions
     """
 
     connection = None
 
-    # https://www.psycopg.org/docs/module.html#exceptions
     try:
-        connection = psycopg2.connect(NOTIFICATION_API_DB_URI)
+        connection = psycopg2.connect(SQLALCHEMY_DATABASE_URI + "_master" if (NOTIFY_ENVIRONMENT == "test") else '')
     except psycopg2.Warning as e:
         logging.warning(e)
     except psycopg2.Error as e:
@@ -95,6 +121,7 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context) -> dict:
         https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-concepts.html#gettingstarted-concepts-event
     """
 
+    global db_connection, pem
     logging.debug(event)
 
     if "txAuditId" not in event or "bios" not in event or not isinstance(event["bios"], list):
@@ -124,9 +151,9 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context) -> dict:
 
         try:
             params = (                             # Stored function parameters:
-                record["VaProfileId"],             #     _va_profile_id
-                record["CommunicationItemId"],     #     _communication_item_id
-                record["CommunicationChannelId"],  #     _communication_channel_name
+                record["vaProfileId"],             #     _va_profile_id
+                record["communicationItemId"],     #     _communication_item_id
+                record["communicationChannelId"],  #     _communication_channel_name
                 record["allowed"],                 #     _allowed
                 record["sourceDate"],              #     _source_datetime
             )
@@ -140,7 +167,10 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context) -> dict:
 
             # Execute the stored function.
             with db_connection.cursor() as c:
-                put_record["status"] = "COMPLETED_SUCCESS" if c.execute(OPT_IN_OUT_QUERY, params) else "COMPLETED_NOOP"
+                # https://www.psycopg.org/docs/cursor.html#cursor.execute
+                c.execute(OPT_IN_OUT_QUERY, params)
+                put_record["status"] = "COMPLETED_SUCCESS" if c.fetchone()[0] else "COMPLETED_NOOP"
+                db_connection.commit()
         except KeyError as e:
             # Bad Request.  Required attributes are missing.
             response["statusCode"] = 400

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -6,10 +6,10 @@ flake8==3.7.7
 freezegun==1.2.0
 moto==3.0.7
 pytest==7.0.1
-pytest-env==0.6.2
-pytest-mock==3.7.0
 pytest-cov==2.10.1
+pytest-env==0.6.2
 pytest-flask-sqlalchemy==1.0.2
+pytest-mock==3.7.0
 pytest-xdist==2.5.0
 requests-mock==1.9.3
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,25 @@
+# Running a Subset of Tests Using Containers
+
+You can run specific test directories or files rather than the entire suite as follows.  These instructions assume that you have previously run the docker-compose command to start the local ecosystem and, therefore, that all migrations have been applied to the database and the default container network, ci_default, exists.
+
+## Setting Environment Variables
+
+The docker-compose command used to run the full test suite sets environment variables.  Step 3 above references the file env_vars for the same purpose.
+
+## Setup
+
+1. Stop all running containers associated with Notification-api.
+2. Start the Postgres (ci_db_1) container, and any other containers required by the functionality under test: `docker start ci_db_1`.  All migrations should already be applied.
+3. Start a test container shell by running `docker run --rm -it -v "<absolute path to notification-api>:/app" --env-file tests/env_vars ci_test bash`.
+4. Add the test container started in the previous step to the default network: `docker network connect ci_default <test container name or ID>`.
+5. Run `py.test -h` to see the syntax for running tests.  Without flags, you can run `py.test [file or directory]...`.
+
+## Running Individual Tests
+
+This is an example of running a specific test in a test file:
+
+```$ py.test tests/lambda_functions/va_profile/test_va_profile_integration.py::test_va_profile_cache_exists```
+
+## A Note About .bash_history
+
+Running Bash commands on a container with read-write access, such as ci_test, will result in the creation of .bash_history in your notification_api/ directory.  That file is in .gitignore.

--- a/tests/app/test_cronitor.py
+++ b/tests/app/test_cronitor.py
@@ -72,7 +72,7 @@ def test_cronitor_does_nothing_if_cronitor_not_enabled(notify_api, rmock):
     }):
         assert successful_task() == 1
 
-    assert rmock.called is False
+    assert not rmock.called
 
 
 def test_cronitor_does_nothing_if_name_not_recognised(notify_api, rmock, caplog):
@@ -85,7 +85,7 @@ def test_cronitor_does_nothing_if_name_not_recognised(notify_api, rmock, caplog)
     error_log = caplog.records[0]
     assert error_log.levelname == 'ERROR'
     assert error_log.msg == 'Cronitor enabled but task_name hello not found in environment'
-    assert rmock.called is False
+    assert not rmock.called
 
 
 def test_cronitor_doesnt_crash_if_request_fails(notify_api, rmock):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,12 @@ def create_test_db(database_uri):
 
 @pytest.fixture(scope='session')
 def notify_db(notify_api, worker_id):
-    assert 'test_notification_api' in db.engine.url.database, 'dont run tests against main db'
+    """
+    Yield an instance of flask_sqlalchemy.SQLAlchemy.
+        https://flask-sqlalchemy.palletsprojects.com/en/2.x/api/#flask_sqlalchemy.SQLAlchemy
+    """
+
+    assert "test_notification_api" in db.engine.url.database, "Don't run tests against main db."
 
     # create a database for this worker thread -
     from flask import current_app

--- a/tests/env_vars
+++ b/tests/env_vars
@@ -1,0 +1,8 @@
+SQLALCHEMY_DATABASE_URI=postgresql://postgres:LocalPassword@db:5432/test_notification_api
+NOTIFY_ENVIRONMENT=test
+AWS_ACCESS_KEY_IDtest
+AWS_SECRET_ACCESS_KEY=test
+AWS_SESSION_TOKEN=test
+AWS_SECURITY_TOKEN=test
+AWS_REGION=us-east-1
+VA_PROFILE_DOMAIN=int.vaprofile.va.gov

--- a/tests/lambda_functions/va_profile/test_va_profile_integration.py
+++ b/tests/lambda_functions/va_profile/test_va_profile_integration.py
@@ -1,0 +1,246 @@
+"""
+notify_db and notify_db_session are fixtures in tests/conftest.py.
+
+https://docs.sqlalchemy.org/en/13/core/connections.html
+
+Truncating the va_profile_local_cache table at the beginning and end of some tests is necessary because the database
+side effects of executing the VA Profile lambda function are not rolled back at the conclusion of a test.
+"""
+
+from lambda_functions.va_profile.va_profile_opt_in_out_lambda import va_profile_opt_in_out_lambda_handler
+from sqlalchemy import text
+
+
+OPT_IN_OUT = text("""SELECT va_profile_opt_in_out(:va_profile_id, :communication_item_id, :communication_channel_id, :allowed, :source_datetime);""")
+
+COUNT = r"""SELECT COUNT(*) FROM va_profile_local_cache;"""
+
+VA_PROFILE_TEST = text("""\
+SELECT allowed
+FROM va_profile_local_cache
+WHERE va_profile_id=:va_profile_id AND communication_item_id=:communication_item_id AND communication_channel_id=:communication_channel_id;""")
+
+
+def test_va_profile_cache_exists(notify_db):
+    assert notify_db.engine.has_table("va_profile_local_cache")
+
+
+def test_va_profile_opt_in_out(notify_db_session):
+    """
+    Test the stored function va_profile_opt_in_out by calling it directly.  The lambda function associated with
+    VA Profile integration calls this stored function.  The stored function should return True if any row was
+    created or updated; otherwise, False.
+    """
+
+    with notify_db_session.engine.begin() as connection:
+        # Begin with a sanity check.
+        result = connection.execute(COUNT)
+        assert result.fetchone()[0] == 0, "The cache should be empty at the start."
+
+        opt_in_out = OPT_IN_OUT.bindparams(
+            va_profile_id=0,
+            communication_item_id=0,
+            communication_channel_id=0,
+            allowed=False,
+            source_datetime="2022-03-07T19:37:59.320Z"
+        )
+
+        va_profile_test = VA_PROFILE_TEST.bindparams(
+            va_profile_id=0,
+            communication_item_id=0,
+            communication_channel_id=0
+        )
+
+        result = connection.execute(opt_in_out)
+        assert result.fetchone()[0], "The stored function should return True."
+
+        result = connection.execute(COUNT)
+        assert result.fetchone()[0] == 1, "The stored function should have created a new row."
+
+        result = connection.execute(va_profile_test)
+        assert not result.fetchone()[0], "The user opted out.  (allowed=False)"
+
+        opt_in_out = OPT_IN_OUT.bindparams(
+            va_profile_id=0,
+            communication_item_id=0,
+            communication_channel_id=0,
+            allowed=True,
+            source_datetime="2022-02-07T19:37:59.320Z"  # Older date
+        )
+
+        result = connection.execute(opt_in_out)
+        assert not result.fetchone()[0], "The date is older than the existing entry."
+
+        result = connection.execute(COUNT)
+        assert result.fetchone()[0] == 1, "The stored function should not have created a new row."
+
+        result = connection.execute(va_profile_test)
+        assert not result.fetchone()[0], "The user should still be opted out.  (allowed=False)"
+
+        opt_in_out = OPT_IN_OUT.bindparams(
+            va_profile_id=0,
+            communication_item_id=0,
+            communication_channel_id=0,
+            allowed=True,
+            source_datetime="2022-04-07T19:37:59.320Z"  # Newer date
+        )
+
+        result = connection.execute(opt_in_out)
+        assert result.fetchone()[0], "The date is newer than the existing entry."
+
+        result = connection.execute(COUNT)
+        assert result.fetchone()[0] == 1, "An existing entry should have been updated."
+
+        result = connection.execute(va_profile_test)
+        assert result.fetchone()[0], "The user should be opted in.  (allowed=True)"
+
+        opt_in_out = OPT_IN_OUT.bindparams(
+            va_profile_id=1,
+            communication_item_id=1,
+            communication_channel_id=1,
+            allowed=True,
+            source_datetime="2022-02-07T19:37:59.320Z"
+        )
+
+        va_profile_test = VA_PROFILE_TEST.bindparams(
+            va_profile_id=1,
+            communication_item_id=1,
+            communication_channel_id=1
+        )
+
+        result = connection.execute(opt_in_out)
+        assert result.fetchone()[0], "The stored function should have created a new row."
+
+        result = connection.execute(COUNT)
+        assert result.fetchone()[0] == 2, "The stored function should have created a new row."
+
+        result = connection.execute(va_profile_test)
+        assert result.fetchone()[0], "The user should be opted in.  (allowed=True)"
+
+
+def test_handler_va_profile_opt_in_out_lambda_missing_attribute():
+    """
+    Test the VA Profile integration lambda by sending a bad request (missing top level attribute).
+    """
+
+    event = create_event("txAuditId", "txAuditId", "2022-03-07T19:37:59.320Z", 0, 0, 0, True)
+    del event["txAuditId"]
+    response = va_profile_opt_in_out_lambda_handler(event, None)
+    assert isinstance(response, dict)
+    assert response["statusCode"] == 400
+    assert response["body"] == "A required top level attribute is missing from the request or has the wrong type."
+
+
+def test_handler_va_profile_opt_in_out_lambda_valid_requests(notify_db):
+    """
+    Test the VA Profile integration lambda by sending valid requests that do not result in a PUT
+    request to VA Profile (because the .pem chain is None in the lambda code).    
+    """
+
+    with notify_db.engine.begin() as connection:
+        connection.execute("truncate va_profile_local_cache;")
+
+        # Begin with a sanity check.
+        result = connection.execute(COUNT)
+        assert result.fetchone()[0] == 0, "The cache should be empty at the start."
+
+    # Send a request that should result in a new row.
+    event = create_event("txAuditId", "txAuditId", "2022-03-07T19:37:59.320Z", 0, 0, 0, True)
+    response = va_profile_opt_in_out_lambda_handler(event, None)
+    assert isinstance(response, dict)
+    assert response["statusCode"] == 200
+
+    va_profile_test = VA_PROFILE_TEST.bindparams(
+        va_profile_id=0,
+        communication_item_id=0,
+        communication_channel_id=0
+    )
+
+    with notify_db.engine.begin() as connection:
+        result = connection.execute(COUNT)
+        assert result.fetchone()[0] == 1, "A new row should have been created."
+
+        result = connection.execute(va_profile_test)
+        assert result.fetchone()[0], "The user opted in.  (allowed=True)"
+
+    # Send a request that should not affect the database (older date).
+    event = create_event("txAuditId", "txAuditId", "2022-02-07T19:37:59.320Z", 0, 0, 0, False)
+    response = va_profile_opt_in_out_lambda_handler(event, None)
+    assert isinstance(response, dict)
+    assert response["statusCode"] == 200
+
+    with notify_db.engine.begin() as connection:
+        result = connection.execute(COUNT)
+        assert result.fetchone()[0] == 1, "A new row should not have been created."
+
+        result = connection.execute(va_profile_test)
+        assert result.fetchone()[0], "The user should remain opted in.  (allowed=True)"
+
+
+    # Send a request that should update the database (newer date).
+    event = create_event("txAuditId", "txAuditId", "2022-04-07T19:37:59.320Z", 0, 0, 0, False)
+    response = va_profile_opt_in_out_lambda_handler(event, None)
+    assert isinstance(response, dict)
+    assert response["statusCode"] == 200
+
+    with notify_db.engine.begin() as connection:
+        result = connection.execute(COUNT)
+        assert result.fetchone()[0] == 1, "A new row should not have been created."
+
+        result = connection.execute(va_profile_test)
+        assert not result.fetchone()[0], "The user opted out.  (allowed=False)"
+
+    # Send another request that should result in a new row.
+    event = create_event("txAuditId", "txAuditId", "2022-03-07T19:37:59.320Z", 1, 1, 1, True)
+    response = va_profile_opt_in_out_lambda_handler(event, None)
+    assert isinstance(response, dict)
+    assert response["statusCode"] == 200
+
+    va_profile_test = VA_PROFILE_TEST.bindparams(
+        va_profile_id=1,
+        communication_item_id=1,
+        communication_channel_id=1
+    )
+
+    with notify_db.engine.begin() as connection:
+        result = connection.execute(COUNT)
+        assert result.fetchone()[0] == 2, "A new row should have been created."
+
+        result = connection.execute(va_profile_test)
+        assert result.fetchone()[0], "The user opted in.  (allowed=True)"
+
+        connection.execute("truncate va_profile_local_cache;")
+
+
+def test_handler_va_profile_opt_in_out_lambda_PUT():
+    """
+    Test the VA Profile integration lambda by inspecting the PUT request is initiates to
+    VA Profile in response to a request.
+    """
+
+    pass
+
+
+def create_event(master_tx_audit_id: str, tx_audit_id: str, source_date: str, va_profile_id: int, communication_channel_id: int, communication_item_id: int, is_allowed: bool) -> dict:
+    """
+    Return a dictionary in the format of the payload the lambda function expects to receive from VA Profile.
+    """
+
+    return {
+        "txAuditId": master_tx_audit_id,
+        "bios": [
+            create_bios_element(tx_audit_id, source_date, va_profile_id, communication_channel_id, communication_item_id, is_allowed)
+        ]
+    }
+
+
+def create_bios_element(tx_audit_id: str, source_date: str, va_profile_id: int, communication_channel_id: int, communication_item_id: int, is_allowed: bool) -> dict:
+    return {
+        "txAuditId": tx_audit_id,
+        "sourceDate": source_date,
+        "vaProfileId": va_profile_id,
+        "communicationChannelId": communication_channel_id,
+        "communicationItemId": communication_item_id,
+        "allowed": is_allowed,
+    }
+


### PR DESCRIPTION
#680 

VA Profile will make POST requests to our endpoint that will call a lambda function, which in turn might execute a stored function in our Postgres database.  The lambda function might make a PUT request back to VA Profile, but that functionality is tested via other tickets.  These changes:

- Unit tests the stored function
- Unit test execution of the lambda function (without regard for PUT requests)
- Alter the lambda function to fix errors exposed by the tests and to make the function easier to test
- Include new documentation for running subsets of unit tests

Lambda functions in AWS can access runtime environment variables specified by the infrastructure, and I made some of the names in the infrastructure spec match environment variable names we already use locally.  This means the lambda can execute locally, via unit test, or via AWS with little regard for the differences.  One exception is that the lambda code checks if the environment name is "test".  If so, it avoids making a call to AWS SSM to retrieve the .pem chain.