### PR TITLE
356 datadog agent migration

### DIFF
--- a/cd/application-deployment/dev/vaec-api-task-definition.json
+++ b/cd/application-deployment/dev/vaec-api-task-definition.json
@@ -301,12 +301,16 @@
         {
           "name": "ECS_FARGATE",
           "value": "true"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "ddog-gov.com"
         }
       ],
       "secrets": [
         {
           "name": "DD_API_KEY",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/datadog/apikey"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/datadog-gov/apikey"
         }
       ]
     }

--- a/cd/application-deployment/dev/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/dev/vaec-celery-beat-task-definition.json
@@ -244,12 +244,16 @@
         {
           "name": "ECS_FARGATE",
           "value": "true"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "ddog-gov.com"
         }
       ],
       "secrets": [
         {
           "name": "DD_API_KEY",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/datadog/apikey"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/datadog-gov/apikey"
         }
       ]
     }

--- a/cd/application-deployment/dev/vaec-celery-task-definition.json
+++ b/cd/application-deployment/dev/vaec-celery-task-definition.json
@@ -299,12 +299,16 @@
         {
           "name": "ECS_FARGATE",
           "value": "true"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "ddog-gov.com"
         }
       ],
       "secrets": [
         {
           "name": "DD_API_KEY",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/datadog/apikey"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/datadog-gov/apikey"
         }
       ]
     }

--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -249,12 +249,16 @@
         {
           "name": "ECS_FARGATE",
           "value": "true"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "ddog-gov.com"
         }
       ],
       "secrets": [
         {
           "name": "DD_API_KEY",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/datadog/apikey"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/datadog-gov/apikey"
         }
       ]
     }

--- a/cd/application-deployment/perf/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-beat-task-definition.json
@@ -216,12 +216,16 @@
         {
           "name": "ECS_FARGATE",
           "value": "true"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "ddog-gov.com"
         }
       ],
       "secrets": [
         {
           "name": "DD_API_KEY",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/datadog/apikey"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/datadog-gov/apikey"
         }
       ]
     }

--- a/cd/application-deployment/perf/vaec-celery-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-task-definition.json
@@ -227,12 +227,16 @@
         {
           "name": "ECS_FARGATE",
           "value": "true"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "ddog-gov.com"
         }
       ],
       "secrets": [
         {
           "name": "DD_API_KEY",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/datadog/apikey"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/datadog-gov/apikey"
         }
       ]
     }

--- a/cd/application-deployment/prod/vaec-api-task-definition.json
+++ b/cd/application-deployment/prod/vaec-api-task-definition.json
@@ -281,12 +281,16 @@
         {
           "name": "ECS_FARGATE",
           "value": "true"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "ddog-gov.com"
         }
       ],
       "secrets": [
         {
           "name": "DD_API_KEY",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/datadog/apikey"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/datadog-gov/apikey"
         }
       ]
     }

--- a/cd/application-deployment/prod/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/prod/vaec-celery-beat-task-definition.json
@@ -232,12 +232,16 @@
         {
           "name": "ECS_FARGATE",
           "value": "true"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "ddog-gov.com"
         }
       ],
       "secrets": [
         {
           "name": "DD_API_KEY",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/datadog/apikey"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/datadog-gov/apikey"
         }
       ]
     }

--- a/cd/application-deployment/prod/vaec-celery-task-definition.json
+++ b/cd/application-deployment/prod/vaec-celery-task-definition.json
@@ -263,12 +263,16 @@
         {
           "name": "ECS_FARGATE",
           "value": "true"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "ddog-gov.com"
         }
       ],
       "secrets": [
         {
           "name": "DD_API_KEY",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/datadog/apikey"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/datadog-gov/apikey"
         }
       ]
     }

--- a/cd/application-deployment/staging/vaec-api-task-definition.json
+++ b/cd/application-deployment/staging/vaec-api-task-definition.json
@@ -297,12 +297,16 @@
         {
           "name": "ECS_FARGATE",
           "value": "true"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "ddog-gov.com"
         }
       ],
       "secrets": [
         {
           "name": "DD_API_KEY",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/datadog/apikey"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/datadog-gov/apikey"
         }
       ]
     }

--- a/cd/application-deployment/staging/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/staging/vaec-celery-beat-task-definition.json
@@ -248,12 +248,16 @@
         {
           "name": "ECS_FARGATE",
           "value": "true"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "ddog-gov.com"
         }
       ],
       "secrets": [
         {
           "name": "DD_API_KEY",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/datadog/apikey"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/datadog-gov/apikey"
         }
       ]
     }

--- a/cd/application-deployment/staging/vaec-celery-task-definition.json
+++ b/cd/application-deployment/staging/vaec-celery-task-definition.json
@@ -270,12 +270,16 @@
         {
           "name": "ECS_FARGATE",
           "value": "true"
+        },
+        {
+          "name": "DD_SITE",
+          "value": "ddog-gov.com"
         }
       ],
       "secrets": [
         {
           "name": "DD_API_KEY",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/datadog/apikey"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/datadog-gov/apikey"
         }
       ]
     }


### PR DESCRIPTION
[vanotify-infra#356](https://github.com/department-of-veterans-affairs/vanotify-infra/issues/356)

This PR updates the Fargate container task definitions for datadog-agents to point to the new datadog-gov intstance.