### PR TITLE
VA Profile Sync - Update Lambda with the Comp & Pen Id Filter#684

### DIFF
--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -153,6 +153,11 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context, worker_id=None) -
             put_request_body["bios"].append(put_record)
             continue
 
+        if record.get("communicationItemId", -1) != 5:
+            put_record["status"] = "COMPLETED_NOOP"
+            put_request_body["bios"].append(put_record)
+            continue
+
         try:
             params = (                             # Stored function parameters:
                 record["vaProfileId"],             #     _va_profile_id


### PR DESCRIPTION
#684 

Updated lambda function with Comp & Pen ID filter to check if communicationChannelID is equal to 5 or not.
Wrote a unit test as a current placeholder because we have to test the PUT request first in another ticket #704, of which the format will change.