### PR TITLE
Additing a requirements file for the va_profile_remove_old_opt_outs lambda

### DIFF
--- a/lambda_functions/va_profile_remove_old_opt_outs/requirements-lambda.txt
+++ b/lambda_functions/va_profile_remove_old_opt_outs/requirements-lambda.txt
@@ -1,0 +1,1 @@
+psycopg2-binary==2.9.3


### PR DESCRIPTION
#681 

Lambda functions in Python that import modules that are not part of the standard library must declare requirements for the AWS Lambda execution environment.  We missed this when reviewing [the ticket's merged PR](https://github.com/department-of-veterans-affairs/notification-api/pull/732).