### PR TITLE
updated script to dynamically pull env name to deploy to

### DIFF
--- a/.github/workflows/lambda-functions.yaml
+++ b/.github/workflows/lambda-functions.yaml
@@ -88,8 +88,7 @@ jobs:
       - name: Package and deploy lambda function
         run: |
           zip -ug vetext_incoming_forwarder_lambda.zip vetext_incoming_forwarder_lambda.py
-          aws lambda update-function-code --function-name project-dev-vetext-incoming-forwarder-lambda --zip-file fileb://vetext_incoming_forwarder_lambda.zip
-          aws lambda update-function-code --function-name project-staging-vetext-incoming-forwarder-lambda --zip-file fileb://vetext_incoming_forwarder_lambda.zip
+          aws lambda update-function-code --function-name project-${{ github.event.inputs.environment }}-vetext-incoming-forwarder-lambda --zip-file fileb://vetext_incoming_forwarder_lambda.zip
 
   deploy-other-lambdas:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The deploy method was statically deploying to both dev and staging on every deployment no matter what environment was entered in during workflow run.  This code changes that to match the environment name passed in.  