### PR TITLE
VA Profile - Remove list of returned values in PUT request

### DIFF
--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -68,6 +68,8 @@ def get_va_root_pem() -> str:
     The execution role that imports the module is not the same execution role that executes
     the handler.  Call this function from within the handler to avoid a hard-to-identify
     permissions problem that results in the lambda call timing-out.
+
+    This function sets a module variable.  Don't call it more than once.
     """
 
     assert not requested_va_root_pem, "Don't call this function more than once."
@@ -137,18 +139,19 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context, worker_id=None) -
         {
             txAuditId": "string",
             ...
-            "bios": [
-                {
-                    "txAuditId": "string",
-                    "sourceDate": "2022-03-07T19:37:59.320Z",
-                    "vaProfileId": 0,
-                    "communicationChannelId": 0,
-                    "communicationItemId": 0,
-                    "allowed": true,
-                    ...
-                }
-            ]
+            "bios": [{
+                "txAuditId": "string",
+                "sourceDate": "2022-03-07T19:37:59.320Z",
+                "vaProfileId": 0,
+                "communicationChannelId": 0,
+                "communicationItemId": 0,
+                "allowed": true,
+                ...
+            }],
         }
+
+    "bios" is a list of dictionaries, but we only expect it to have one element for reasons documented here:
+        https://github.com/department-of-veterans-affairs/notification-api/issues/704#issuecomment-1198427986
 
     When this function is called from a unit test, the database URI will differ slightly from the environment
     variable, SQLALCHEMY_DATABASE_URI.  The parameter worker_id is used to construct the modified name in the
@@ -161,110 +164,75 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context, worker_id=None) -
     if not jwt_is_valid(headers.get("Authorization", headers.get("authorization", ''))):
         return { "statusCode": 401 }
 
-    global db_connection, requested_va_root_pem, ssl_context, va_root_pem
-    body = event["body"]
+    post_body = event["body"]
 
-    if "txAuditId" not in body or "bios" not in body or not isinstance(body["bios"], list):
+    if "txAuditId" not in post_body or "bios" not in post_body or not isinstance(post_body["bios"], list):
         return { "statusCode": 400, "body": "A required top level attribute is missing from the request body or has the wrong type." }
 
-    response = { "statusCode": 200 }
+    post_response = { "statusCode": 200 }
 
-    put_request_body = {
-        "txAuditId": body["txAuditId"],
-        "bios": [],
-    }
+    if len(post_body["bios"]) > 1:
+        # Refer to https://github.com/department-of-veterans-affairs/notification-api/issues/704#issuecomment-1198427986
+        logger.warning("The POST request contains more than one update.  Only the first will be processed.")
 
-    # Process the preference updates.
-    for record in body["bios"]:
-        put_record = {
-            "vaProfileId": record.get("vaProfileId", "unknown"),
-            "communicationChannelId": record.get("communicationChannelId", "unknown"),
-            "communicationItemId": record.get("communicationItemId", "unknown"),
-        }
+    bio = post_body["bios"][0]
 
-        if record.get("txAuditId", '') != body["txAuditId"]:
-            # Do not query the database in response to this record.
-            put_record["status"] = "COMPLETED_FAILURE"
-            put_record["info"] = "The record's txAuditId, {}, does not match the event's txAuditId, {}.".format(record.get('txAuditId', '<unknown>'), body["txAuditId"])
-            put_request_body["bios"].append(put_record)
-            continue
+    put_body = {"dateTime": bio["sourceDate"]}
 
-        if record.get("communicationItemId", -1) != 5:
-            put_record["status"] = "COMPLETED_NOOP"
-            put_request_body["bios"].append(put_record)
-            continue
+    if bio.get("txAuditId", '') != post_body["txAuditId"]:
+        put_body["status"] = "COMPLETED_FAILURE"
+        put_body["messages"] = [{
+            "text": "The record's txAuditId, {}, does not match the event's txAuditId, {}.".format(bio.get("txAuditId", "<unknown>"), post_body["txAuditId"]),
+            "severity": "ERROR",
+            "potentiallySelfCorrectingOnRetry": False,
+        }]
+        make_PUT_request(post_body["txAuditId"], put_body)
+        return post_response
 
-        try:
-            params = (                             # Stored function parameters:
-                record["vaProfileId"],             #     _va_profile_id
-                record["communicationItemId"],     #     _communication_item_id
-                record["communicationChannelId"],  #     _communication_channel_name
-                record["allowed"],                 #     _allowed
-                record["sourceDate"],              #     _source_datetime
-            )
+    # VA Profile filters on their end and should only sent us records that match a criteria.
+    if bio.get("communicationItemId", -1) != 5 or bio.get("communicationChannelId", -1) != 2:
+        put_body["status"] = "COMPLETED_NOOP"
+        make_PUT_request(post_body["txAuditId"], put_body)
+        return post_response
 
-            if db_connection is None or db_connection.status != 0:
-                # Attempt to (re-)establish a database connection
-                db_connection = make_connection(worker_id)
+    try:
+        params = (                          # Stored function parameters:
+            bio["vaProfileId"],             #     _va_profile_id
+            bio["communicationItemId"],     #     _communication_item_id
+            bio["communicationChannelId"],  #     _communication_channel_name
+            bio["allowed"],                 #     _allowed
+            bio["sourceDate"],              #     _source_datetime
+        )
 
-            if db_connection is None:
-                raise RuntimeError("No database connection.")
+        global db_connection
 
-            # Execute the stored function.
-            with db_connection.cursor() as c:
-                # https://www.psycopg.org/docs/cursor.html#cursor.execute
-                c.execute(OPT_IN_OUT_QUERY, params)
-                put_record["status"] = "COMPLETED_SUCCESS" if c.fetchone()[0] else "COMPLETED_NOOP"
-                db_connection.commit()
-        except KeyError as e:
-            # Bad Request.  Required attributes are missing.
-            response["statusCode"] = 400
-            put_record["status"] = "COMPLETED_FAILURE"
-            logger.exception(e)
-        except Exception as e:
-            # Internal Server Error.  Prefer to return 400 if multiple records raise exceptions.
-            if response["statusCode"] != 400:
-                response["statusCode"] = 500
-            put_record["status"] = "COMPLETED_FAILURE"
-            logger.exception(e)
-        finally:
-            put_request_body["bios"].append(put_record)
+        if db_connection is None or db_connection.status != 0:
+            # Attempt to (re-)establish a database connection
+            db_connection = make_connection(worker_id)
 
-    if not requested_va_root_pem:
-        va_root_pem = get_va_root_pem()
-        requested_va_root_pem = True
+        if db_connection is None:
+            raise RuntimeError("No database connection.")
 
-    if va_root_pem is not None and put_request_body["bios"]:
-        try:
-            if ssl_context is None:
-                # Use the VA root .pem to authenticate VA Profile's server.
-                ssl_context = ssl.create_default_context(cadata=va_root_pem)
+        # Execute the stored function.
+        with db_connection.cursor() as c:
+            # https://www.psycopg.org/docs/cursor.html#cursor.execute
+            c.execute(OPT_IN_OUT_QUERY, params)
+            put_body["status"] = "COMPLETED_SUCCESS" if c.fetchone()[0] else "COMPLETED_NOOP"
+            db_connection.commit()
+    except KeyError as e:
+        # Bad Request.  Required attributes are missing.
+        post_response["statusCode"] = 400
+        put_body["status"] = "COMPLETED_FAILURE"
+        logger.exception(e)
+    except Exception as e:
+        # Internal Server Error.
+        post_response["statusCode"] = 500
+        put_body["status"] = "COMPLETED_FAILURE"
+        logger.exception(e)
+    finally:
+        make_PUT_request(post_body["txAuditId"], put_body)
 
-            try:
-                # Make a PUT request to VA Profile.
-                https_connection = HTTPSConnection(VA_PROFILE_DOMAIN, context=ssl_context)
-
-                https_connection.request(
-                    "PUT",
-                    VA_PROFILE_PATH_BASE + body["txAuditId"],
-                    dumps(put_request_body),
-                    { "Content-Type": "application/json" }
-                )
-
-                put_response = https_connection.response()
-
-                if put_response.status != 200:
-                    logger.info("VA Profile responded to our PUT request with HTTP status %d.", put_response.status)
-                    logger.debug(put_response)
-            except ConnectionError as e:
-                logger.error("The PUT request to VA Profile failed.")
-                logger.exception(e)
-            finally:
-                https_connection.close()
-        except ssl.SSLError as e:
-            logger.exception(e)
-
-    return response
+    return post_response
 
 
 def jwt_is_valid(auth_header_value: str) -> bool:
@@ -303,3 +271,48 @@ def jwt_is_valid(auth_header_value: str) -> bool:
         logger.debug(auth_header_value)
 
     return False
+
+
+def make_PUT_request(tx_audit_id: str, body: dict):
+    if NOTIFY_ENVIRONMENT == "test":
+        # Don't make PUT requests during unit testing.
+        return
+
+    global requested_va_root_pem, ssl_context, va_root_pem
+
+    if not requested_va_root_pem:
+        va_root_pem = get_va_root_pem()
+        requested_va_root_pem = True
+
+    if va_root_pem is None:
+        return
+
+    try:
+        if ssl_context is None:
+            # Use the VA root .pem to authenticate VA Profile's server.
+            ssl_context = ssl.create_default_context(cadata=va_root_pem)
+
+        try:
+            # Make a PUT request to VA Profile.
+            https_connection = HTTPSConnection(VA_PROFILE_DOMAIN, context=ssl_context)
+
+            https_connection.request(
+                "PUT",
+                VA_PROFILE_PATH_BASE + tx_audit_id,
+                body,
+                { "Content-Type": "application/json" }
+            )
+
+            put_response = https_connection.response()
+
+            if put_response.status != 200:
+                logger.info("VA Profile responded to our PUT request with HTTP status %d.", put_response.status)
+                logger.debug(put_response)
+        except ConnectionError as e:
+            logger.error("The PUT request to VA Profile failed.")
+            logger.exception(e)
+        finally:
+            https_connection.close()
+    except ssl.SSLError as e:
+        logger.exception(e)
+


### PR DESCRIPTION
#704

Per our conversation with VA Profile, the Notify team expects that POST requests from Profile will contain JSON with a "bios" attribute that is an array with a single element. This is a consequence of Profile filtering the "bios" before they make their POST request such that communicationItemId is 5 (see #684) and communicationChannelId is not 1 (sms). By process of elimination, communicationChannelId must be 2 (e-mail). For a given veteran, this combination should be unique, and one POST request corresponds to a preference update for a single veteran.

I have implemented the lambda handler to process only the first element in "bios" and to log a warning if the array has more than one element.  Issue #766 will set up a monitor for these warnings.

The changes also refactor the lambda handler by moving the PUT request to a standalone function that is easier to unit test.