### PR TITLE
VEText migration - Update API and Postman collections for SMS Sender

### DIFF
--- a/app/dao/dao_utils.py
+++ b/app/dao/dao_utils.py
@@ -1,11 +1,14 @@
 import itertools
-from functools import wraps
-
 from app import db
 from app.history_meta import create_history
+from functools import wraps
 
 
 def transactional(func):
+    """
+    This is a decorator for creating a transactional database operation.
+    """
+
     @wraps(func)
     def commit_or_rollback(*args, **kwargs):
         from flask import current_app
@@ -17,6 +20,7 @@ def transactional(func):
             current_app.logger.error(e)
             db.session.rollback()
             raise
+
     return commit_or_rollback
 
 

--- a/app/service/service_senders_schema.py
+++ b/app/service/service_senders_schema.py
@@ -49,9 +49,10 @@ update_service_sms_sender_request = {
     "title": "Update SMS sender for service",
     "properties": {
         "sms_sender": {"type": "string"},
+        "sms_sender_specifics": {"type": ["object", "null"]},
         "is_default": {"type": "boolean"},
         "rate_limit": {"type": ["integer", "null"], "minimum": 1},
         "rate_limit_interval": {"type": ["integer", "null"], "minimum": 1},
-        "inbound_number_id": uuid
+        "inbound_number_id": uuid,
     }
 }

--- a/app/service/sms_sender_rest.py
+++ b/app/service/sms_sender_rest.py
@@ -1,21 +1,24 @@
-from flask import request, jsonify, Blueprint, current_app
-
 from app.authentication.auth import validate_admin_auth
-from app.dao.service_sms_sender_dao import (
-    dao_add_sms_sender_for_service,
-    dao_update_service_sms_sender,
-    archive_sms_sender,
-    dao_get_service_sms_sender_by_id,
-    dao_get_sms_senders_by_service_id
-)
-from app.service.exceptions import \
-    SmsSenderDefaultValidationException, \
-    SmsSenderInboundNumberIntegrityException, \
-    SmsSenderRateLimitIntegrityException
 from app.dao.services_dao import dao_fetch_service_by_id
+from app.dao.service_sms_sender_dao import (
+    archive_sms_sender,
+    dao_add_sms_sender_for_service,
+    dao_get_service_sms_sender_by_id,
+    dao_get_sms_senders_by_service_id,
+    dao_update_service_sms_sender,
+)
 from app.errors import register_errors
 from app.schema_validation import validate
-from app.service.service_senders_schema import add_service_sms_sender_request, update_service_sms_sender_request
+from app.service.exceptions import (
+    SmsSenderDefaultValidationException,
+    SmsSenderInboundNumberIntegrityException,
+    SmsSenderRateLimitIntegrityException,
+)
+from app.service.service_senders_schema import (
+    add_service_sms_sender_request,
+    update_service_sms_sender_request,
+)
+from flask import Blueprint, current_app, jsonify, request
 
 
 def _validate_service_exists():
@@ -78,5 +81,4 @@ def update_service_sms_sender(service_id, sms_sender_id):
 @service_sms_sender_blueprint.route('/<uuid:sms_sender_id>/archive', methods=['POST'])
 def delete_service_sms_sender(service_id, sms_sender_id):
     sms_sender = archive_sms_sender(service_id, sms_sender_id)
-
     return jsonify(data=sms_sender.serialize()), 200

--- a/scripts/postman/notification-api.postman_collection.json
+++ b/scripts/postman/notification-api.postman_collection.json
@@ -3042,14 +3042,16 @@
 									"raw": "{\r\n    \"sms_sender\": \"+18334981539\",\r\n    \"is_default\": true\r\n}"
 								},
 								"url": {
-									"raw": "{{notification-api-url}}/service/{{service-id}}/sms-sender",
+									"raw": "{{notification-api-url}}/service/{{service-id}}/sms-sender/{{sms-sender-id}}/archive",
 									"host": [
 										"{{notification-api-url}}"
 									],
 									"path": [
 										"service",
 										"{{service-id}}",
-										"sms-sender"
+										"sms-sender",
+										"{{sms-sender-id}}",
+										"archive"
 									]
 								}
 							},

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Running a Subset of Tests Using Containers
 
-You can run specific test directories or files rather than the entire suite as follows.  These instructions assume that you have previously run the docker-compose command to start the local ecosystem and, therefore, that all migrations have been applied to the database and the default container network, ci_default, exists.
+You can run specific test directories, files, or individual tests rather than the entire suite as follows.  These instructions assume that you have previously run the docker-compose command to start the local ecosystem and, therefore, that all migrations have been applied to the database and the default container network, ci_default, exists.
 
 ## Setting Environment Variables
 
@@ -16,9 +16,11 @@ The docker-compose command used to run the full test suite sets environment vari
 
 ## Running Individual Tests
 
-This is an example of running a specific test in a test file from within a test container shell:
+This is an example of running a specific test in a test file from *within a test container shell*:
 
-```$ py.test tests/lambda_functions/va_profile/test_va_profile_integration.py::test_va_profile_cache_exists```
+```
+$ py.test tests/lambda_functions/va_profile/test_va_profile_integration.py::test_va_profile_cache_exists
+```
 
 ## A Note About .bash_history
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -605,7 +605,8 @@ def create_service_sms_sender(
         sms_sender,
         is_default=True,
         inbound_number_id=None,
-        archived=False
+        archived=False,
+        sms_sender_specifics={}
 ):
     data = {
         'service_id': service.id,
@@ -613,6 +614,7 @@ def create_service_sms_sender(
         'is_default': is_default,
         'inbound_number_id': inbound_number_id,
         'archived': archived,
+        'sms_sender_specifics': sms_sender_specifics,
     }
     service_sms_sender = ServiceSmsSender(**data)
 

--- a/tests/app/service/test_schema.py
+++ b/tests/app/service/test_schema.py
@@ -1,32 +1,34 @@
 import json
-import uuid
-
 import pytest
-from jsonschema import ValidationError
-
+import uuid
 from app.models import DELIVERY_STATUS_CALLBACK_TYPE, WEBHOOK_CHANNEL_TYPE
 from app.schema_validation import validate
 from app.service.service_callback_api_schema import (
-    update_service_inbound_api_schema, update_service_callback_api_request_schema,
-    create_service_callback_api_request_schema)
+    create_service_callback_api_request_schema,
+    update_service_callback_api_request_schema,
+    update_service_inbound_api_schema,
+)
+from app.service.service_senders_schema import update_service_sms_sender_request
+from jsonschema import ValidationError
 
 
 def test_service_inbound_api_schema_validates():
-    under_test = {"url": "https://some_url.for_service",
-                  "bearer_token": "something_ten_chars",
-                  "updated_by_id": str(uuid.uuid4())
-                  }
+    under_test = {
+        "url": "https://some_url.for_service",
+        "bearer_token": "something_ten_chars",
+        "updated_by_id": str(uuid.uuid4()),
+    }
 
-    validated = validate(under_test, update_service_inbound_api_schema)
-    assert validated == under_test
+    assert validate(under_test, update_service_inbound_api_schema) == under_test
 
 
 @pytest.mark.parametrize("url", ["not a url", "https not a url", "http://valid.com"])
 def test_service_inbound_api_schema_errors_for_url_not_valid_url(url):
-    under_test = {"url": url,
-                  "bearer_token": "something_ten_chars",
-                  "updated_by_id": str(uuid.uuid4())
-                  }
+    under_test = {
+        "url": url,
+        "bearer_token": "something_ten_chars",
+        "updated_by_id": str(uuid.uuid4()),
+    }
 
     with pytest.raises(ValidationError) as e:
         validate(under_test, update_service_inbound_api_schema)
@@ -36,10 +38,11 @@ def test_service_inbound_api_schema_errors_for_url_not_valid_url(url):
 
 
 def test_service_inbound_api_schema_bearer_token_under_ten_char():
-    under_test = {"url": "https://some_url.for_service",
-                  "bearer_token": "shorty",
-                  "updated_by_id": str(uuid.uuid4())
-                  }
+    under_test = {
+        "url": "https://some_url.for_service",
+        "bearer_token": "shorty",
+        "updated_by_id": str(uuid.uuid4()),
+    }
 
     with pytest.raises(ValidationError) as e:
         validate(under_test, update_service_inbound_api_schema)
@@ -54,11 +57,10 @@ def test_create_service_callback_api_schema_validate_succeeds():
         "bearer_token": "something_ten_chars",
         "notification_statuses": ["failed"],
         "callback_channel": WEBHOOK_CHANNEL_TYPE,
-        "callback_type": DELIVERY_STATUS_CALLBACK_TYPE
+        "callback_type": DELIVERY_STATUS_CALLBACK_TYPE,
     }
 
-    validated = validate(under_test, create_service_callback_api_request_schema)
-    assert validated == under_test
+    assert validate(under_test, create_service_callback_api_request_schema) == under_test
 
 
 @pytest.mark.parametrize('key, value', [
@@ -86,7 +88,7 @@ def test_create_service_callback_api_schema_validate_fails_with_misspelled_keys(
         "bearer_token": "something_ten_chars",
         "notification_statuses": ["failed"],
         "callback_channel": WEBHOOK_CHANNEL_TYPE,
-        "callback_type": DELIVERY_STATUS_CALLBACK_TYPE
+        "callback_type": DELIVERY_STATUS_CALLBACK_TYPE,
     }
     del under_test[key]
     under_test[wrong_key] = value
@@ -103,16 +105,15 @@ def test_create_service_callback_api_schema_validate_fails_with_misspelled_keys(
 def test_update_service_callback_api_schema_validate_succeeds():
     under_test = {
         "url": "https://some_url.for_service",
-        "bearer_token": "something_ten_chars"
+        "bearer_token": "something_ten_chars",
     }
 
-    validated = validate(under_test, update_service_callback_api_request_schema)
-    assert validated == under_test
+    assert validate(under_test, update_service_callback_api_request_schema) == under_test
 
 
 def test_update_service_callback_api_schema_validate_fails_with_invalid_keys():
     under_test = {
-        "bearers_token": "something_ten_chars"
+        "bearers_token": "something_ten_chars",
     }
 
     with pytest.raises(ValidationError) as e:
@@ -122,3 +123,19 @@ def test_update_service_callback_api_schema_validate_fails_with_invalid_keys():
     assert len(errors) == 1
     assert errors[0]['error'] == 'ValidationError'
     assert 'bearers_token' in errors[0]['message']
+
+
+def test_update_service_sms_sender_request_schema_validates():
+    under_test = {
+        "sms_sender": "sender",
+        "sms_sender_specifics": {
+            "some": "data",
+            "other_data": 15.3,
+        },
+        "is_default": True,
+        "rate_limit": 3000,
+        "rate_limit_interval": 1,
+        "inbound_number_id": str(uuid.uuid4()),
+    }
+
+    assert validate(under_test, update_service_sms_sender_request) == under_test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,7 +91,7 @@ def notify_db(notify_api, worker_id):
     db.session.remove()
     db.get_engine(notify_api).dispose()
 
-#     TODO: properly delete the database after all workers finish?
+    # TODO - properly delete the database after all workers finish?
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
#748

These changes should implement all necessary endpoint and unit test changes to accommodate the addition of the sms_sender_specifics field in #746.  By volume, most of the changes are clean-ups I made during the process.

The only change I made to the Postman collection is changing the URL for deleting a ServiceSmsSender record.  I don't think this merits any sort of version change for the API because the path in Postman did not match what the API implements.  I merely corrected it.