### PR TITLE
Vetext incoming forwarder lambda hotfix for twilio response

### DIFF
--- a/lambda_functions/vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
+++ b/lambda_functions/vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
@@ -12,13 +12,14 @@ import boto3
 logger = logging.getLogger("vetext_incoming_forwarder_lambda")
 logger.setLevel(logging.DEBUG)
 
+
 def vetext_incoming_forwarder_lambda_handler(event: dict, context: any):
     """this method takes in an event passed in by either an alb or sqs.
         @param: event   -  contains data pertaining to an incoming sms from Twilio
         @param: context -  contains information regarding information
             regarding what triggered the lambda (context.invoked_function_arn).
     """
-    
+
     try:
         logger.debug(event)
         # Determine if the invoker of the lambda is SQS or ALB
@@ -26,7 +27,7 @@ def vetext_incoming_forwarder_lambda_handler(event: dict, context: any):
         #   ALB will submit a single request but to simplify code, it will also return an array of event bodies
         if "requestContext" in event and "elb" in event["requestContext"]:
             logger.info("alb invocation")
-            event_bodies = process_body_from_alb_invocation(event)            
+            event_bodies = process_body_from_alb_invocation(event)
         elif "Records" in event:
             logger.info("sqs invocation")
             event_bodies = process_body_from_sqs_invocation(event)
@@ -42,29 +43,30 @@ def vetext_incoming_forwarder_lambda_handler(event: dict, context: any):
 
         responses = []
 
-        for event_body in event_bodies:       
+        for event_body in event_bodies:
             logger.debug(f"Processing event_body: {event_body}")
-            
-            response = make_vetext_request(event_body)                
-            
+
+            response = make_vetext_request(event_body)
+
             if response is None:
                 push_to_retry_sqs(event_body)
-            
-            responses.append(response)          
+
+            responses.append(response)
 
         logger.debug(responses)
-        
+
         return create_twilio_response(200)
-    except Exception as e:        
+    except Exception as e:
         logger.error(event)
         logger.exception(e)
         push_to_dead_letter_sqs(event, "vetext_incoming_forwarder_lambda_handler")
 
         return create_twilio_response(500)
 
+
 def create_twilio_response(status_code):
     twiml_response = '<?xml version="1.0" encoding="UTF-8"?><Response></Response>'
-    
+
     response = {
         "statusCode": status_code,
         "isBase64Encoded": False,
@@ -76,6 +78,7 @@ def create_twilio_response(status_code):
 
     return response
 
+
 def process_body_from_sqs_invocation(event):
     event_bodies = []
     for record in event["Records"]:
@@ -86,7 +89,7 @@ def process_body_from_sqs_invocation(event):
         # event["body"] is a base 64 encoded string
         # parse_qsl converts url-encoded strings to array of tuple objects
         # event_body takes the array of tuples and creates a dictionary
-        try: 
+        try:
             event_body = record.get("body", "")
 
             if not event_body:
@@ -100,14 +103,15 @@ def process_body_from_sqs_invocation(event):
             event_bodies.append(event_body)
         except json.decoder.JSONDecodeError as je:
             logger.error("Failed to load json event_body")
-            logger.exception(je)        
+            logger.exception(je)
             push_to_dead_letter_sqs(event_body, "process_body_from_sqs_invocation")
         except Exception as e:
             logger.error("Failed to load event from sqs")
-            logger.exception(e)        
+            logger.exception(e)
             push_to_dead_letter_sqs(event_body, "process_body_from_sqs_invocation")
-    
+
     return event_bodies
+
 
 def process_body_from_alb_invocation(event):
     # event is a json document with a body attribute that contains
@@ -119,7 +123,7 @@ def process_body_from_alb_invocation(event):
 
     if not event_body_encoded:
         logger.info("event_body from alb record was not present")
-        logger.debug(event)        
+        logger.debug(event)
 
     event_body_decoded = parse_qsl(b64decode(event_body_encoded).decode('utf-8'))
     logger.debug(f"Decoded event body {event_body_decoded}")
@@ -127,17 +131,18 @@ def process_body_from_alb_invocation(event):
     event_body = dict(event_body_decoded)
     logger.debug(f"Converted body to dictionary: {event_body}")
 
-    if 'AddOns' in event_body:        
+    if 'AddOns' in event_body:
         logger.info(f"AddOns present in event_body: {event_body['AddOns']}")
         del event_body['AddOns']
         logger.info("Removed AddOns from event_body")
-   
+
     return [event_body]
 
+
 def read_from_ssm(key: str) -> str:
-    try: 
+    try:
         ssm_client = boto3.client('ssm')
-        
+
         response = ssm_client.get_parameter(
             Name=key,
             WithDecryption=True
@@ -145,11 +150,12 @@ def read_from_ssm(key: str) -> str:
 
         return response.get("Parameter", {}).get("Value", '')
     except Exception as e:
-        logger.error("General Exception With Call to VeText")                
-        logger.exception(e)       
+        logger.error("General Exception With Call to VeText")
+        logger.exception(e)
         return ''
 
-def make_vetext_request(request_body):    
+
+def make_vetext_request(request_body):
     # We have been directed by the VeText team to ignore SSL validation
     #   that is why we use the ssl._create_unverified_context method
 
@@ -166,31 +172,31 @@ def make_vetext_request(request_body):
     path = os.getenv('vetext_api_endpoint_path')
     if path is None:
         logger.error("Unable to retrieve vetext_api_endpoint_path from env variables")
-        return None    
-    
+        return None
+
     # Authorization is basic token authentication that is stored in environment.
     auth_token = read_from_ssm(ssm_path)
-    
+
     if auth_token == '':
         logger.error("Unable to retrieve auth token from SSM")
         return None
-    
+
     logger.info("Retrieved AuthToken from SSM")
 
     headers = {
-            'Content-type': 'application/json',
-            'Authorization': 'Basic ' + auth_token
-        }
+        'Content-type': 'application/json',
+        'Authorization': 'Basic ' + auth_token
+    }
 
     body = {
-            "accountSid": request_body.get("AccountSid", ""),
-            "messageSid": request_body.get("MessageSid", ""),
-            "messagingServiceSid": request_body.get("MessagingServiceSid", ""),
-            "to": request_body.get("To", ""),
-            "from": request_body.get("From", ""),
-            "messageStatus": request_body.get("SmsStatus", ""),
-            "body": request_body.get("Body", "")
-        }
+        "accountSid": request_body.get("AccountSid", ""),
+        "messageSid": request_body.get("MessageSid", ""),
+        "messagingServiceSid": request_body.get("MessagingServiceSid", ""),
+        "to": request_body.get("To", ""),
+        "from": request_body.get("From", ""),
+        "messageStatus": request_body.get("SmsStatus", ""),
+        "body": request_body.get("Body", "")
+    }
 
     json_data = json.dumps(body)
 
@@ -200,9 +206,9 @@ def make_vetext_request(request_body):
     connection = None
 
     try:
-        connection = http.client.HTTPSConnection(domain,  context = ssl._create_unverified_context())
+        connection = http.client.HTTPSConnection(domain, context=ssl._create_unverified_context())
         logger.info("generated connection to VeText")
-        
+
         connection.request(
             'POST',
             path,
@@ -210,25 +216,26 @@ def make_vetext_request(request_body):
             headers)
 
         response = connection.getresponse()
-        
+
         logger.info(f"VeText call complete with response: {response.status}")
         logger.debug(f"VeText response: {response}")
 
         if response.status == 200:
-            return response        
+            return response
 
         logger.error("VeText call failed.")
     except http.client.HTTPException as e:
-        logger.error("HttpException With Call To VeText")                
-        logger.exception(e)                                                     
+        logger.error("HttpException With Call To VeText")
+        logger.exception(e)
     except Exception as e:
-        logger.error("General Exception With Call to VeText")                
-        logger.exception(e)                                                
+        logger.error("General Exception With Call to VeText")
+        logger.exception(e)
     finally:
-        if connection: 
+        if connection:
             connection.close()
 
     return None
+
 
 def push_to_retry_sqs(event_body):
     """Places event body dictionary on queue to be retried at a later time"""
@@ -240,12 +247,12 @@ def push_to_retry_sqs(event_body):
     if queue_url is None:
         logger.error("Unable to retrieve vetext_request_drop_sqs_url from env variables")
         logger.error(event_body)
-        return None    
+        return None
 
     logger.debug(f"Retrieved queue_url: {queue_url}")
 
     try:
-        sqs = boto3.client('sqs')        
+        sqs = boto3.client('sqs')
 
         queue_msg = json.dumps(event_body)
         queue_msg_attrs = {
@@ -256,15 +263,16 @@ def push_to_retry_sqs(event_body):
         }
 
         sqs.send_message(QueueUrl=queue_url,
-                        MessageAttributes=queue_msg_attrs,
-                        MessageBody=queue_msg)
-        
+                         MessageAttributes=queue_msg_attrs,
+                         MessageBody=queue_msg)
+
         logger.info("Completed enqueue of message to retry queue")
     except Exception as e:
         logger.error("Push to Retry SQS Exception")
         logger.error(event_body)
-        logger.exception(e)        
+        logger.exception(e)
         push_to_dead_letter_sqs(event_body, "push_to_retry_sqs")
+
 
 def push_to_dead_letter_sqs(event, source):
     """Places unaccounted for event on dead-letter queue to be inspected"""
@@ -282,7 +290,7 @@ def push_to_dead_letter_sqs(event, source):
     logger.debug(f"Retrieved queue_url: {queue_url}")
 
     try:
-        sqs = boto3.client('sqs')        
+        sqs = boto3.client('sqs')
 
         queue_msg = json.dumps(event)
         queue_msg_attrs = {
@@ -293,11 +301,11 @@ def push_to_dead_letter_sqs(event, source):
         }
 
         sqs.send_message(QueueUrl=queue_url,
-                        MessageAttributes=queue_msg_attrs,
-                        MessageBody=queue_msg)
-        
+                         MessageAttributes=queue_msg_attrs,
+                         MessageBody=queue_msg)
+
         logger.info("Completed enqueue of message to dead letter queue")
     except Exception as e:
         logger.error("Push to Dead Letter SQS Exception")
         logger.error(event)
-        logger.exception(e)        
+        logger.exception(e)

--- a/lambda_functions/vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
+++ b/lambda_functions/vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
@@ -18,9 +18,9 @@ def vetext_incoming_forwarder_lambda_handler(event: dict, context: any):
         @param: context -  contains information regarding information
             regarding what triggered the lambda (context.invoked_function_arn).
     """
-
+    
     twilio_response = create_twilio_response()
-
+    
     try:
         logger.debug(event)
         # Determine if the invoker of the lambda is SQS or ALB

--- a/lambda_functions/vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
+++ b/lambda_functions/vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
@@ -35,7 +35,6 @@ def vetext_incoming_forwarder_lambda_handler(event: dict, context: any):
             logger.debug(event)
             push_to_dead_letter_sqs(event, "vetext_incoming_forwarder_lambda_handler")
 
-
             return create_twilio_response(400)
 
         logger.info("Successfully processed event to event_bodies")

--- a/lambda_functions/vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
+++ b/lambda_functions/vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
@@ -19,8 +19,6 @@ def vetext_incoming_forwarder_lambda_handler(event: dict, context: any):
             regarding what triggered the lambda (context.invoked_function_arn).
     """
     
-    twilio_response = create_twilio_response()
-    
     try:
         logger.debug(event)
         # Determine if the invoker of the lambda is SQS or ALB
@@ -37,7 +35,8 @@ def vetext_incoming_forwarder_lambda_handler(event: dict, context: any):
             logger.debug(event)
             push_to_dead_letter_sqs(event, "vetext_incoming_forwarder_lambda_handler")
 
-            return twilio_response
+
+            return create_twilio_response(400)
 
         logger.info("Successfully processed event to event_bodies")
         logger.debug(event_bodies)
@@ -56,19 +55,19 @@ def vetext_incoming_forwarder_lambda_handler(event: dict, context: any):
 
         logger.debug(responses)
         
-        return twilio_response
+        return create_twilio_response(200)
     except Exception as e:        
         logger.error(event)
         logger.exception(e)
         push_to_dead_letter_sqs(event, "vetext_incoming_forwarder_lambda_handler")
 
-        return twilio_response
+        return create_twilio_response(500)
 
-def create_twilio_response():
+def create_twilio_response(status_code):
     twiml_response = '<?xml version="1.0" encoding="UTF-8"?><Response></Response>'
     
     response = {
-        "statusCode": 200,
+        "statusCode": status_code,
         "isBase64Encoded": False,
         "headers": {
             "Content-Type": "text/xml"

--- a/lambda_functions/vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
+++ b/lambda_functions/vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
@@ -19,6 +19,8 @@ def vetext_incoming_forwarder_lambda_handler(event: dict, context: any):
             regarding what triggered the lambda (context.invoked_function_arn).
     """
 
+    twilio_response = create_twilio_response()
+
     try:
         logger.debug(event)
         # Determine if the invoker of the lambda is SQS or ALB
@@ -35,9 +37,7 @@ def vetext_incoming_forwarder_lambda_handler(event: dict, context: any):
             logger.debug(event)
             push_to_dead_letter_sqs(event, "vetext_incoming_forwarder_lambda_handler")
 
-            return{
-                'statusCode': 400
-            }
+            return twilio_response
 
         logger.info("Successfully processed event to event_bodies")
         logger.debug(event_bodies)
@@ -56,17 +56,27 @@ def vetext_incoming_forwarder_lambda_handler(event: dict, context: any):
 
         logger.debug(responses)
         
-        return {
-            'statusCode': 200
-        }    
+        return twilio_response
     except Exception as e:        
         logger.error(event)
         logger.exception(e)
         push_to_dead_letter_sqs(event, "vetext_incoming_forwarder_lambda_handler")
 
-        return{
-            'statusCode':500
-        }
+        return twilio_response
+
+def create_twilio_response():
+    twiml_response = '<?xml version="1.0" encoding="UTF-8"?><Response></Response>'
+    
+    response = {
+        "statusCode": 200,
+        "isBase64Encoded": False,
+        "headers": {
+            "Content-Type": "text/xml"
+        },
+        "body": twiml_response
+    }
+
+    return response
 
 def process_body_from_sqs_invocation(event):
     event_bodies = []

--- a/tests/lambda_functions/vetext_incoming_forwarder_lambda/test_vetext_incoming_forwarder_lambda.py
+++ b/tests/lambda_functions/vetext_incoming_forwarder_lambda/test_vetext_incoming_forwarder_lambda.py
@@ -85,6 +85,7 @@ def test_request_makes_vetext_call(mocker, all_path_env_param_set, http_success_
     response = vetext_incoming_forwarder_lambda_handler(event, None)
 
     assert response['statusCode'] == 200
+    assert response['body'] == '<?xml version="1.0" encoding="UTF-8"?><Response></Response>'
     sqs_mock.assert_not_called()
 
 @pytest.mark.parametrize('event', [(albInvokedWithoutAddOn), (albInvokeWithAddOn), (sqsInvokedWithAddOn)])
@@ -136,6 +137,7 @@ def test_failed_alb_invocation_call_throws_general_exception_goes_to_retry_sqs(m
     response = vetext_incoming_forwarder_lambda_handler(event, None)
 
     assert response['statusCode'] == 500
+    assert response['body'] == '<?xml version="1.0" encoding="UTF-8"?><Response></Response>'
     sqs_mock.assert_not_called()
 
 @pytest.mark.parametrize('event', [(albInvokedWithoutAddOn), (albInvokeWithAddOn), (sqsInvokedWithAddOn)])
@@ -181,6 +183,7 @@ def test_unexpected_event_received(mocker, all_path_env_param_set):
     response = vetext_incoming_forwarder_lambda_handler(event, None)
 
     assert response['statusCode'] == 400
+    assert response['body'] == '<?xml version="1.0" encoding="UTF-8"?><Response></Response>'
     sqs_dead_letter_mock.assert_called_once()
 
 def test_failed_getenv_vetext_api_auth_ssm_path(mocker, all_path_env_param_set):


### PR DESCRIPTION
[538](https://app.zenhub.com/workspaces/va-notify-620d21369d810a00146ed9c8/issues/department-of-veterans-affairs/vanotify-team/538)

Twilio needs a response that includes TWIML in order to NOT log errors in the twilio console.

    In the body of the message, add the twiml xml doc
    In the headers/content-type, set the text/xml value
