### PR TITLE
#777 Resolve Lambda Timeout Related to Removing Opt-outs

### DIFF
--- a/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
+++ b/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from typing import final
 import psycopg2
 import sys
 
@@ -8,19 +7,12 @@ import sys
 # Set globals
 REMOVE_OPTED_OUT_RECORDS_QUERY = """SELECT va_profile_remove_old_opt_outs();"""
 SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI")
-
+CONNECTION = None
 
 # Set logger
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
-if SQLALCHEMY_DATABASE_URI is None:
-    logger.error("The database URI is not set.")
-    sys.exit("Couldn't connect to the database.")
-else:
-    logger.info('Execution environment prepared...')
-
-connection = None
 
 def make_connection(worker_id=None) -> None:
     """
@@ -30,11 +22,11 @@ def make_connection(worker_id=None) -> None:
     https://www.psycopg.org/docs/module.html#exceptions
     """
 
-    global connection
+    global CONNECTION
 
     try:
         logger.info('Connecting to database...')
-        connection = psycopg2.connect(SQLALCHEMY_DATABASE_URI + ('' if worker_id is None else f"_{worker_id}"))
+        CONNECTION = psycopg2.connect(SQLALCHEMY_DATABASE_URI + ('' if worker_id is None else f"_{worker_id}"))
         logger.info('Connected to database...')
     except psycopg2.Warning as e:
         logger.warning(e)
@@ -44,37 +36,52 @@ def make_connection(worker_id=None) -> None:
     except Exception as e:
         logger.exception(f'Unexpected error: {e}')
 
+
+# Set the connection in the execution environment
+make_connection()
+
+# Verify environment is setup correctly
+if SQLALCHEMY_DATABASE_URI is None:
+    logger.error("The database URI is not set.")
+    sys.exit("Couldn't connect to the database.")
+elif CONNECTION is None:
+    logger.error("The database connection is not set.")
+    sys.exit("Couldn't connect to the database.")
+else:
+    logger.info('Execution environment prepared...')
+
+
 def execute_remove_function(worker_id=None, is_retry: bool = False) -> None:
     """
     Executes the REMOVE_OPTED_OUT_RECORDS_QUERY statement and commits.
 
     Returns None 
     """
-    global connection
-
-    if not connection:
-        logger.info('Failed to execute removal function, no connection...')
-        return
+    global CONNECTION
 
     try:
-        with connection.cursor() as c:
+        with CONNECTION.cursor() as c:
             logger.info('Executing remove opt out function...')
             c.execute(REMOVE_OPTED_OUT_RECORDS_QUERY)
             logger.info('Committing to database...')
-            connection.commit()
+            CONNECTION.commit()
             logger.info('Commit to database...')
     except psycopg2.Warning as e:
         logger.warning(e)
     except psycopg2.Error as e:
         logger.exception(e)
+        # https://www.postgresql.org/docs/11/errcodes-appendix.html
         logger.error(e.pgcode)
         logger.error(f'Possible lost connection to database, {"retrying" if not is_retry else "aborting"}...')
+
+        # Attempt to retry the connection and the execution
         if not is_retry:
             make_connection(worker_id)
             execute_remove_function(worker_id, is_retry=True)
     except Exception as e:
         logger.error(f'Unexpected error')
         logger.exception(e)
+
 
 def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=None):
     """
@@ -87,5 +94,3 @@ def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=N
         execute_remove_function(worker_id)
     except Exception as e:
         logger.exception(e)
-
-make_connection()

--- a/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
+++ b/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
@@ -4,17 +4,20 @@ from typing import final
 import psycopg2
 import sys
 
+
+# Set globals
 REMOVE_OPTED_OUT_RECORDS_QUERY = """SELECT va_profile_remove_old_opt_outs();"""
 SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI")
 
+# Set logger
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 if SQLALCHEMY_DATABASE_URI is None:
     logger.error("The database URI is not set.")
     sys.exit("Couldn't connect to the database.")
-
-logger.info('Execution environment prepared...')
+else:
+    logger.info('Execution environment prepared...')
 
 
 def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=None):
@@ -23,11 +26,51 @@ def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=N
     are opted out and greater than 24 hours old.
     """
 
-    connection = None
     # https://www.psycopg.org/docs/module.html#exceptions
     try:
-        connection = make_connetion(worker_id)
+        connection = make_connection(worker_id)
+        execute_remove_function(connection)
+    except Exception as e:
+        logger.exception(e)
+    finally:
+        if connection:
+            connection.close()
+            logger.info('Connection to database closed...')
+
+def make_connection(worker_id):
+    """
+    Return a connection to the database, or return None.
+
+    https://www.psycopg.org/docs/module.html#psycopg2.connect
+    https://www.psycopg.org/docs/module.html#exceptions
+    """
+
+    connection = None
+
+    try:
+        connection = psycopg2.connect(SQLALCHEMY_DATABASE_URI + ('' if worker_id is None else f"_{worker_id}"))
         logger.info('Connected to database...')
+    except psycopg2.Warning as e:
+        logger.warning(e)
+    except psycopg2.Error as e:
+        logger.exception(e)
+        logger.error(e.pgcode)
+    except Exception as e:
+        logger.exception(f'Unexpected error: {e}')
+
+    return connection
+
+def execute_remove_function(connection) -> None:
+    """
+    Executes the REMOVE_OPTED_OUT_RECORDS_QUERY statement and commits.
+
+    Returns None 
+    """
+    if not connection:
+        logger.info('Failed to execute removal function...')
+        return
+
+    try:
         with connection.cursor() as c:
             logger.info('Executing remove opt out function...')
             c.execute(REMOVE_OPTED_OUT_RECORDS_QUERY)
@@ -40,12 +83,5 @@ def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=N
         logger.exception(e)
         logger.error(e.pgcode)
     except Exception as e:
+        logger.error(f'Unexpected error')
         logger.exception(e)
-    finally:
-        if connection:
-            connection.close()
-            logger.info('Connection to database closed...')
-
-def make_connetion(worker_id):
-    logger.info('Connecting to database...')
-    return psycopg2.connect(SQLALCHEMY_DATABASE_URI + ('' if worker_id is None else f"_{worker_id}"))

--- a/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
+++ b/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
@@ -3,84 +3,18 @@ import os
 import psycopg2
 import sys
 
-
 # Set globals
 REMOVE_OPTED_OUT_RECORDS_QUERY = """SELECT va_profile_remove_old_opt_outs();"""
 SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI")
-CONNECTION = None
-
-# Set logger
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-
-
-def make_connection(worker_id=None) -> None:
-    """
-    Return a connection to the database, or return None.
-
-    https://www.psycopg.org/docs/module.html#psycopg2.connect
-    https://www.psycopg.org/docs/module.html#exceptions
-    """
-
-    global CONNECTION
-
-    try:
-        logger.info('Connecting to database...')
-        CONNECTION = psycopg2.connect(SQLALCHEMY_DATABASE_URI + ('' if worker_id is None else f"_{worker_id}"))
-        logger.info('Connected to database...')
-    except psycopg2.Warning as e:
-        logger.warning(e)
-    except psycopg2.Error as e:
-        logger.exception(e)
-        logger.error(e.pgcode)
-    except Exception as e:
-        logger.exception(f'Unexpected error: {e}')
-
-
-# Set the connection in the execution environment
-make_connection()
+logger.setLevel(logging.INFO)
 
 # Verify environment is setup correctly
 if SQLALCHEMY_DATABASE_URI is None:
     logger.error("The database URI is not set.")
     sys.exit("Couldn't connect to the database.")
-elif CONNECTION is None:
-    logger.error("The database connection is not set.")
-    sys.exit("Couldn't connect to the database.")
 else:
     logger.info('Execution environment prepared...')
-
-
-def execute_remove_function(worker_id=None, is_retry: bool = False) -> None:
-    """
-    Executes the REMOVE_OPTED_OUT_RECORDS_QUERY statement and commits.
-
-    Returns None 
-    """
-    global CONNECTION
-
-    try:
-        with CONNECTION.cursor() as c:
-            logger.info('Executing remove opt out function...')
-            c.execute(REMOVE_OPTED_OUT_RECORDS_QUERY)
-            logger.info('Committing to database...')
-            CONNECTION.commit()
-            logger.info('Commit to database...')
-    except psycopg2.Warning as e:
-        logger.warning(e)
-    except psycopg2.Error as e:
-        logger.exception(e)
-        # https://www.postgresql.org/docs/11/errcodes-appendix.html
-        logger.error(e.pgcode)
-        logger.error(f'Possible lost connection to database, {"retrying" if not is_retry else "aborting"}...')
-
-        # Attempt to retry the connection and the execution
-        if not is_retry:
-            make_connection(worker_id)
-            execute_remove_function(worker_id, is_retry=True)
-    except Exception as e:
-        logger.error(f'Unexpected error')
-        logger.exception(e)
 
 
 def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=None):
@@ -88,9 +22,27 @@ def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=N
     This function deletes any va_profile cache records that
     are opted out and greater than 24 hours old.
     """
+    connection = None
 
     # https://www.psycopg.org/docs/module.html#exceptions
     try:
-        execute_remove_function(worker_id)
+        logger.info('Connecting to database...')
+        connection = psycopg2.connect(SQLALCHEMY_DATABASE_URI + ('' if worker_id is None else f"_{worker_id}"))
+
+        with connection.cursor() as c:
+            logger.info('Executing database function...')
+            c.execute(REMOVE_OPTED_OUT_RECORDS_QUERY)
+            logger.info('Committing to database...')
+            connection.commit()
+            logger.info('Completed commit...')
+    except psycopg2.Warning as e:
+        logger.warning(e)
+    except psycopg2.Error as e:
+        logger.exception(e)
+        # https://www.postgresql.org/docs/11/errcodes-appendix.html
+        logger.error(e.pgcode)
     except Exception as e:
         logger.exception(e)
+    finally:
+        if connection:
+            connection.close()

--- a/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
+++ b/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
@@ -6,7 +6,7 @@ import sys
 # Set globals
 REMOVE_OPTED_OUT_RECORDS_QUERY = """SELECT va_profile_remove_old_opt_outs();"""
 SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI")
-logger = logging.getLogger()
+logger = logging.getLogger('va_profile_remove_old_opt_outs')
 logger.setLevel(logging.INFO)
 
 # Verify environment is setup correctly

--- a/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
+++ b/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
@@ -6,8 +6,11 @@ import sys
 REMOVE_OPTED_OUT_RECORDS_QUERY = """SELECT va_profile_remove_old_opt_outs();"""
 SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI")
 
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
 if SQLALCHEMY_DATABASE_URI is None:
-    logging.error("The database URI is not set.")
+    logger.error("The database URI is not set.")
     sys.exit("Couldn't connect to the database.")
 
 
@@ -24,9 +27,9 @@ def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=N
             c.execute(REMOVE_OPTED_OUT_RECORDS_QUERY)
             connection.commit()
     except psycopg2.Warning as e:
-        logging.warning(e)
+        logger.warning(e)
     except psycopg2.Error as e:
-        logging.exception(e)
-        logging.error(e.pgcode)
+        logger.exception(e)
+        logger.error(e.pgcode)
     except Exception as e:
-        logging.exception(e)
+        logger.exception(e)

--- a/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
+++ b/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
@@ -9,6 +9,7 @@ import sys
 REMOVE_OPTED_OUT_RECORDS_QUERY = """SELECT va_profile_remove_old_opt_outs();"""
 SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI")
 
+
 # Set logger
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -19,25 +20,9 @@ if SQLALCHEMY_DATABASE_URI is None:
 else:
     logger.info('Execution environment prepared...')
 
+connection = None
 
-def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=None):
-    """
-    This function deletes any va_profile cache records that
-    are opted out and greater than 24 hours old.
-    """
-
-    # https://www.psycopg.org/docs/module.html#exceptions
-    try:
-        connection = make_connection(worker_id)
-        execute_remove_function(connection)
-    except Exception as e:
-        logger.exception(e)
-    finally:
-        if connection:
-            connection.close()
-            logger.info('Connection to database closed...')
-
-def make_connection(worker_id):
+def make_connection(worker_id=None) -> None:
     """
     Return a connection to the database, or return None.
 
@@ -45,7 +30,7 @@ def make_connection(worker_id):
     https://www.psycopg.org/docs/module.html#exceptions
     """
 
-    connection = None
+    global connection
 
     try:
         logger.info('Connecting to database...')
@@ -59,16 +44,16 @@ def make_connection(worker_id):
     except Exception as e:
         logger.exception(f'Unexpected error: {e}')
 
-    return connection
-
-def execute_remove_function(connection) -> None:
+def execute_remove_function(worker_id=None, is_retry: bool = False) -> None:
     """
     Executes the REMOVE_OPTED_OUT_RECORDS_QUERY statement and commits.
 
     Returns None 
     """
+    global connection
+
     if not connection:
-        logger.info('Failed to execute removal function...')
+        logger.info('Failed to execute removal function, no connection...')
         return
 
     try:
@@ -83,6 +68,24 @@ def execute_remove_function(connection) -> None:
     except psycopg2.Error as e:
         logger.exception(e)
         logger.error(e.pgcode)
+        logger.error(f'Possible lost connection to database, {"retrying" if not is_retry else "aborting"}...')
+        if not is_retry:
+            make_connection(worker_id)
+            execute_remove_function(worker_id, is_retry=True)
     except Exception as e:
         logger.error(f'Unexpected error')
         logger.exception(e)
+
+def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=None):
+    """
+    This function deletes any va_profile cache records that
+    are opted out and greater than 24 hours old.
+    """
+
+    # https://www.psycopg.org/docs/module.html#exceptions
+    try:
+        execute_remove_function(worker_id)
+    except Exception as e:
+        logger.exception(e)
+
+make_connection()

--- a/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
+++ b/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
@@ -46,3 +46,4 @@ def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=N
     finally:
         if connection:
             connection.close()
+            logger.info('Connection closed...')

--- a/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
+++ b/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
@@ -14,6 +14,8 @@ if SQLALCHEMY_DATABASE_URI is None:
     logger.error("The database URI is not set.")
     sys.exit("Couldn't connect to the database.")
 
+logger.info('Execution environment prepared...')
+
 
 def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=None):
     """

--- a/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
+++ b/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
@@ -26,8 +26,8 @@ def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=N
     connection = None
     # https://www.psycopg.org/docs/module.html#exceptions
     try:
-        logger.info('Connecting to database...')
-        connection = psycopg2.connect(SQLALCHEMY_DATABASE_URI + ('' if worker_id is None else f"_{worker_id}"))
+        connection = make_connetion(worker_id)
+        logger.info('Connected to database...')
         with connection.cursor() as c:
             logger.info('Executing remove opt out function...')
             c.execute(REMOVE_OPTED_OUT_RECORDS_QUERY)
@@ -45,3 +45,7 @@ def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=N
         if connection:
             connection.close()
             logger.info('Connection to database closed...')
+
+def make_connetion(worker_id):
+    logger.info('Connecting to database...')
+    return psycopg2.connect(SQLALCHEMY_DATABASE_URI + ('' if worker_id is None else f"_{worker_id}"))

--- a/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
+++ b/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
@@ -48,6 +48,7 @@ def make_connection(worker_id):
     connection = None
 
     try:
+        logger.info('Connecting to database...')
         connection = psycopg2.connect(SQLALCHEMY_DATABASE_URI + ('' if worker_id is None else f"_{worker_id}"))
         logger.info('Connected to database...')
     except psycopg2.Warning as e:


### PR DESCRIPTION
Just added comments, changed it to not use the root logger, and ensured the connection gets closed at the end.

Timeout issue is infra-related.

[Cloudwatch log](https://console.amazonaws-us-gov.com/cloudwatch/home?region=us-gov-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fproject-dev-va-profile-remove-old-opt-outs-lambda/log-events$3Fstart$3D1660246157000$26filterPattern$3D$26end$3D1660246158000) of it working.

![image](https://user-images.githubusercontent.com/16893311/184223816-1cc015ea-6d0e-4447-98dd-f6516d78fa6c.png)

