### PR TITLE
#793 Allow for Manual Lambda Deployments to Dev

### DIFF
--- a/.github/workflows/deploy_lambda_dev.yml
+++ b/.github/workflows/deploy_lambda_dev.yml
@@ -8,7 +8,7 @@ on:
         default: master
 
 jobs:
-  setup-job:
+  setup_job:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -17,7 +17,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
 
   build_deploy_lambda:
-    needs: [setup-job]
+    needs: [setup_job]
     uses: ./.github/workflows/lambda-functions.yml
     with:
       environment: "dev"

--- a/.github/workflows/deploy_lambda_dev.yml
+++ b/.github/workflows/deploy_lambda_dev.yml
@@ -22,3 +22,4 @@ jobs:
     with:
       environment: "dev"
       ref: ${{ github.event.inputs.ref }}
+    secrets: inherit

--- a/.github/workflows/deploy_lambda_dev.yml
+++ b/.github/workflows/deploy_lambda_dev.yml
@@ -1,0 +1,23 @@
+name: Deploy Lambda to Dev
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch to deploy
+        required: true
+        default: master
+
+jobs:
+  setup-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+  build_deploy_lambda:
+    uses: ./.github/workflows/lambda-functions.yml
+    with:
+      environment: "dev"
+      ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/deploy_lambda_dev.yml
+++ b/.github/workflows/deploy_lambda_dev.yml
@@ -1,4 +1,4 @@
-name: Deploy Lambda to Dev
+name: Deploy Lambdas to Dev
 on:
   workflow_dispatch:
     inputs:
@@ -17,6 +17,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
 
   build_deploy_lambda:
+    needs: [setup-job]
     uses: ./.github/workflows/lambda-functions.yml
     with:
       environment: "dev"


### PR DESCRIPTION
# Description

Part of the actions rework removed the ability to deploy lambda code to dev individually. This action re-enables that functionality. 

We have a `workflow_distpatch` that will run the build/deploy lambda job and only deploy the lambda code to dev. 

Fixes #793 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- This will be validated when it's merged into the default branch and allowed to be triggered. 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
