### PR TITLE
VA Profile integration: Alter opt-in/out lambda to handle the payload delivered by the loadbalancer.

### DIFF
--- a/lambda_functions/va_profile/requirements-lambda.txt
+++ b/lambda_functions/va_profile/requirements-lambda.txt
@@ -1,6 +1,11 @@
 boto3==1.24.26
 psycopg2-binary==2.9.3
 
-# https://pyjwt.readthedocs.io/en/stable/installation.html#installation-cryptography
+# https://pyjwt.readthedocs.io/en/stable/installation.html#cryptographic-dependencies-optional
 # When this is upgraded, also upgrade the version in requirements_for_test.txt.
 PyJWT[crypto]==2.4.0
+
+# https://cryptography.io/en/latest/changelog/#v38-0-0
+# 13 September 2022: The current AWS Lambda runtime does not include the version of Rust needed
+# to build later versions.  Pinning PyJWT (above) does not also pin "cryptography".
+cryptography < 38.0.0

--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -18,6 +18,7 @@ hard-to-identify permissions problem that results in the lambda call timing-out.
 """
 
 import boto3
+import json
 import jwt
 import logging
 import os
@@ -27,8 +28,7 @@ import sys
 from botocore.exceptions import ClientError
 from cryptography.x509 import Certificate, load_pem_x509_certificate
 from http.client import HTTPSConnection
-from json import dumps
-from typing import Optional
+from typing import Optional, Tuple
 
 logger = logging.getLogger("VAProfileOptInOut")
 logger.setLevel(logging.DEBUG)
@@ -54,87 +54,77 @@ if SQLALCHEMY_DATABASE_URI is None:
 
 
 # This is a public certificate in .pem format.  Use it to verify the signature
-# of the JWT contained in POST requests from VA Profile.
+# on the JWT contained in POST requests from VA Profile.
 va_profile_public_cert = None
-requested_va_profile_public_cert = False
-
-
-def get_va_profile_public_cert() -> Certificate:
-    """
-    Get the VA Profile public certificate pem from AWS SSM Parameter Store.
-    """
-
-    assert not requested_va_profile_public_cert, "Don't call this function more than once."
-    assert VA_PROFILE_DOMAIN is not None, "There's no point getting a value that won't be used."
-    the_pem = None
-
-    logger.debug("Getting the VA Profile public pem from SSM . . .")
-    ssm_client = boto3.client("ssm")
-
-    try:
-        response = ssm_client.get_parameter(
-            Name=f"/{NOTIFY_ENVIRONMENT}/notification-api/va-profile/va-profile-public-pem",
-            WithDecryption=True
-        )
-    except ClientError as e:
-        logger.exception(e)
-        return None
-
-    the_pem = response.get("Parameter", {}).get("Value")
-
-    if the_pem is None:
-        logger.error("Couldn't get the VA Profile public pem.  Unable to authenticate POST requests.")
-        logger.debug(response)
-        sys.exit("Unable to verify JWTs in POST requests.")
-    else:
-        logger.debug("Retrieved the VA Profile public pem.")
-
-        try:
-            va_profile_public_cert = load_pem_x509_certificate(the_pem.encode()).public_key()
-        except ValueError as e:
-            logger.exception(e)
-            logger.debug("the_pem =\n%s", the_pem)
-            sys.exit("Unable to verify JWTs in POST requests.")
-
-    return va_profile_public_cert
-
 
 # This is the VA root chain used to verify the certiicate VA Profile uses for 2-way TLS when
 # this code makes a PUT request to a VA Profile endpoint.
 va_root_pem = None
-requested_va_root_pem = False
+
+# Only make one request to SSM Parameter Store.  The above two variables are module-level
+# so a new request doesn't need to be made for each HTTP request received during the
+# life of the execution environment.
+requested_certificates = False
 
 
-def get_va_root_pem() -> Optional[str]:
+def get_certificates_from_ssm() -> Tuple[Optional[Certificate], Optional[Certificate]]:
     """
-    Get the VA root certificate pem chain from AWS SSM Parameter Store.
+    Query AWS SSM Parameter Store to get the VA Profile public certificate and the VA root
+    certificate chain.
     """
 
-    assert not requested_va_root_pem, "Don't call this function more than once."
-    assert NOTIFY_ENVIRONMENT != "test"
-    the_pem = None
+    assert not requested_certificates, "Don't call this function more than once."
 
-    logger.debug("Getting the VA root pem from SSM . . .")
+    PROFILE_CERT_NAME = f"/{NOTIFY_ENVIRONMENT}/notification-api/va-profile/va-profile-public-pem"
+    VA_CERT_NAME = f"/{NOTIFY_ENVIRONMENT}/notification-api/va-profile/va-root-pem"
+
     ssm_client = boto3.client("ssm")
+    logger.debug("Getting certificates from SSM Parameter Store . . .")
 
     try:
-        response = ssm_client.get_parameter(
-            Name=f"/{NOTIFY_ENVIRONMENT}/notification-api/va-profile/va-root-pem",
+        response = ssm_client.get_parameters(
+            Names=[
+                PROFILE_CERT_NAME,
+                VA_CERT_NAME,
+            ],
             WithDecryption=True
         )
     except ClientError as e:
         logger.exception(e)
-        return None
+        return (None, None)
 
-    the_pem = response.get("Parameter", {}).get("Value")
+    logger.debug(". . . Retrieved certificates from SSM Parameter Store.")
 
-    if the_pem is None:
-        logger.error("Couldn't get the VA root chain.  Unable to make PUT requests.")
-        logger.debug(response)
-    else:
-        logger.debug("Retrieved the VA root pem.")
+    invalid_parameters =  response.get("InvalidParameters", [])
+    if invalid_parameters:
+        logger.error("Couldn't get these parameters from SSM Parameter Store: %s", invalid_parameters)
 
-    return the_pem
+    profile_cert = None
+    va_cert = None
+
+    for parameter in response.get("Parameters", []):
+        name = parameter.get("Name", '')
+
+        if name == PROFILE_CERT_NAME:
+            if profile_cert is not None:
+                logger.warning("Parameter Store returned multiple values for %s.", name)
+
+            try:
+                # The call to str.encode converts the string to a bytes object.
+                profile_cert = load_pem_x509_certificate(parameter.get("Value", '').encode()).public_key()
+            except ValueError as e:
+                logger.exception(e)
+                logger.debug("Cannot get the Profile public certificate from:\n%s", parameter.get("Value", "the empty string"))
+        elif name == VA_CERT_NAME:
+            if va_cert is not None:
+                logger.warning("Parameter Store returned multiple values for %s.", name)
+            va_cert = parameter.get("Value")
+        elif not name:
+            logger.debug("Parameter Store returned a parameter without a name.")
+        else:
+            logger.debug("Parameter Store returned an unsolicited parameter: %s", name)
+
+    return (profile_cert, va_cert)
 
 
 def make_connection(worker_id):
@@ -145,10 +135,12 @@ def make_connection(worker_id):
     https://www.psycopg.org/docs/module.html#exceptions
     """
 
+    logger.debug("Connecting to the database . . .")
     connection = None
 
     try:
         connection = psycopg2.connect(SQLALCHEMY_DATABASE_URI + ('' if worker_id is None else f"_{worker_id}"))
+        logger.debug(". . . Connected to the database.")
     except psycopg2.Warning as e:
         logger.warning(e)
     except psycopg2.Error as e:
@@ -164,10 +156,10 @@ ssl_context = None
 
 def va_profile_opt_in_out_lambda_handler(event: dict, context, worker_id=None) -> dict:
     """
-    Use the event data to process veterans' opt-in/out requests as relayed by VA Profile.  The event is as proxied by the
-    API gateway:
+    Use the event data to process veterans' opt-in/out requests as relayed by VA Profile.  The event is as
+    proxied by the API gateway or application load balancer:
         https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html#apigateway-example-event
-    
+
     The event "body" fields are as specified in the "VA Profile Syncronization" document:
 
         {
@@ -192,18 +184,32 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context, worker_id=None) -
     same manner as in the tests/conftest.py::notify_db fixture.
     """
 
-    logger.debug(event)
-    global requested_va_profile_public_cert, va_profile_public_cert, requested_va_root_pem, va_root_pem
+    logger.debug("POST event: %s", event)
+    global requested_certificates, va_profile_public_cert, va_root_pem
 
-    if not requested_va_profile_public_cert:
-        va_profile_public_cert = get_va_profile_public_cert()
-        requested_va_profile_public_cert = True
+    if not requested_certificates:
+        va_profile_public_cert, va_root_pem = get_certificates_from_ssm()
 
+        if va_profile_public_cert is None:
+            sys.exit("Cannot verify JWT signatures on POST requests from VA Profile.")
+
+        requested_certificates = True
+
+    # Authenticate the request from VA Profile.
     headers = event.get("headers", {})
     if not jwt_is_valid(headers.get("Authorization", headers.get("authorization", '')), va_profile_public_cert):
         return { "statusCode": 401 }
 
     post_body = event["body"]
+
+    if isinstance(post_body, (bytes, str)):
+        try:
+            post_body = json.loads(post_body)
+        except json.decoder.JSONDecodeError:
+            return { "statusCode": 400, "body": "malformed JSON" }
+
+    if not isinstance(post_body, dict):
+        return { "statusCode": 400, "body": "The request body should be a JSON object." }
 
     if "txAuditId" not in post_body or "bios" not in post_body or not isinstance(post_body["bios"], list):
         return { "statusCode": 400, "body": "A required top level attribute is missing from the request body or has the wrong type." }
@@ -219,19 +225,22 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context, worker_id=None) -
     put_body = {"dateTime": bio["sourceDate"]}
 
     if bio.get("txAuditId", '') != post_body["txAuditId"]:
-        put_body["status"] = "COMPLETED_FAILURE"
-        put_body["messages"] = [{
-            "text": "The record's txAuditId, {}, does not match the event's txAuditId, {}.".format(bio.get("txAuditId", "<unknown>"), post_body["txAuditId"]),
-            "severity": "ERROR",
-            "potentiallySelfCorrectingOnRetry": False,
-        }]
-        make_PUT_request(post_body["txAuditId"], put_body)
+        if (va_root_pem is not None or NOTIFY_ENVIRONMENT == "test") and VA_PROFILE_DOMAIN is not None:
+            put_body["status"] = "COMPLETED_FAILURE"
+            put_body["messages"] = [{
+                "text": "The record's txAuditId, {}, does not match the event's txAuditId, {}.".format(bio.get("txAuditId", "<unknown>"), post_body["txAuditId"]),
+                "severity": "ERROR",
+                "potentiallySelfCorrectingOnRetry": False,
+            }]
+            make_PUT_request(post_body["txAuditId"], put_body)
         return post_response
 
     # VA Profile filters on their end and should only sent us records that match a criteria.
-    if bio.get("communicationItemId", -1) != 5 or bio.get("communicationChannelId", -1) != 2:
-        put_body["status"] = "COMPLETED_NOOP"
-        make_PUT_request(post_body["txAuditId"], put_body)
+    # communicationChannelId 1 signifies SMS; 2, e-mail.
+    if bio.get("communicationItemId", -1) != 5 or bio.get("communicationChannelId", -1) != 1:
+        if (va_root_pem is not None or NOTIFY_ENVIRONMENT == "test") and VA_PROFILE_DOMAIN is not None:
+            put_body["status"] = "COMPLETED_NOOP"
+            make_PUT_request(post_body["txAuditId"], put_body)
         return post_response
 
     try:
@@ -246,18 +255,20 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context, worker_id=None) -
         global db_connection
 
         if db_connection is None or db_connection.status != 0:
-            # Attempt to (re-)establish a database connection
+            # Attempt to (re-)establish a database connection.
             db_connection = make_connection(worker_id)
 
         if db_connection is None:
             raise RuntimeError("No database connection.")
 
         # Execute the stored function.
+        logger.debug("Executing the stored function . . .")
         with db_connection.cursor() as c:
             # https://www.psycopg.org/docs/cursor.html#cursor.execute
             c.execute(OPT_IN_OUT_QUERY, params)
             put_body["status"] = "COMPLETED_SUCCESS" if c.fetchone()[0] else "COMPLETED_NOOP"
             db_connection.commit()
+        logger.debug(". . . Executed the stored function.")
     except KeyError as e:
         # Bad Request.  Required attributes are missing.
         post_response["statusCode"] = 400
@@ -269,15 +280,11 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context, worker_id=None) -
         put_body["status"] = "COMPLETED_FAILURE"
         logger.exception(e)
     finally:
-        # Make a PUT request to VA Profile if appropriate and possible.
-        if VA_PROFILE_DOMAIN is not None:
-            if not requested_va_root_pem and NOTIFY_ENVIRONMENT != "test":
-                va_root_pem = get_va_root_pem()
-                requested_va_root_pem = True
+        if (va_root_pem is not None or NOTIFY_ENVIRONMENT == "test") and VA_PROFILE_DOMAIN is not None:
+            assert bool(put_body.get("status"))
+            make_PUT_request(post_body["txAuditId"], put_body)
 
-            if va_root_pem is not None or NOTIFY_ENVIRONMENT == "test":
-                make_PUT_request(post_body["txAuditId"], put_body)
-
+    logger.debug("POST response: %s", post_response)
     return post_response
 
 
@@ -322,8 +329,10 @@ def jwt_is_valid(auth_header_value: str, public_key: Certificate) -> bool:
 def make_PUT_request(tx_audit_id: str, body: dict):
     global ssl_context, va_root_pem
     assert NOTIFY_ENVIRONMENT != "test", "Don't make PUT requests during unit testing."
-    assert VA_PROFILE_DOMAIN is not None, "What is the domain of the PUT request?"
-    assert va_root_pem is not None
+    assert isinstance(VA_PROFILE_DOMAIN, str), "What is the domain of the PUT request?"
+    assert va_root_pem is not None, "Can't verify the authenticity of the server."
+    assert isinstance(tx_audit_id, str)
+    logger.debug("PUT request body: %s", body)
 
     try:
         if ssl_context is None:
@@ -337,20 +346,23 @@ def make_PUT_request(tx_audit_id: str, body: dict):
             https_connection.request(
                 "PUT",
                 VA_PROFILE_PATH_BASE + tx_audit_id,
-                body,
+                json.dumps(body),
                 { "Content-Type": "application/json" }
             )
 
-            put_response = https_connection.response()
+            put_response = https_connection.getresponse()
 
+            logger.info("VA Profile responded to the PUT request with HTTP status %d.", put_response.status)
             if put_response.status != 200:
-                logger.info("VA Profile responded to our PUT request with HTTP status %d.", put_response.status)
                 logger.debug(put_response)
         except ConnectionError as e:
+            logger.error("The PUT request to VA Profile failed.")
+            logger.exception(e)
+        except Exception as e:
+            # TODO - Make this more specific.  Is it a timeout?
             logger.error("The PUT request to VA Profile failed.")
             logger.exception(e)
         finally:
             https_connection.close()
     except ssl.SSLError as e:
         logger.exception(e)
-

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -6,7 +6,7 @@ flake8==3.7.7
 freezegun==1.2.0
 moto==3.0.7
 
-# https://pyjwt.readthedocs.io/en/stable/installation.html#installation-cryptography
+# https://pyjwt.readthedocs.io/en/stable/installation.html#cryptographic-dependencies-optional
 # When this is upgraded, also upgrade the version in lambda_functions/va_profile/requirements-lambda.txt.
 PyJWT[crypto]==2.4.0
 


### PR DESCRIPTION
#810

See the ticket for the long description.  The short version is that the lambda needs to be able to handle the request body delivered as a stringified JSON object.  I also made changes to retrieve all necessary values from the SSM Parameter Store in one call.

These changes get POST functionality working.  Other ticket addresses the still-broken PUT functionality.  Included herein:

1. Alter opt-in/out lambda to handle the payload delivered by the load-balancer (stringified JSON object).
2. Make only one call to SSM Parameter Store to retrieve all necessary values.
3. Use communicationChannelId 1 instead of 2.  (Change in what Profile previously communicated to us.)
4. Pin the version of the cryptography package used with lambdas.