### PR TITLE
Modified the timeout to specify connection and byte read timeouts.

### DIFF
--- a/lambda_functions/vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
+++ b/lambda_functions/vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
@@ -12,7 +12,7 @@ logger = logging.getLogger("vetext_incoming_forwarder_lambda")
 logger.setLevel(logging.DEBUG)
 
 # http timeout for calling vetext endpoint
-HTTPTIMEOUT = 6
+HTTPTIMEOUT = (3.05, 1)
 
 
 def vetext_incoming_forwarder_lambda_handler(event: dict, context: any):


### PR DESCRIPTION
# Description

Necessary change to differentiate between connection and byte reads. The only change is to change the timeout from a scaler to a tuple, with associated timeout values. 

Documentation related to the change: 

- https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
- https://requests.readthedocs.io/en/latest/api/?highlight=requests.post#requests.request (see timeout param)

Fixes #819 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This is an intermittent issue regarding VeText's endpoint. We do not have a way to replicate this for testing locally. This will be tested when we start hammering the endpoint tomorrow.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

