### PR TITLE
Updated vetext url.

### DIFF
--- a/cd/application-deployment/prod/vaec-api-task-definition.json
+++ b/cd/application-deployment/prod/vaec-api-task-definition.json
@@ -152,7 +152,7 @@
         },
         {
           "name": "VETEXT_URL",
-          "value": "https://api.vetext.va.gov/api/vetext/pub"
+          "value": "https://alb.api.vetext.va.gov/api/vetext/pub"
         },
         {
           "name": "VA_FLAGSHIP_APP_SID",

--- a/cd/application-deployment/prod/vaec-celery-task-definition.json
+++ b/cd/application-deployment/prod/vaec-celery-task-definition.json
@@ -146,7 +146,7 @@
         },
         {
           "name": "VETEXT_URL",
-          "value": "https://api.vetext.va.gov/api/vetext/pub"
+          "value": "https://alb.api.vetext.va.gov/api/vetext/pub"
         },
         {
           "name": "VA_FLAGSHIP_APP_SID",


### PR DESCRIPTION
# Description

This was updated a week or so ago with VeText as a test and left in place to see how it handled.

We would like to leave it in place indefinitely. This change is already in prod. A branch was cut off what was in prod with just this one change, then pushed through to deployment.

## Type of change

- [ ] Revision at request of partnered service

## How Has This Been Tested?

This has been in prod for about a week.

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
