### PR TITLE
#902 Lambda functions should read the database URL from SSM Parameter Store

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -324,6 +324,6 @@ fileignoreconfig:
     - filename: migrations/env.py
       checksum: 2dd4f14a2d88a892182c9f3b32a5ff058691066982e71a72a6aa5a0856db1cd6
     - filename: lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
-      checksum: 07277537b6c68606f9672e2b7a3096d403a00612118e3d865d2ec31494868a85
+      checksum: 71a7d63165dbd748d3195b68ad6c5f9ff476c3a3ac18339e67b2a69c6e503a3c
     - filename: tests/lambda_functions/va_profile/test_va_profile_integration.py
       checksum: 689a27fc1319888d900055c52d460b23b6c2b1dea97f4ec078a0e22ff631ae01

--- a/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
+++ b/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
@@ -3,18 +3,36 @@ import os
 import psycopg2
 import sys
 
-# Set globals
-REMOVE_OPTED_OUT_RECORDS_QUERY = """SELECT va_profile_remove_old_opt_outs();"""
-SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI")
-logger = logging.getLogger('va_profile_remove_old_opt_outs')
+logger = logging.getLogger("va_profile_remove_old_opt_outs")
 logger.setLevel(logging.INFO)
 
-# Verify environment is setup correctly
-if SQLALCHEMY_DATABASE_URI is None:
-    logger.error("The database URI is not set.")
-    sys.exit("Couldn't connect to the database.")
-else:
-    logger.info('Execution environment prepared...')
+REMOVE_OPTED_OUT_RECORDS_QUERY = """SELECT va_profile_remove_old_opt_outs();"""
+
+# Get the database URI.  The environment variable SQLALCHEMY_DATABASE_URI is
+# set during unit testing.
+sqlalchemy_database_uri = os.getenv("SQLALCHEMY_DATABASE_URI")
+
+if sqlalchemy_database_uri is None:
+    # This should be an AWS deployment environment.  SQLALCHEMY_DATABASE_URI
+    # is not set in that case.
+
+    database_uri_path = os.getenv("DATABASE_URI_PATH")
+    if database_uri_path is None:
+        # Without this value, this code cannot know the path to the required
+        # SSM Parameter Store resource.
+        sys.exit("DATABASE_URI_PATH is not set.  Check the Lambda console.")
+
+    logger.debug("Getting the database URI from SSM Parameter Store . . .")
+    ssm_client = boto3.client("ssm")
+    ssm_response: dict = ssm_client.get_parameter(
+        Name=database_uri_path,
+        WithDecryption=True
+    )
+    logger.debug(". . . Retrieved the database URI from SSM Parameter Store.")
+    sqlalchemy_database_uri = ssm_response.get("Parameter", {}).get("Value")
+
+if sqlalchemy_database_uri is None:
+    sys.exit("Can't get the database URI.")
 
 
 def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=None):
@@ -22,19 +40,21 @@ def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=N
     This function deletes any va_profile cache records that
     are opted out and greater than 24 hours old.
     """
+
+    logger.info("Removing old opt-outs . . .")
     connection = None
 
     # https://www.psycopg.org/docs/module.html#exceptions
     try:
-        logger.info('Connecting to database...')
-        connection = psycopg2.connect(SQLALCHEMY_DATABASE_URI + ('' if worker_id is None else f"_{worker_id}"))
+        logger.info("Connecting to the database...")
+        connection = psycopg2.connect(sqlalchemy_database_uri + ('' if worker_id is None else f"_{worker_id}"))
+        logger.info(". . . Connected to the database.")
 
         with connection.cursor() as c:
-            logger.info('Executing database function...')
+            logger.info("Executing the stored function")
             c.execute(REMOVE_OPTED_OUT_RECORDS_QUERY)
-            logger.info('Committing to database...')
+            logger.info("Committing the database transaction.")
             connection.commit()
-            logger.info('Completed commit...')
     except psycopg2.Warning as e:
         logger.warning(e)
     except psycopg2.Error as e:
@@ -44,6 +64,8 @@ def va_profile_remove_old_opt_outs_handler(event=None, context=None, worker_id=N
     except Exception as e:
         logger.exception(e)
     finally:
-        if connection:
+        if connection is not None:
             connection.close()
-            logger.info('Connection closed...')
+            logger.info("Connection closed.")
+
+    logger.info(". . . Finished removing old opt-outs.")


### PR DESCRIPTION
As described in the ticket.

Deployed:
[Opt-In/Out](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/3322621949)
[Remove old](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/3322729389)

I manually tested calling the opt-in/out lambda via Lambda console: [CloudWatch logs](https://console.amazonaws-us-gov.com/cloudwatch/home?region=us-gov-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fproject-dev-va-profile-opt-in-out-lambda/log-events/2022$252F10$252F25$252F$255B$2524LATEST$255D7442083e2f314ee5952aabe45a07c805)

You can verify in the Lambda console "environment variables" tab that the database URI is no longer part of the execution environment:
[Opt-In/Out](https://console.amazonaws-us-gov.com/lambda/home?region=us-gov-west-1#/functions/project-dev-va-profile-remove-old-opt-outs-lambda?tab=configure)
[Remove old](https://console.amazonaws-us-gov.com/lambda/home?region=us-gov-west-1#/functions/project-dev-va-profile-opt-in-out-lambda?tab=configure)

Closes #902.