### PR TITLE
#863 VA Profile integration: Revise the format of the POST response returned during QA testing

### DIFF
--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -244,7 +244,12 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context, worker_id=None) -
             make_PUT_request(post_body["txAuditId"], put_body)
 
             if is_integration_test:
-                post_response["put_body"] = put_body
+                post_response["headers"] = {
+                    "Content-Type": "application/json",
+                }
+                post_response["body"] = json.dumps({
+                    "put_body": put_body,
+                })
 
         logger.info("POST response: %s", post_response)
         return post_response
@@ -257,7 +262,12 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context, worker_id=None) -
             make_PUT_request(post_body["txAuditId"], put_body)
 
             if is_integration_test:
-                post_response["put_body"] = put_body
+                post_response["headers"] = {
+                    "Content-Type": "application/json",
+                }
+                post_response["body"] = json.dumps({
+                    "put_body": put_body,
+                })
 
         logger.info("POST response: %s", post_response)
         return post_response
@@ -303,7 +313,12 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context, worker_id=None) -
             make_PUT_request(post_body["txAuditId"], put_body)
 
             if is_integration_test:
-                post_response["put_body"] = put_body
+                post_response["headers"] = {
+                    "Content-Type": "application/json",
+                }
+                post_response["body"] = json.dumps({
+                    "put_body": put_body,
+                })
 
     logger.info("POST response: %s", post_response)
     return post_response

--- a/tests/lambda_functions/va_profile/test_va_profile_integration.py
+++ b/tests/lambda_functions/va_profile/test_va_profile_integration.py
@@ -14,7 +14,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import Certificate, load_pem_x509_certificate
 from datetime import datetime, timedelta, timezone
-from json import dumps
+from json import dumps, loads
 from lambda_functions.va_profile.va_profile_opt_in_out_lambda import jwt_is_valid, va_profile_opt_in_out_lambda_handler
 from sqlalchemy import text
 
@@ -625,6 +625,9 @@ def test_va_profile_opt_in_out_lambda_handler_integration_testing(notify_db, wor
     response = va_profile_opt_in_out_lambda_handler(event, None, worker_id)
     assert isinstance(response, dict)
     assert response["statusCode"] == 200
+    assert response.get("headers", {}).get("Content-Type", '') == "application/json"
+    response_body = loads(response.get("body", "{}"))
+    assert "put_body" in response_body
 
     expected_put_body = {
         "dateTime": "2022-04-07T19:37:59.320Z",
@@ -633,7 +636,7 @@ def test_va_profile_opt_in_out_lambda_handler_integration_testing(notify_db, wor
 
     put_mock.assert_called_once_with("txAuditId", expected_put_body)
     get_integration_testing_public_cert_mock.assert_called_once()
-    assert response["put_body"] == expected_put_body
+    assert response_body["put_body"] == expected_put_body
 
 
 def create_event(


### PR DESCRIPTION
During QA/integration testing, the POST response is supposed to contain the PUT request body.  This is for convenience when making POST requests from a command line client, such as curl, so the user doesn't have to check the CloudWatch logs to see the PUT body.

The PUT body wasn't showing up, and the reason is that AWS Lambda requires the lambda handler return value to include an HTTP response body in a "body" attribute with a stringified value.  This is [not well documented](https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html#python-handler-return).

Using curl in the EC2 bastion host terminal:
```
< HTTP/2 200
< server: awselb/2.0
< date: Mon, 24 Oct 2022 21:21:48 GMT
< content-type: application/json
< content-length: 78
<
* Connection #0 to host dev.api.notifications.va.gov left intact
{"put_body": {"dateTime": "2022-10-15T02:00:12Z", "status": "COMPLETED_NOOP"}}
```

Closes #863.