### PR TITLE
Github actions 'set-output' updated

### DIFF
--- a/.github/workflows/db-downgrade.yml
+++ b/.github/workflows/db-downgrade.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Register migration task definition
         id: register
         run: |
-          echo "::set-output name=arn::$(aws ecs register-task-definition --cli-input-json file://${{ steps.render.outputs.task-definition}} | jq -r '.taskDefinition.taskDefinitionArn')"
+          echo "arn=$(aws ecs register-task-definition --cli-input-json file://${{ steps.render.outputs.task-definition}} | jq -r '.taskDefinition.taskDefinitionArn')" >> $GITHUB_OUTPUT
 
       - name: Run migration task
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Register migration task definition
         id: register
         run: |
-          echo "::set-output name=arn::$(aws ecs register-task-definition --cli-input-json file://${{ steps.render.outputs.task-definition}} | jq -r '.taskDefinition.taskDefinitionArn')"
+          echo "arn=$(aws ecs register-task-definition --cli-input-json file://${{ steps.render.outputs.task-definition}} | jq -r '.taskDefinition.taskDefinitionArn')" >> $GITHUB_OUTPUT
 
       - name: Run migration task
         run: |

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set Hash
         id: set-hash
         run: |
-          echo "::set-output name=commit-hash::"$(git rev-parse HEAD)""
+          echo "commit-hash="$(git rev-parse HEAD)"" >> $GITHUB_OUTPUT
 
       - name: Env Values
         run: |

--- a/.github/workflows/release_trigger.yml
+++ b/.github/workflows/release_trigger.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Get the version
         id: tag
         run: |
-          echo "::set-output name=version::"${GITHUB_REF/refs\/tags\//}""
+          echo "version="${GITHUB_REF/refs\/tags\//}"" >> $GITHUB_OUTPUT
 
       - name: Env Values
         run: |

--- a/.github/workflows/tag_trigger.yml
+++ b/.github/workflows/tag_trigger.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Get the version
         id: tag
         run: |
-          echo "::set-output name=version::"${GITHUB_REF/refs\/tags\//}""
+          echo "version="${GITHUB_REF/refs\/tags\//}"" >> $GITHUB_OUTPUT
 
       - name: Env Values
         run: |

--- a/scripts/tag_git_dev.sh
+++ b/scripts/tag_git_dev.sh
@@ -31,5 +31,5 @@ create_git_tag () {
 
 current_version_tag=$(get_latest_version_tag)
 incremented_tag=$(increase_patch_number $current_version_tag)
-echo "::set-output name=TAG::$incremented_tag"
+echo "TAG=$incremented_tag" >> $GITHUB_OUTPUT
 create_git_tag "$incremented_tag" "$1"

--- a/scripts/tag_git_staging.sh
+++ b/scripts/tag_git_staging.sh
@@ -10,5 +10,5 @@ create_git_tag () {
 
 create_git_tag "$1"
 
-echo "::set-output name=STAGING_TAG::$removed_refs"
-echo "::set-output name=TAG::$version"
+echo "STAGING_TAG=$removed_refs" >> $GITHUB_OUTPUT
+echo "TAG=$version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description
Github actions updated according to the guide, `$GITHUB_OTUPUT` is used to replace `set-ouput`. No `set-state` in the code base.

## Checklist
- [ ] `set-state` replaced
- [x] `set-output` replaced