### PR TITLE
#918 VA Profile integration: KeyError raised when the sourceDate attribute is missing from the POST body

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -324,6 +324,6 @@ fileignoreconfig:
     - filename: migrations/env.py
       checksum: 2dd4f14a2d88a892182c9f3b32a5ff058691066982e71a72a6aa5a0856db1cd6
     - filename: lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
-      checksum: 71a7d63165dbd748d3195b68ad6c5f9ff476c3a3ac18339e67b2a69c6e503a3c
+      checksum: 76ce0c9109e51795a6e1d61e070ea335703707f390861fe134a3638b4ea9c828
     - filename: tests/lambda_functions/va_profile/test_va_profile_integration.py
-      checksum: 689a27fc1319888d900055c52d460b23b6c2b1dea97f4ec078a0e22ff631ae01
+      checksum: 7647fdd36c40ee8c76ee95423685b9aafe567ebea0317fb8ab823100b60466d7

--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -243,7 +243,7 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context, worker_id=None) -
         logger.warning("The POST request contains more than one update.  Only the first will be processed.")
 
     bio = post_body["bios"][0]
-    put_body = {"dateTime": bio["sourceDate"]}
+    put_body = {"dateTime": bio.get("sourceDate", "not available")}
 
     if bio.get("txAuditId", '') != post_body["txAuditId"]:
         if should_make_put_request:
@@ -313,11 +313,21 @@ def va_profile_opt_in_out_lambda_handler(event: dict, context, worker_id=None) -
         # Bad Request.  Required attributes are missing.
         post_response["statusCode"] = 400
         put_body["status"] = "COMPLETED_FAILURE"
+        put_body["messages"] = [{
+            "text": f"KeyError: The bios dictionary attribute is missing the required attribute {e}.",
+            "severity": "ERROR",
+            "potentiallySelfCorrectingOnRetry": False,
+        }]
         logger.exception(e)
     except Exception as e:
         # Internal Server Error.
         post_response["statusCode"] = 500
         put_body["status"] = "COMPLETED_FAILURE"
+        put_body["messages"] = [{
+            "text": str(e),
+            "severity": "ERROR",
+            "potentiallySelfCorrectingOnRetry": False,
+        }]
         logger.exception(e)
     finally:
         if should_make_put_request:

--- a/tests/lambda_functions/va_profile/test_va_profile_integration.py
+++ b/tests/lambda_functions/va_profile/test_va_profile_integration.py
@@ -527,7 +527,7 @@ def test_va_profile_opt_in_out_lambda_handler_newer_date(notify_db, worker_id, j
     put_mock.assert_called_once_with("txAuditId", expected_put_body)
 
 
-def test_va_profile_opt_in_out_lambda_handler_KeyError(jwt_encoded, worker_id, put_mock):
+def test_va_profile_opt_in_out_lambda_handler_KeyError1(jwt_encoded, worker_id, put_mock):
     """
     Test the VA Profile integration lambda by inspecting the PUT request is initiates to
     VA Profile in response to a request.  This test should generate a KeyError in the handler
@@ -543,6 +543,37 @@ def test_va_profile_opt_in_out_lambda_handler_KeyError(jwt_encoded, worker_id, p
     expected_put_body = {
         "dateTime": "2022-04-07T19:37:59.320Z",
         "status": "COMPLETED_FAILURE",
+        "messages": [{
+            "text": "KeyError: The bios dictionary attribute is missing the required attribute 'allowed'.",
+            "severity": "ERROR",
+            "potentiallySelfCorrectingOnRetry": False,
+        }]
+    }
+
+    put_mock.assert_called_once_with("txAuditId", expected_put_body)
+
+
+def test_va_profile_opt_in_out_lambda_handler_KeyError2(jwt_encoded, worker_id, put_mock):
+    """
+    Test the VA Profile integration lambda by inspecting the PUT request is initiates to
+    VA Profile in response to a request.  This test should generate a KeyError in the handler
+    that should be caught.
+    """
+
+    event = create_event("txAuditId", "txAuditId", "2022-04-07T19:37:59.320Z", 0, 1, 5, True, jwt_encoded)
+    del event["body"]["bios"][0]["sourceDate"]
+    response = va_profile_opt_in_out_lambda_handler(event, None, worker_id)
+    assert isinstance(response, dict)
+    assert response["statusCode"] == 400
+
+    expected_put_body = {
+        "dateTime": "not available",
+        "status": "COMPLETED_FAILURE",
+        "messages": [{
+            "text": "KeyError: The bios dictionary attribute is missing the required attribute 'sourceDate'.",
+            "severity": "ERROR",
+            "potentiallySelfCorrectingOnRetry": False,
+        }]
     }
 
     put_mock.assert_called_once_with("txAuditId", expected_put_body)


### PR DESCRIPTION
# Description

My implementation had the possibility of raising KeyError because I referenced an attribute in a dictionary created from a POST request body.  It could be the case that the POST body is missing required attributes.  I replaced the bracket syntax with the dict.get method call that does not raise KeyError.

Fixes #918

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I updated and ran unit tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
