### PR TITLE
Github actions 'set-output' updated

### DIFF
--- a/.github/workflows/db-downgrade.yml
+++ b/.github/workflows/db-downgrade.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Register migration task definition
         id: register
         run: |
-          echo "arn=$(aws ecs register-task-definition --cli-input-json file://${{ steps.render.outputs.task-definition}} | jq -r '.taskDefinition.taskDefinitionArn')" >> $GITHUB_OUTPUT
+          echo "arn=$(aws ecs register-task-definition --cli-input-json file://${{ steps.render.outputs.task-definition}} | jq -r '.taskDefinition.taskDefinitionArn')" >> $GITHUB_ENV
 
       - name: Run migration task
         run: |
-          bash ./scripts/run_ci_migrations.sh -c ${{ github.event.inputs.environment }}-notification-cluster -e ${{ github.event.inputs.environment }} -t ${{ steps.register.outputs.arn }}
+          bash ./scripts/run_ci_migrations.sh -c ${{ github.event.inputs.environment }}-notification-cluster -e ${{ github.event.inputs.environment }} -t ${{ env.arn }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -45,11 +45,11 @@ jobs:
       - name: Register migration task definition
         id: register
         run: |
-          echo "arn=$(aws ecs register-task-definition --cli-input-json file://${{ steps.render.outputs.task-definition}} | jq -r '.taskDefinition.taskDefinitionArn')" >> $GITHUB_OUTPUT
+          echo "arn=$(aws ecs register-task-definition --cli-input-json file://${{ steps.render.outputs.task-definition}} | jq -r '.taskDefinition.taskDefinitionArn')" >> $GITHUB_ENV
 
       - name: Run migration task
         run: |
-          bash ./scripts/run_ci_migrations.sh -c ${{ inputs.environment }}-notification-cluster -e ${{ inputs.environment }} -t ${{ steps.register.outputs.arn }}
+          bash ./scripts/run_ci_migrations.sh -c ${{ inputs.environment }}-notification-cluster -e ${{ inputs.environment }} -t ${{ env.arn }}
 
   deploy-api:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment }}
     outputs:
-      git-hash: ${{ steps.set-hash.outputs.commit-hash }}
+      git-hash: ${{ env.commit-hash }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -32,13 +32,13 @@ jobs:
       - name: Set Hash
         id: set-hash
         run: |
-          echo "commit-hash="$(git rev-parse HEAD)"" >> $GITHUB_OUTPUT
+          echo "commit-hash="$(git rev-parse HEAD)"" >> $GITHUB_ENV
 
       - name: Env Values
         run: |
           echo "The environment is ${{ github.event.inputs.environment }}"
           echo "The branch/tag is ${{ github.event.inputs.ref }}"
-          echo "The commit hash is ${{ steps.set-hash.outputs.commit-hash }}"
+          echo "The commit hash is ${{ env.commit-hash }}"
 
   run-build:
     needs: [setup-environment]

--- a/.github/workflows/release_trigger.yml
+++ b/.github/workflows/release_trigger.yml
@@ -7,7 +7,7 @@ jobs:
   setup-release:
     runs-on: ubuntu-latest
     outputs:
-      git-tag: ${{ steps.tag.outputs.version }}
+      git-tag: ${{ env.version }}
       env: ${{ steps.setup.outputs.environment }}
     steps:
       - name: Setup Environment
@@ -25,12 +25,12 @@ jobs:
       - name: Get the version
         id: tag
         run: |
-          echo "version="${GITHUB_REF/refs\/tags\//}"" >> $GITHUB_OUTPUT
+          echo "version="${GITHUB_REF/refs\/tags\//}"" >> $GITHUB_ENV
 
       - name: Env Values
         run: |
           echo "The environment is ${{ steps.setup.outputs.environment }}"
-          echo "The tag is ${{ steps.tag.outputs.version }}"
+          echo "The tag is ${{ env.version }}"
 
   run-build:
     needs: [setup-release]

--- a/.github/workflows/tag_trigger.yml
+++ b/.github/workflows/tag_trigger.yml
@@ -8,17 +8,17 @@ jobs:
   setup-env:
     runs-on: ubuntu-latest
     outputs:
-      git-tag: ${{ steps.tag.outputs.version }}
+      git-tag: ${{ env.version }}
     steps:
       - name: Get the version
         id: tag
         run: |
-          echo "version="${GITHUB_REF/refs\/tags\//}"" >> $GITHUB_OUTPUT
+          echo "version="${GITHUB_REF/refs\/tags\//}"" >> $GITHUB_ENV
 
       - name: Env Values
         run: |
           echo "The environment is Perf"
-          echo "The commit tag is ${{ steps.tag.outputs.version }}"
+          echo "The commit tag is ${{ env.version }}"
 
   run-build:
     needs: [setup-env]

--- a/scripts/tag_git_dev.sh
+++ b/scripts/tag_git_dev.sh
@@ -31,5 +31,5 @@ create_git_tag () {
 
 current_version_tag=$(get_latest_version_tag)
 incremented_tag=$(increase_patch_number $current_version_tag)
-echo "TAG=$incremented_tag" >> $GITHUB_OUTPUT
+echo "TAG=$incremented_tag" >> $GITHUB_ENV
 create_git_tag "$incremented_tag" "$1"

--- a/scripts/tag_git_staging.sh
+++ b/scripts/tag_git_staging.sh
@@ -10,5 +10,5 @@ create_git_tag () {
 
 create_git_tag "$1"
 
-echo "STAGING_TAG=$removed_refs" >> $GITHUB_OUTPUT
-echo "TAG=$version" >> $GITHUB_OUTPUT
+echo "STAGING_TAG=$removed_refs" >> $GITHUB_ENV
+echo "TAG=$version" >> $GITHUB_ENV


### PR DESCRIPTION
## Description
Github actions updated according to the guide, `$GITHUB_OTUPUT` is used to replace `set-ouput`. No `set-state` in the code base.

## Checklist
- [ ] `set-state` replaced
- [x] `set-output` replaced