### PR TITLE
#855 Modify the deployment packaging for VA Profile integration lambdas.

### DIFF
--- a/.github/workflows/lambda-functions.yml
+++ b/.github/workflows/lambda-functions.yml
@@ -151,6 +151,7 @@ jobs:
           zip -j pinpoint_inbound_sms_lambda pinpoint_inbound_sms/pinpoint_inbound_sms_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-pinpoint-inbound-sms-lambda --zip-file fileb://pinpoint_inbound_sms_lambda.zip
 
+        # This function does not need to package psycopg2-binary, which is included as a lambda layer.  The AWS Lambda execution environment should include boto3 by default.
       - name: Package and deploy VA Profile opt-in/out lambda function
         if: ${{ (inputs.lambdaName == 'ProfileOptInOut') || (inputs.lambdaName == 'All') }}
         run: |
@@ -158,6 +159,7 @@ jobs:
           python3 -m venv venv_va_profile_opt_in_out
           source venv_va_profile_opt_in_out/bin/activate
           pip install -r requirements-lambda.txt
+          pip uninstall -y psycopg2-binary
           deactivate
           cd venv_va_profile_opt_in_out/lib/python3.8/site-packages
           zip -r9 ../../../../va_profile_opt_in_out_lambda.zip .
@@ -165,18 +167,11 @@ jobs:
           zip -ugj va_profile_opt_in_out_lambda va_profile_opt_in_out_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-va-profile-opt-in-out-lambda --zip-file fileb://va_profile_opt_in_out_lambda.zip
 
+        # This function depends only on psycopg2-binary, which is included as a lambda layer.  The AWS Lambda execution environment should include boto3 by default.
       - name: Package and deploy VA Profile remove old opt-outs lambda function
         if: ${{ (inputs.lambdaName == 'ProfileRemoveOldOptOuts') || (inputs.lambdaName == 'All') }}
         run: |
-          cd va_profile_remove_old_opt_outs/
-          python3 -m venv venv_va_profile_remove_old_opt_outs
-          source venv_va_profile_remove_old_opt_outs/bin/activate
-          pip install -r requirements-lambda.txt
-          deactivate
-          cd venv_va_profile_remove_old_opt_outs/lib/python3.8/site-packages
-          zip -r9 ../../../../va_profile_remove_old_opt_outs_lambda.zip .
-          cd ../../../../
-          zip -ugj va_profile_remove_old_opt_outs_lambda va_profile_remove_old_opt_outs_lambda.py
+          zip -j va_profile_remove_old_opt_outs_lambda va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-va-profile-remove-old-opt-outs-lambda --zip-file fileb://va_profile_remove_old_opt_outs_lambda.zip
 
       - name: Package and deploy nightly stats bigquery upload lambda function

--- a/.github/workflows/lambda-functions.yml
+++ b/.github/workflows/lambda-functions.yml
@@ -158,8 +158,8 @@ jobs:
           cd va_profile/
           python3 -m venv venv_va_profile_opt_in_out
           source venv_va_profile_opt_in_out/bin/activate
-          pip install -r requirements-lambda.txt
-          pip uninstall -y psycopg2-binary
+          pip install PyJWT~=2.6.0
+          pip install cryptography~=37.0.4
           deactivate
           cd venv_va_profile_opt_in_out/lib/python3.8/site-packages
           zip -r9 ../../../../va_profile_opt_in_out_lambda.zip .

--- a/lambda_functions/va_profile/requirements-lambda.txt
+++ b/lambda_functions/va_profile/requirements-lambda.txt
@@ -1,4 +1,4 @@
-boto3==1.24.26
+boto3
 psycopg2-binary==2.9.5
 
 # https://pyjwt.readthedocs.io/en/stable/installation.html#cryptographic-dependencies-optional
@@ -7,5 +7,5 @@ PyJWT[crypto]~=2.6.0
 
 # https://cryptography.io/en/latest/changelog/#v38-0-0
 # 13 September 2022: The current AWS Lambda runtime does not include the version of Rust needed
-# to build later versions.  Pinning PyJWT (above) does not also pin "cryptography".
-cryptography < 38.0.0
+# to build versions >= 38.  Pinning PyJWT (above) does not also pin "cryptography".
+cryptography~=37.0.4

--- a/lambda_functions/va_profile/requirements-lambda.txt
+++ b/lambda_functions/va_profile/requirements-lambda.txt
@@ -1,5 +1,5 @@
 boto3==1.24.26
-psycopg2-binary==2.9.3
+psycopg2-binary==2.9.5
 
 # https://pyjwt.readthedocs.io/en/stable/installation.html#cryptographic-dependencies-optional
 # When this is upgraded, also upgrade the version in requirements_for_test.txt.

--- a/lambda_functions/va_profile_remove_old_opt_outs/requirements-lambda.txt
+++ b/lambda_functions/va_profile_remove_old_opt_outs/requirements-lambda.txt
@@ -1,1 +1,1 @@
-psycopg2-binary==2.9.3
+psycopg2-binary==2.9.5

--- a/lambda_functions/va_profile_remove_old_opt_outs/requirements-lambda.txt
+++ b/lambda_functions/va_profile_remove_old_opt_outs/requirements-lambda.txt
@@ -1,1 +1,2 @@
+boto3
 psycopg2-binary==2.9.5

--- a/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
+++ b/lambda_functions/va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
@@ -1,10 +1,11 @@
+import boto3
 import logging
 import os
 import psycopg2
 import sys
 
 logger = logging.getLogger("va_profile_remove_old_opt_outs")
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 
 REMOVE_OPTED_OUT_RECORDS_QUERY = """SELECT va_profile_remove_old_opt_outs();"""
 


### PR DESCRIPTION
# Description

[vanotify-infra 438](https://github.com/department-of-veterans-affairs/vanotify-infra/issues/438) created a lambda layer containing the Python package psycopg2-binary version 2.9.5 and added this layer to the two lambdas associated with VA Profile integration.

The changes for this PR remove psycopg2-binary from the lambda build process.  This should not have any impact on functionality.

I also discovered during testing that I recently broke va_profile_remove_old_opt_outs_lambda.  I made a couple of changes under this PR that allowed me to run that function in Lambda console, which is enough to verify that the code is able to import psycopg2-binary from the layer, but I will create a new ticket for fixing the problem.

Closes #855.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix - added missing "import boto3" statement to a lambda

## How Has This Been Tested?

We packaged and deployed the lambdas from the branch using Github CLI (using the GUI always deploys from master), and I manually executed the functions from the Lambda console.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
