### PR TITLE
#867 BigQuery Update New Column

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -128,7 +128,10 @@ def generate_daily_notification_status_csv_report(process_day_string):
     buff = io.StringIO()
 
     writer = csv.writer(buff, dialect='excel', delimiter=',')
-    header = ["date", "service id", "service name", "template id", "template name", "status", "status reason", "count"]
+    header = [
+        "date", "service id", "service name", "template id", "template name", "status", "status reason", "count",
+        "channel_type"
+    ]
     writer.writerow(header)
     writer.writerows((process_day,) + row for row in transit_data)
 

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -573,7 +573,8 @@ def fetch_notification_statuses_per_service_and_template_for_date(date):
         Template.name.label('template_name'),
         FactNotificationStatus.notification_status.label('status'),
         FactNotificationStatus.status_reason.label('status_reason'),
-        FactNotificationStatus.notification_count.label('count')
+        FactNotificationStatus.notification_count.label('count'),
+        Template.template_type.label('channel_type')
     ).join(
         Template, FactNotificationStatus.template_id == Template.id
     ).join(

--- a/lambda_functions/nightly_stats_bigquery_upload/nightly_stats_bigquery_upload_lambda.py
+++ b/lambda_functions/nightly_stats_bigquery_upload/nightly_stats_bigquery_upload_lambda.py
@@ -50,13 +50,14 @@ def add_updated_rows_for_date(bigquery_client: bigquery.Client, table_id: str, n
     job_config = bigquery.LoadJobConfig(
         schema=[
             bigquery.SchemaField("date", "DATE"),
-            bigquery.SchemaField("service_id", "STRING") ,
+            bigquery.SchemaField("service_id", "STRING"),
             bigquery.SchemaField("service_name", "STRING"),
             bigquery.SchemaField("template_id", "STRING"),
             bigquery.SchemaField("template_name", "STRING"),
             bigquery.SchemaField("status", "STRING"),
             bigquery.SchemaField("status_reason", "STRING"),
-            bigquery.SchemaField("count", "INTEGER")
+            bigquery.SchemaField("count", "INTEGER"),
+            bigquery.SchemaField("channel_type", "STRING")
         ],
         skip_leading_rows=1
     )

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -506,8 +506,8 @@ def test_create_nightly_notification_status_for_day_respects_local_timezone(samp
 def test_generate_daily_notification_status_csv_report(notify_api, mocker):
     service_id = uuid.uuid4()
     template_id = uuid.uuid4()
-    mock_transit_data = [(service_id, 'foo', template_id, 'bar', 'delivered', '', 1),
-                         (service_id, 'foo', template_id, 'bar', 'delivered', 'baz', 1)]
+    mock_transit_data = [(service_id, 'foo', template_id, 'bar', 'delivered', '', 1, 'email'),
+                         (service_id, 'foo', template_id, 'bar', 'delivered', 'baz', 1, 'sms')]
     mocker.patch('app.celery.reporting_tasks.fetch_notification_statuses_per_service_and_template_for_date',
                  return_value=mock_transit_data)
 
@@ -517,6 +517,7 @@ def test_generate_daily_notification_status_csv_report(notify_api, mocker):
     mock_boto.client.return_value.put_object.assert_called_once()
     _, kwargs = mock_boto.client.return_value.put_object.call_args
     assert kwargs['Key'] == '2021-12-16.csv'
-    assert kwargs['Body'] == f'date,service id,service name,template id,template name,status,status reason,count\r\n' \
-                             f'2021-12-16,{service_id},foo,{template_id},bar,delivered,,1\r\n' \
-                             f'2021-12-16,{service_id},foo,{template_id},bar,delivered,baz,1\r\n'
+    assert kwargs['Body'] == 'date,service id,service name,template id,template name,status,status reason,count,' \
+                             'channel_type\r\n' \
+                             f'2021-12-16,{service_id},foo,{template_id},bar,delivered,,1,email\r\n' \
+                             f'2021-12-16,{service_id},foo,{template_id},bar,delivered,baz,1,sms\r\n'

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -833,13 +833,13 @@ def test_fetch_notification_statuses_per_service_and_template_for_date(notify_db
 
     assert len(results) == 6
 
-    # "service id", "service name", "template id", "template name", "status", "reason", "count"
+    # "service id", "service name", "template id", "template name", "status", "reason", "count", "channel_type"
     notification_param_lists = [
-        [test_service.id, 'service', test_template.id, 'template', NOTIFICATION_PERMANENT_FAILURE, 'baz', 4],
-        [test_service.id, 'service', test_template.id, 'template', NOTIFICATION_DELIVERED, 'foo', 2],
-        [test_service.id, 'service', test_template.id, 'template', NOTIFICATION_TECHNICAL_FAILURE, '', 5],
-        [test_service.id, 'service', test_template.id, 'template', NOTIFICATION_PERMANENT_FAILURE, 'bar', 5],
-        [test_service.id, 'service', test_template.id, 'template', NOTIFICATION_TECHNICAL_FAILURE, '', 5]
+        [test_service.id, 'service', test_template.id, 'template', NOTIFICATION_PERMANENT_FAILURE, 'baz', 4, 'sms'],
+        [test_service.id, 'service', test_template.id, 'template', NOTIFICATION_DELIVERED, 'foo', 2, 'sms'],
+        [test_service.id, 'service', test_template.id, 'template', NOTIFICATION_TECHNICAL_FAILURE, '', 5, 'sms'],
+        [test_service.id, 'service', test_template.id, 'template', NOTIFICATION_PERMANENT_FAILURE, 'bar', 5, 'sms'],
+        [test_service.id, 'service', test_template.id, 'template', NOTIFICATION_TECHNICAL_FAILURE, '', 5, 'sms']
     ]
 
     for param_list in notification_param_lists:

--- a/tests/lambda_functions/nightly_stats_bigquery_upload/test_nightly_stats_bigquery_upload.py
+++ b/tests/lambda_functions/nightly_stats_bigquery_upload/test_nightly_stats_bigquery_upload.py
@@ -63,9 +63,9 @@ EXAMPLE_SERVICE_ACCOUNT_INFO = {
 }
 
 EXAMPLE_NIGHTLY_STATS_LIST = [
-    ["service id", "service name", "template id", "template name", "status", "count"],
-    ["some service id", "some service name", "some template id", "some template name", "some status", "5"],
-    ["other service id", "other service name", "other template id", "other template name", "other status", "5"],
+    ["service id", "service name", "template id", "template name", "status", "count", "channel_type"],
+    ["some service id", "some service name", "some template id", "some template name", "some status", "5", "email"],
+    ["other service id", "other service name", "other template id", "other template name", "other status", "5", "sms"],
 ]
 
 


### PR DESCRIPTION
# Description

This change was to add a new column called `channel_type` in the nightly statistics table so we can categorize the messages in datadog. 

Fixes #867

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] The code was deployed and allowed to run overnight. The new column `channel_type` was populated in the s3 files and the BigQuery tables for the day it was allowed to run

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules