### PR TITLE
#856 API Doc update - Email Notification Endpoint

### DIFF
--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -1024,7 +1024,7 @@ paths:
                   billing_code: string
                   email_reply_to_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
                   email: "test@notification.com"
-              recipient_identifier_example:
+              recipient_identifier:
                 value:
                   reference: string
                   template_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -1036,7 +1036,7 @@ paths:
                   email_reply_to_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
                   recipient_identifier:
                     id_type: ICN
-                    id_value: 1008788712V759106
+                    id_value: 1000000000V000000
       responses:
         '201':
           description: CREATED

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -1012,6 +1012,31 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/EmailNotificationRequest'
+            examples:
+              email_example:
+                value:
+                  reference: string
+                  template_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+                  personalisation:
+                    full_name: John Smith
+                    claim_id: '123456'
+                  scheduled_for: string
+                  billing_code: string
+                  email_reply_to_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+                  email: "test@notification.com"
+              recipient_identifier_example:
+                value:
+                  reference: string
+                  template_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+                  personalisation:
+                    full_name: John Smith
+                    claim_id: '123456'
+                  scheduled_for: string
+                  billing_code: string
+                  email_reply_to_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+                  recipient_identifier:
+                    id_type: ICN
+                    id_value: 1008788712V759106
       responses:
         '201':
           description: CREATED

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -1013,7 +1013,7 @@ paths:
             schema:
               $ref: '#/components/schemas/EmailNotificationRequest'
             examples:
-              email_example:
+              email:
                 value:
                   reference: string
                   template_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6


### PR DESCRIPTION
# Description

Email Notification Endpoint API Doc updated, example for `recipient_identifier` added.

Fixes #856 

## Type of change

- [x] Documentation changes only
