### PR TITLE
#858 Update API Docs: SMS Notification Endpoint

### DIFF
--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -1081,6 +1081,31 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SMSNotificationRequest'
+            examples:
+              phone_number:
+                value:
+                  reference: string
+                  template_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+                  personalisation:
+                    full_name: John Smith
+                    claim_id: '123456'
+                  scheduled_for: string
+                  billing_code: string
+                  sms_sender_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6                  
+                  phone_number: "+19876543210"
+              recipient_identifier:
+                value:
+                  reference: string
+                  template_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+                  personalisation:
+                    full_name: John Smith
+                    claim_id: '123456'
+                  scheduled_for: string
+                  billing_code: string
+                  sms_sender_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6                  
+                  recipient_identifier:
+                    id_type: ICN
+                    id_value: 1000000000V000000
       responses:
         '201':
           description: CREATED


### PR DESCRIPTION
# Description
SMS Notification Endpoint API Doc updated, example for `recipient_identifier` added.

Fixes #858 

## Type of change

Please delete options that are not relevant.
- [x] Documentation changes only