### PR TITLE
#975 Update provider selection logic for e-mail

### DIFF
--- a/lambda_functions/user_flows/test_retrieve_everything.py
+++ b/lambda_functions/user_flows/test_retrieve_everything.py
@@ -146,7 +146,7 @@ def test_send_email(notification_url, service_id, service_api_key, template_id):
     """
     Test sending a notification using an e-mail template associated with the User Flows Test Service.
     The available, associated e-mail templates do not have an associated provider.  Therefore,
-    "Govdelivery", the provider associated with the service, should be used.
+    "ses", the provider associated with the service, should be used.
     """
 
     service_jwt = encode_jwt(service_id, service_api_key)
@@ -166,7 +166,7 @@ def test_send_email(notification_url, service_id, service_api_key, template_id):
 
     assert notification_status_response['status'] == desired_status
     assert notification_status_response['email_address'] is not None
-    assert notification_status_response['sent_by'] == 'govdelivery'
+    assert notification_status_response['sent_by'] == 'ses'
 
 
 def test_send_email_with_va_profile_id(notification_url, service_id, service_test_api_key, template_id):


### PR DESCRIPTION
# Description

The tickets prescribes updating provider selection logic for e-mail, but I don't think any changes are necessary for that after my previous [changes for 944](https://github.com/department-of-veterans-affairs/notification-api/pull/950).

The ticket also prescribe database changes that include deactivating the Govdelivery provider.  The changes in this PR update user flows tests to accommodate that change.

Fixes #975

## Type of change

This is a non-breaking change to tests in response to a change in the development environment.

## How Has This Been Tested?

I deployed the branch and got user flows tests to pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes