### PR TITLE
#663 fix JWT and change phone number

### DIFF
--- a/load_testing/send_sms_load_test.py
+++ b/load_testing/send_sms_load_test.py
@@ -30,7 +30,7 @@ class SendSms(HttpUser):
         )
         return resp["Parameter"]["Value"]
 
-    def _get_jwt(self) -> bytes:
+    def _get_jwt(self) -> str:
         header = {'typ': 'JWT', 'alg': 'HS256'}
         combo = {}
         currentTimestamp = int(time.time())
@@ -47,13 +47,15 @@ class SendSms(HttpUser):
 
     @task
     def send(self):
+        encoded_jwt = self._get_jwt()
         headers = {
-            'Authorization': f"Bearer {self._get_jwt().decode('utf-8')}"
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {encoded_jwt}'
         }
         payload = {
             'template_id': self.sms_template_id,
             'sms_sender_id': self.sms_sender_id,
-            'phone_number': '+16502532222'
+            'phone_number': '+14254147755'
         }
         self.client.post(
             '/v2/notifications/sms',


### PR DESCRIPTION
# Description
To run the Locust load test for sms, changes were required of the test to fix the JWT sent in the POST request and the phone number used to an Amazon simulated number.

- Changes the function annotation for the create JWT function from `-> bytes` to `-> str`, since the method returns a string
- Updates the headers sent to just use the returned JWT and adds a Content-Type header
- Changes the phone number to an Amazon simulated number.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Reproduced locust test locally and verified it
- [x] Tested in perf on the disable-sms branch and verified it 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
