### PR TITLE
#979 Updated AWS_PINPOINT_APP_ID to use the correct id

### DIFF
--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -96,7 +96,7 @@
         },
         {
           "name": "AWS_PINPOINT_APP_ID",
-          "value": "164e77155a7a45299b3bc15562732540"
+          "value": "f8cab892fe2740c2901560b55a398440"
         },
         {
           "name": "AWS_SES_EMAIL_FROM_USER",

--- a/cd/application-deployment/perf/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-beat-task-definition.json
@@ -82,7 +82,7 @@
         },
         {
           "name": "AWS_PINPOINT_APP_ID",
-          "value": "164e77155a7a45299b3bc15562732540"
+          "value": "f8cab892fe2740c2901560b55a398440"
         },
         {
           "name": "AWS_SES_EMAIL_FROM_USER",

--- a/cd/application-deployment/perf/vaec-celery-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-task-definition.json
@@ -86,7 +86,7 @@
         },
         {
           "name": "AWS_PINPOINT_APP_ID",
-          "value": "164e77155a7a45299b3bc15562732540"
+          "value": "f8cab892fe2740c2901560b55a398440"
         },
         {
           "name": "AWS_SES_EMAIL_FROM_USER",


### PR DESCRIPTION
# Description

Perf was showing an error when attempting to send SMS that showed the incorrect pinpoint id (it was using staging). This is changed to use the correct project id:

![image](https://user-images.githubusercontent.com/16893311/206246797-0b51d2a6-1eab-402a-b160-364d4c2329b8.png)

Fixes #979 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

It was attempting to send SMS with the wrong Pinpoint Project ID, so to test we updated the ID and pushed it to perf. The messages that failed to send then actually sent thanks to Celery's retry policy on those tasks.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

No new tests were added. This is a configuration for the system and I'm not sure it needs them. Welcome to your thoughts on the matter @cris-oddball 