### PR TITLE
#989 modify defaults for locust sms test

### DIFF
--- a/.github/workflows/load-test-sms-response-time.yaml
+++ b/.github/workflows/load-test-sms-response-time.yaml
@@ -16,12 +16,12 @@ on:
         type: string
         description: "Stop after the specified amount of time, e.g. (300s, 20m, 3h, 1h30m, etc.)"
         required: true
-        default: "1m"
+        default: "10s"
       num_users:
         type: string
         description: "Number of concurrent Locust users."
         required: true
-        default: "5"
+        default: "1"
       spawn_rate:
         type: string
         description: "The rate per second in which users are spawned."
@@ -42,12 +42,12 @@ on:
         type: string
         description: "Stop after the specified amount of time, e.g. (300s, 20m, 3h, 1h30m, etc.)"
         required: true
-        default: "1m"
+        default: "10s"
       num_users:
         type: string
         description: "Number of concurrent Locust users."
         required: true
-        default: "5"
+        default: "1"
       spawn_rate:
         type: string
         description: "The rate per second in which users are spawned."


### PR DESCRIPTION
# Description
Since the phone number for the test was changed to an Amazon simulated number, there is a cost incurred with each sms sent to that number. To ensure that someone doesn't randomly run an expensive sms load test, the defaults are modified such that the runtime is 10 seconds with 1 concurrent user.  

Fixes #989 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Locally with those defaults
- [x] In existing action changing the fields to the new defaults

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

