### PR TITLE
#992 Changed Push Timeout

### DIFF
--- a/app/va/vetext/client.py
+++ b/app/va/vetext/client.py
@@ -15,7 +15,7 @@ class Credentials(TypedDict):
 
 class VETextClient:
     STATSD_KEY = "clients.vetext"
-    TIMEOUT = (3.05, 1)
+    TIMEOUT = 3.05
 
     def init_app(self, url: str, credentials: Credentials, logger: Logger, statsd: StatsdClient):
         self.base_url = url


### PR DESCRIPTION
# Description
This timeout has been modified [twice before](https://github.com/department-of-veterans-affairs/notification-api/commits/master/app/va/vetext/client.py). This is another short-term solution to our long-term problem of long timeouts. This needs to become a celery task or use some alternate method for long-term stability. 

[Documentation](https://requests.readthedocs.io/en/stable/user/quickstart/#timeouts) on the timeout attribute.

![image](https://user-images.githubusercontent.com/16893311/208132011-cc9544f2-f1d1-45e0-aa70-ffd94e9ead79.png)


#992 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
This is essentially reverting [this](https://github.com/department-of-veterans-affairs/notification-api/commit/cc0682a22b49262e38324f34644e03c6624905a1) change. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
