### PR TITLE
964 update twistlock project name and restore action

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -58,8 +58,17 @@ jobs:
       lambdaName: "All"
     secrets: inherit
 
-  run-deployment:
+  run-twistlock:
     needs: [setup-environment, run-build]
+    if: ${{ inputs.environment }} == "dev" || ${{ inputs.environment }} == "perf"
+    uses: ./.github/workflows/twistlock.yml
+    with:
+      environment: "${{ inputs.environment }}"
+      ref: "${{ needs.setup-environment.outputs.git-hash }}"
+    secrets: inherit
+
+  run-deployment:
+    needs: [setup-environment, run-twistlock]
     uses: ./.github/workflows/deployment.yml
     with:
       environment: "${{ inputs.environment }}"

--- a/.github/workflows/tag_trigger.yml
+++ b/.github/workflows/tag_trigger.yml
@@ -37,8 +37,16 @@ jobs:
       lambdaName: "All"
     secrets: inherit
 
-  run-deployment:
+  run-twistlock:
     needs: [setup-env, run-build]
+    uses: ./.github/workflows/twistlock.yml
+    with:
+      environment: "perf"
+      ref: "${{ needs.setup-env.outputs.git-tag }}"
+    secrets: inherit
+
+  run-deployment:
+    needs: [setup-env, run-twistlock]
     uses: ./.github/workflows/deployment.yml
     with:
       environment: "perf"

--- a/.github/workflows/twistlock.yml
+++ b/.github/workflows/twistlock.yml
@@ -46,7 +46,7 @@ jobs:
             "docker pull '"$ECR_REGISTRY"'/'"$IMAGE_REPOSITORY"':'"$IMAGE_TAG"' 1>/dev/null",
             "docker logout '"$ECR_REGISTRY"'",
             "export TWISTLOCK_PASSWORD=$(aws --region us-gov-west-1 ssm get-parameter --name /utility/twistlock/vanotify-ci-user-password --with-decryption | jq '.Parameter.Value' -r)",
-            "twistcli images scan --project VaNotify --address https://twistlock.devops.va.gov --user vanotify-ci-user '"$ECR_REGISTRY"'/'"$IMAGE_REPOSITORY"':'"$IMAGE_TAG"'",
+            "twistcli images scan --project vanotify --address https://twistlock.devops.va.gov --user vanotify-ci-user '"$ECR_REGISTRY"'/'"$IMAGE_REPOSITORY"':'"$IMAGE_TAG"'",
             "STATUS_CODE=$?",
             "docker image prune -a -f 1>/dev/null",
             "exit $STATUS_CODE"


### PR DESCRIPTION
Fixes #964 

- Updated the name of the project from  VaNotify
- Restored the Twistlock action for Deploy to Dev

tested by 
- deployed [Infra code change](https://github.com/department-of-veterans-affairs/vanotify-infra/pull/481) such that the base url and the twistlock client are updated on the EC2 instance
- deployed this api branch to dev and [confirmed that the twistlock scan actually ran](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/3660901717/jobs/6188601200) (and found vulnerabilies!)

