### PR TITLE
#932 Alter inbound number schema logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,8 @@ install-safety:
 	pip install safety
 
 check-dependencies: install-safety ## Scan dependencies for security vulnerabilities
-	# 9 May 2022:
-	#     40416 & 40399 - eventlet < 0.31.0
-	# The other issues are documented in requirements-app.txt.
-	safety check -r requirements.txt --full-report -i 40416 -i 40399 -i 42497 -i 42498 -i 43738 -i 47833
+	# The ignored issues are documented in requirements-app.txt.
+	safety check -r requirements.txt --full-report -i 40416 -i 40399 -i 42497 -i 42498 -i 43738 -i 47833 -i 51668
 
 .PHONY:
 	help \

--- a/app/inbound_number/inbound_number_schema.py
+++ b/app/inbound_number/inbound_number_schema.py
@@ -1,31 +1,31 @@
+# Creation schema
 post_create_inbound_number_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft/2020-12/schema#",
     "description": "POST create inbound number schema",
     "type": "object",
     "properties": {
+        "active": {"type": "boolean"},
         "number": {"type": "string"},
         "provider": {"type": "string"},
-        "service_id": {"type": "string"},
-        "active": {"type": "boolean"},
-        "url_endpoint": {"type": "string"},
         "self_managed": {"type": "boolean"},
+        "service_id": {"type": "string"},
+        "url_endpoint": {"type": "string"},
     },
     "required": ["number", "provider"],
-    "additionalProperties": False
-}
-
-
-post_update_inbound_number_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "POST update inbound number schema",
-    "type": "object",
-    "properties": {
-        "number": {"type": "string"},
-        "provider": {"type": "string"},
-        "service_id": {"type": "string"},
-        "active": {"type": "boolean"},
-        "url_endpoint": {"type": "string"},
-        "self_managed": {"type": "boolean"},
+    "if": {
+        "properties": {
+            "self_managed": {"const": True},
+        },
+        "required": ["self_managed"],
     },
-    "additionalProperties": False
+    "then": {
+        "required": ["url_endpoint"],
+    },
+    "additionalProperties": False,
 }
+
+
+# Update schema.  This is the creation schema without some of the required attributes.
+post_update_inbound_number_schema = post_create_inbound_number_schema.copy()
+post_update_inbound_number_schema["description"] = "POST update inbound number schema"
+del post_update_inbound_number_schema["required"]

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -16,7 +16,8 @@ click-datetime>=0.2
 
 docopt>=0.6.2
 
-# 10 May 2022: Newer versions--even 0.30.3--cause import errors.
+# 10 May 2022: Newer versions--even 0.30.3--cause import errors.  Versions < 0.31.0 have
+# security vulnerabilities 40416 and 40399, which are ignored in Makefile.
 eventlet==0.30.2
 
 # 9 June 2022: Flask raises ImportError with higher versions.
@@ -71,7 +72,10 @@ python-magic>=0.4.27
 rfc3339-validator>=0.1.4
 
 sentry-sdk[flask]>=1.11.1
+
+# 10 December 2022: Ignoring security vulnerability 51668 in Makefile.  It is fixed in >=2.0.0b1.
 SQLAlchemy < 1.4
+
 twilio>=7.15.4
 Unidecode>=1.3.6
 validatesns>=0.1.1


### PR DESCRIPTION
# Description

Alter inbound number schema to require url_endpoint whenever self_managed is true.  I also documented and ignored a new vulnerability Safety identified for SQLAlchemy, which is not something we can upgrade without significant refactoring.

Fixes #932

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I manually tested in a Python interpreter, using https://www.jsonschemavalidator.net/, and by writing new test cases that pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes