### PR TITLE
Removed fixes from PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
 
-Fixes # (issue)
+# (issue)
 
 ## Type of change
 


### PR DESCRIPTION
Removing auto-close feature from PR

"[Fixes](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)" closes the issue automatically. We still want to link the issue, so this PR just removes the auto-close feature.