### PR TITLE
#1017 Modify the packaging actions for the two-way-sms and Vetext lambdas

### DIFF
--- a/.github/workflows/lambda-functions.yml
+++ b/.github/workflows/lambda-functions.yml
@@ -66,42 +66,6 @@ jobs:
           zip -ug user_flows_lambda.zip user_flows_lambda.py steps.py test_retrieve_everything.py conftest.py
           aws lambda update-function-code --function-name project-user-flows-lambda --zip-file fileb://user_flows_lambda.zip
 
-  deploy-vetext-incoming-forwarder-lambda:
-    runs-on: ubuntu-latest
-    if: ${{ (inputs.lambdaName == 'VetTextIncomingForwarder') || (inputs.lambdaName == 'All') }}
-    defaults:
-      run:
-        working-directory: "./lambda_functions/vetext_incoming_forwarder_lambda"
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.ref }}
-
-      - name: Configure VAEC AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1.7.0
-        with:
-          aws-region: us-gov-west-1
-          role-to-assume: ${{ secrets.VAEC_DEPLOY_ROLE }}
-          role-skip-session-tagging: true
-          role-duration-seconds: 900
-
-      - name: Set Python version
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.8"
-
-      - name: Package and deploy lambda function
-        run: |
-          python3 -m venv venv_vetext_incoming_forwarder
-          source venv_vetext_incoming_forwarder/bin/activate
-          pip install -r requirements-lambda.txt
-          deactivate
-          cd venv_vetext_incoming_forwarder/lib/python3.8/site-packages
-          zip -r9 ../../../../vetext_incoming_forwarder_lambda.zip .
-          cd ../../../../
-          zip -ugj vetext_incoming_forwarder_lambda vetext_incoming_forwarder_lambda.py
-          aws lambda update-function-code --function-name project-${{ inputs.environment }}-vetext-incoming-forwarder-lambda --zip-file fileb://vetext_incoming_forwarder_lambda.zip
-
   deploy-other-lambdas:
     runs-on: ubuntu-latest
     defaults:
@@ -133,11 +97,17 @@ jobs:
           zip -j ses_callback_lambda ses_callback/ses_callback_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-ses-callback-lambda --zip-file fileb://ses_callback_lambda.zip
 
-      - name: Package and deploy Two Way SMS lambda function
+      - name: Package and deploy Two Way SMS lambda function v1
         if: ${{ (inputs.lambdaName == 'TwoWaySMS') || (inputs.lambdaName == 'All') }}
         run: |
           zip -j two_way_sms_lambda two_way_sms/two_way_sms_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-two-way-sms-lambda --zip-file fileb://two_way_sms_lambda.zip
+
+      - name: Package and deploy Two Way SMS lambda function v2
+        if: ${{ (inputs.lambdaName == 'TwoWaySMS') || (inputs.lambdaName == 'All') }}
+        run: |
+          zip -j two_way_sms two_way_sms/two_way_sms_v2.py
+          aws lambda update-function-code --function-name project-${{ inputs.environment }}-notify-incoming-sms-lambda --zip-file fileb://two_way_sms.zip
 
       - name: Package and deploy pinpoint callback lambda function
         if: ${{ (inputs.lambdaName == 'PinPointCallback') || (inputs.lambdaName == 'All') }}
@@ -193,30 +163,8 @@ jobs:
           zip -ugj nightly_stats_bigquery_upload_lambda nightly_stats_bigquery_upload_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-nightly-stats-bigquery-upload-lambda --zip-file fileb://nightly_stats_bigquery_upload_lambda.zip
 
-      - name: Package and deploy two-way sms lambda function
-        if: ${{ (inputs.lambdaName == 'TwoWaySMS') || (inputs.lambdaName == 'All') }}
+      - name: Package and deploy vetext incoming forwarder lambda
+        if: ${{ (inputs.lambdaName == 'VetTextIncomingForwarder') || (inputs.lambdaName == 'All') }}
         run: |
-          cd two_way_sms/
-          python3 -m venv venv_two_way_sms
-          source venv_two_way_sms/bin/activate
-          pip install -r requirements-lambda.txt
-          deactivate
-          cd venv_two_way_sms/lib/python3.8/site-packages
-          zip -r9 ../../../../two_way_sms.zip .
-          cd ../../../../
-          zip -ugj two_way_sms two_way_sms_v2.py
-          aws lambda update-function-code --function-name project-${{ inputs.environment }}-notify-incoming-sms-lambda --zip-file fileb://two_way_sms.zip
-
-      - name: Package and deploy nightly billing stats upload lambda function
-        if: ${{ (inputs.lambdaName == 'NightBillingBQUpload') || (inputs.lambdaName == 'All') }}
-        run: |
-          cd nightly_billing_bigquery_upload/
-          python3 -m venv venv_nightly_billing_bigquery_upload
-          source venv_nightly_billing_bigquery_upload/bin/activate
-          pip install -r requirements-lambda.txt
-          deactivate
-          cd venv_nightly_billing_bigquery_upload/lib/python3.8/site-packages
-          zip -r9 ../../../../nightly_billing_stats_upload_lambda.zip .
-          cd ../../../../
-          zip -ugj nightly_billing_stats_upload_lambda nightly_billing_stats_upload_lambda.py
-          aws lambda update-function-code --function-name project-${{ inputs.environment }}-nightly-billing-stats-upload-lambda --zip-file fileb://nightly_billing_stats_upload_lambda.zip
+          zip -j vetext_incoming_forwarder_lambda vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
+          aws lambda update-function-code --function-name project-${{ inputs.environment }}-vetext-incoming-forwarder-lambda --zip-file fileb://vetext_incoming_forwarder_lambda.py

--- a/.github/workflows/lambda-functions.yml
+++ b/.github/workflows/lambda-functions.yml
@@ -167,4 +167,4 @@ jobs:
         if: ${{ (inputs.lambdaName == 'VetTextIncomingForwarder') || (inputs.lambdaName == 'All') }}
         run: |
           zip -j vetext_incoming_forwarder_lambda vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
-          aws lambda update-function-code --function-name project-${{ inputs.environment }}-vetext-incoming-forwarder-lambda --zip-file fileb://vetext_incoming_forwarder_lambda.py
+          aws lambda update-function-code --function-name project-${{ inputs.environment }}-vetext-incoming-forwarder-lambda --zip-file fileb://vetext_incoming_forwarder_lambda.zip

--- a/.github/workflows/lambda-functions.yml
+++ b/.github/workflows/lambda-functions.yml
@@ -163,6 +163,20 @@ jobs:
           zip -ugj nightly_stats_bigquery_upload_lambda nightly_stats_bigquery_upload_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-nightly-stats-bigquery-upload-lambda --zip-file fileb://nightly_stats_bigquery_upload_lambda.zip
 
+      - name: Package and deploy nightly billing stats upload lambda function
+        if: ${{ (inputs.lambdaName == 'NightBillingBQUpload') || (inputs.lambdaName == 'All') }}
+        run: |
+          cd nightly_billing_bigquery_upload/
+          python3 -m venv venv_nightly_billing_bigquery_upload
+          source venv_nightly_billing_bigquery_upload/bin/activate
+          pip install -r requirements-lambda.txt
+          deactivate
+          cd venv_nightly_billing_bigquery_upload/lib/python3.8/site-packages
+          zip -r9 ../../../../nightly_billing_stats_upload_lambda.zip .
+          cd ../../../../
+          zip -ugj nightly_billing_stats_upload_lambda nightly_billing_stats_upload_lambda.py
+          aws lambda update-function-code --function-name project-${{ inputs.environment }}-nightly-billing-stats-upload-lambda --zip-file fileb://nightly_billing_stats_upload_lambda.zip
+
       - name: Package and deploy vetext incoming forwarder lambda
         if: ${{ (inputs.lambdaName == 'VetTextIncomingForwarder') || (inputs.lambdaName == 'All') }}
         run: |

--- a/lambda_functions/two_way_sms/requirements-lambda.txt
+++ b/lambda_functions/two_way_sms/requirements-lambda.txt
@@ -1,3 +1,3 @@
 boto3
 psycopg2-binary==2.9.5
-requests~=2.28.0
+requests~=2.28.1

--- a/lambda_functions/vetext_incoming_forwarder_lambda/requirements-lambda.txt
+++ b/lambda_functions/vetext_incoming_forwarder_lambda/requirements-lambda.txt
@@ -1,1 +1,1 @@
-requests~=2.28.0
+requests~=2.28.1


### PR DESCRIPTION
# Description

This is a companion ticket to [vanotify-infra 480](https://github.com/department-of-veterans-affairs/vanotify-infra/issues/480), which creates a lambda layer for the "requests" Python package.  These changes modify the packaging actions for the two-way-sms and Vetext lambdas so as not to zip Python dependencies.  The layers provide everything necessary.

#1017 

## Type of change

This is a change to lambda packaging.

## How Has This Been Tested?

I [deployed](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/3733202478) all lambdas to dev and verified [here](https://us-gov-west-1.console.amazonaws-us-gov.com/lambda/home?region=us-gov-west-1#/functions/project-dev-vetext-incoming-forwarder-lambda?tab=code) and [here](https://us-gov-west-1.console.amazonaws-us-gov.com/lambda/home?region=us-gov-west-1#/functions/project-dev-notify-incoming-sms-lambda?tab=code) that the lambda source code is visible.  Before these lambdas were using the layers, you would have seen a message that the deployment is too large to view in the console.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes