### PR TITLE
1034-Twilio-Callback-URL-Bugfix

### DIFF
--- a/app/clients/sms/twilio.py
+++ b/app/clients/sms/twilio.py
@@ -47,12 +47,11 @@ class TwilioSMSClient(SmsClient):
         """
 
         start_time = monotonic()
-        # TODO: Following three lines are commented out and 'status_callback' property of messages.create is removed 
+        # TODO: Following two lines are commented out
         # TODO (cont): because the callback url points to an internal url.
-        # TODO (cont): When Reverse Proxy ticket: https://github.com/department-of-veterans-affairs/vanotify-team/issues/716 
-        # TODO (cont): is complete, we can assign that to callback_url and uncomment the next 
-        # TODO (cont): three lines and add status_callback back to both messages.create methods.
-        # callback_url = ""
+        # TODO (cont): When Reverse Proxy ticket(#716)
+        # TODO (cont): is complete, we can assign that to callback_url and uncomment
+        callback_url = ""
         # if self._callback_notify_url_host:
         #    callback_url = f"{self._callback_notify_url_host}/notifications/sms/twilio/{reference}"
 
@@ -90,23 +89,23 @@ class TwilioSMSClient(SmsClient):
                     self.logger.info("Twilio sender has sms_sender_specifics")
 
             if messaging_service_sid is None:
-                # Make a request using a sender phone number.
-                # TODO: add 'status_callback=callback_url,' back to parameter list for messages.create when ticket 716 is completed
+                # Make a request using a sender phone number.                
                 message = self._client.messages.create(
                     to=to,
                     from_=from_number,
                     body=content,
+                    status_callback=callback_url,
                 )
 
                 self.logger.info(f"Twilio message created using from_number")
             else:
                 # Make a request using the messaging service sid.
-                #    https://www.twilio.com/docs/messaging/services
-                # TODO: add 'status_callback=callback_url,' back to parameter list for messages.create when ticket 716 is completed
+                #    https://www.twilio.com/docs/messaging/services                
                 message = self._client.messages.create(
                     to=to,
                     messaging_service_sid=messaging_service_sid,
                     body=content,
+                    status_callback=callback_url,
                 )
 
                 self.logger.info(f"Twilio message created using messaging_service_sid")

--- a/app/clients/sms/twilio.py
+++ b/app/clients/sms/twilio.py
@@ -48,7 +48,8 @@ class TwilioSMSClient(SmsClient):
 
         start_time = monotonic()
         callback_url = ""
-        # TODO: Following two lines are commented out because the callback url points to an internal url.  When reverse proxy endpoint is created, we can assign that to callback_url and uncomment.
+        # TODO: Following two lines are commented out because the callback url points to an internal url.  
+        # TODO (cont): When reverse proxy endpoint is created, we can assign that to callback_url and uncomment.
         #if self._callback_notify_url_host:
         #    callback_url = f"{self._callback_notify_url_host}/notifications/sms/twilio/{reference}"
 

--- a/app/clients/sms/twilio.py
+++ b/app/clients/sms/twilio.py
@@ -48,7 +48,7 @@ class TwilioSMSClient(SmsClient):
 
         start_time = monotonic()
         callback_url = ""
-        # TODO: Following two lines are commented out because the callback url points to an internal url.  
+        # TODO: Following two lines are commented out because the callback url points to an internal url.
         # TODO (cont): When reverse proxy endpoint is created, we can assign that to callback_url and uncomment.
         # if self._callback_notify_url_host:
         #    callback_url = f"{self._callback_notify_url_host}/notifications/sms/twilio/{reference}"

--- a/app/clients/sms/twilio.py
+++ b/app/clients/sms/twilio.py
@@ -48,10 +48,8 @@ class TwilioSMSClient(SmsClient):
 
         start_time = monotonic()
         callback_url = ""
-        # TODO: Following two lines are commented out because the callback url points to an internal url.
-        # TODO (cont): When reverse proxy endpoint is created, we can assign that to callback_url and uncomment.
-        # if self._callback_notify_url_host:
-        #    callback_url = f"{self._callback_notify_url_host}/notifications/sms/twilio/{reference}"
+        if self._callback_notify_url_host:
+            callback_url = f"{self._callback_notify_url_host}/notifications/sms/twilio/{reference}"
 
         try:
             # Importing inline to resolve a circular import error when importing at the top of the file
@@ -88,22 +86,22 @@ class TwilioSMSClient(SmsClient):
 
             if messaging_service_sid is None:
                 # Make a request using a sender phone number.
+                # TODO: add 'status_callback=callback_url,' back to parameter list for messages.create
                 message = self._client.messages.create(
                     to=to,
                     from_=from_number,
                     body=content,
-                    status_callback=callback_url,
                 )
 
                 self.logger.info(f"Twilio message created using from_number")
             else:
                 # Make a request using the messaging service sid.
                 #    https://www.twilio.com/docs/messaging/services
+                # TODO: add 'status_callback=callback_url,' back to parameter list for messages.create
                 message = self._client.messages.create(
                     to=to,
                     messaging_service_sid=messaging_service_sid,
                     body=content,
-                    status_callback=callback_url,
                 )
 
                 self.logger.info(f"Twilio message created using messaging_service_sid")

--- a/app/clients/sms/twilio.py
+++ b/app/clients/sms/twilio.py
@@ -48,8 +48,9 @@ class TwilioSMSClient(SmsClient):
 
         start_time = monotonic()
         callback_url = ""
-        if self._callback_notify_url_host:
-            callback_url = f"{self._callback_notify_url_host}/notifications/sms/twilio/{reference}"
+        # TODO: Following two lines are commented out because the callback url points to an internal url.  When reverse proxy endpoint is created, we can assign that to callback_url and uncomment.
+        #if self._callback_notify_url_host:
+        #    callback_url = f"{self._callback_notify_url_host}/notifications/sms/twilio/{reference}"
 
         try:
             # Importing inline to resolve a circular import error when importing at the top of the file

--- a/app/clients/sms/twilio.py
+++ b/app/clients/sms/twilio.py
@@ -89,7 +89,7 @@ class TwilioSMSClient(SmsClient):
                     self.logger.info("Twilio sender has sms_sender_specifics")
 
             if messaging_service_sid is None:
-                # Make a request using a sender phone number.                
+                # Make a request using a sender phone number.
                 message = self._client.messages.create(
                     to=to,
                     from_=from_number,
@@ -100,7 +100,7 @@ class TwilioSMSClient(SmsClient):
                 self.logger.info(f"Twilio message created using from_number")
             else:
                 # Make a request using the messaging service sid.
-                #    https://www.twilio.com/docs/messaging/services                
+                #    https://www.twilio.com/docs/messaging/services
                 message = self._client.messages.create(
                     to=to,
                     messaging_service_sid=messaging_service_sid,

--- a/app/clients/sms/twilio.py
+++ b/app/clients/sms/twilio.py
@@ -47,9 +47,14 @@ class TwilioSMSClient(SmsClient):
         """
 
         start_time = monotonic()
-        callback_url = ""
-        if self._callback_notify_url_host:
-            callback_url = f"{self._callback_notify_url_host}/notifications/sms/twilio/{reference}"
+        # TODO: Following three lines are commented out and 'status_callback' property of messages.create is removed 
+        # TODO (cont): because the callback url points to an internal url.
+        # TODO (cont): When Reverse Proxy ticket: https://github.com/department-of-veterans-affairs/vanotify-team/issues/716 
+        # TODO (cont): is complete, we can assign that to callback_url and uncomment the next 
+        # TODO (cont): three lines and add status_callback back to both messages.create methods.
+        # callback_url = ""
+        # if self._callback_notify_url_host:
+        #    callback_url = f"{self._callback_notify_url_host}/notifications/sms/twilio/{reference}"
 
         try:
             # Importing inline to resolve a circular import error when importing at the top of the file
@@ -86,7 +91,7 @@ class TwilioSMSClient(SmsClient):
 
             if messaging_service_sid is None:
                 # Make a request using a sender phone number.
-                # TODO: add 'status_callback=callback_url,' back to parameter list for messages.create
+                # TODO: add 'status_callback=callback_url,' back to parameter list for messages.create when ticket 716 is completed
                 message = self._client.messages.create(
                     to=to,
                     from_=from_number,
@@ -97,7 +102,7 @@ class TwilioSMSClient(SmsClient):
             else:
                 # Make a request using the messaging service sid.
                 #    https://www.twilio.com/docs/messaging/services
-                # TODO: add 'status_callback=callback_url,' back to parameter list for messages.create
+                # TODO: add 'status_callback=callback_url,' back to parameter list for messages.create when ticket 716 is completed
                 message = self._client.messages.create(
                     to=to,
                     messaging_service_sid=messaging_service_sid,

--- a/app/clients/sms/twilio.py
+++ b/app/clients/sms/twilio.py
@@ -50,7 +50,7 @@ class TwilioSMSClient(SmsClient):
         callback_url = ""
         # TODO: Following two lines are commented out because the callback url points to an internal url.  
         # TODO (cont): When reverse proxy endpoint is created, we can assign that to callback_url and uncomment.
-        #if self._callback_notify_url_host:
+        # if self._callback_notify_url_host:
         #    callback_url = f"{self._callback_notify_url_host}/notifications/sms/twilio/{reference}"
 
         try:


### PR DESCRIPTION
# Description

When our twilio client is used to initiate an SMS send, it includes a callback URL for delivery status. That callback URL is used by Twilio to deliver delivery statuses for that particular message.

The issue is that the callback URL that is being used uses our notifications.va.gov address, which is not accessible to public internet. This is result in 500 errors in Twilio for EVERY SMS request that goes through Notify that uses Twilio.

[#1034](https://github.com/department-of-veterans-affairs/notification-api/issues/1034)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
