### PR TITLE
#1061 Update the VA Profile integration lambda to accommodate new certificates

### DIFF
--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -125,6 +125,7 @@ elif NOTIFY_ENVIRONMENT != "test":
         # ssl_context = ssl.create_default_context(capath=CA_PATH)
         # TODO - This is a workaround.  The capath approach doesn't seem to load anything.
         ssl_context = ssl.create_default_context(cafile=f"{CA_PATH}VA-Internal-S2-ICA11.cer")
+        ssl_context.load_verify_locations(cafile=f"{CA_PATH}VA-Internal-S2-RCA2.cer")
 
         with NamedTemporaryFile() as f:
             f.write(acm_response["Certificate"].encode())

--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -414,6 +414,7 @@ def make_PUT_request(tx_audit_id: str, body: dict):
     except ssl.SSLCertVerificationError as e:
         logger.error("The PUT request to VA Profile failed with a SSLCertVerificationError.")
         logger.debug("Loaded CA certificates: %s", ssl_context.get_ca_certs())
+        logger.debug("CA directory contents: %s", os.listdir(CA_PATH))
         logger.exception(e)
     except Exception as e:
         # TODO - Make this more specific.  Is it a timeout?

--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -122,7 +122,7 @@ elif NOTIFY_ENVIRONMENT != "test":
         logger.debug(". . . Retrieved the ALB private key from SSM Parameter Store.")
 
         # Include all VA CA certificates in the default SSL environment.
-        ssl_context = ssl.create_default_context(capath=CAPATH)
+        ssl_context = ssl.create_default_context(capath=CA_PATH)
 
         with NamedTemporaryFile() as f:
             f.write(acm_response["Certificate"].encode())

--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -410,6 +410,7 @@ def make_PUT_request(tx_audit_id: str, body: dict):
             logger.debug(put_response)
     except ConnectionError as e:
         logger.error("The PUT request to VA Profile failed.")
+        logger.debug("Loaded CA certificates: %s", ssl_context.get_ca_certs())
         logger.exception(e)
     except Exception as e:
         # TODO - Make this more specific.  Is it a timeout?

--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -122,7 +122,9 @@ elif NOTIFY_ENVIRONMENT != "test":
         logger.debug(". . . Retrieved the ALB private key from SSM Parameter Store.")
 
         # Include all VA CA certificates in the default SSL environment.
-        ssl_context = ssl.create_default_context(capath=CA_PATH)
+        # ssl_context = ssl.create_default_context(capath=CA_PATH)
+        # TODO - This is a workaround.  The capath approach doesn't seem to load anything.
+        ssl_context = ssl.create_default_context(cafile=f"{CA_PATH}VA-Internal-S2-ICA11.cer")
 
         with NamedTemporaryFile() as f:
             f.write(acm_response["Certificate"].encode())

--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -429,7 +429,7 @@ def get_integration_testing_public_cert() -> Certificate:
     assert NOTIFY_ENVIRONMENT != "test"
 
     try:
-        with open("/opt/Notify_integration_testing_public.pem", "rb") as f:
+        with open("/opt/jwt/Notify_integration_testing_public.pem", "rb") as f:
             return load_pem_x509_certificate(f.read()).public_key()
     except Exception as e:
         logger.exception(e)

--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -409,7 +409,10 @@ def make_PUT_request(tx_audit_id: str, body: dict):
         if put_response.status != 200:
             logger.debug(put_response)
     except ConnectionError as e:
-        logger.error("The PUT request to VA Profile failed.")
+        logger.error("The PUT request to VA Profile failed with a ConnectionError.")
+        logger.exception(e)
+    except ssl.SSLCertVerificationError as e:
+        logger.error("The PUT request to VA Profile failed with a SSLCertVerificationError.")
         logger.debug("Loaded CA certificates: %s", ssl_context.get_ca_certs())
         logger.exception(e)
     except Exception as e:

--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -123,7 +123,7 @@ elif NOTIFY_ENVIRONMENT != "test":
 
         # Include all VA CA certificates in the default SSL environment.
         # ssl_context = ssl.create_default_context(capath=CA_PATH)
-        # TODO - This is a workaround.  The capath approach doesn't seem to load anything.
+        # TODO - This is a workaround.  The capath approach doesn't seem to load anything.  See issue #1063.
         ssl_context = ssl.create_default_context(cafile=f"{CA_PATH}VA-Internal-S2-ICA11.cer")
         ssl_context.load_verify_locations(cafile=f"{CA_PATH}VA-Internal-S2-RCA2.cer")
 


### PR DESCRIPTION
# Description

As previously implemented, the VA Profile integration lambda used the certificate chain associated with the Notify environment's load-balancer to verify the certificate for the VA Profile server to which Notify makes a PUT request.  This worked because Notify and Profile used certificates with the same CA signatures, but it broke when Notify updated their certificate.

These changes make use of a [new lambda layer](https://github.com/department-of-veterans-affairs/vanotify-infra/issues/497) that includes all publicly available VA CA certificates.  With this new layer, Notify should again be able to verify Profile's certificate.

The changes contain a workaround.  [Creating the SSL context](https://docs.python.org/3.8/library/ssl.html#ssl.create_default_context) using the "capath" parameter didn't seem to load anything, so I instead used "cafile" twice to load the CA certs we know Profile is actually using.

Deployed (lambda only): https://github.com/department-of-veterans-affairs/notification-api/actions/runs/3961560490

#1061

## Type of change

Please delete options that are not relevant.

- [x] Other (non-breaking change to restore functionality after certificate changes)

## How Has This Been Tested?

- [x] All unit tests pass
- [x] Manual testing in AWS Lambda console with verification in CloudWatch.  --> I observed a [200 response](https://us-gov-west-1.console.amazonaws-us-gov.com/cloudwatch/home?region=us-gov-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fproject-dev-va-profile-opt-in-out-lambda/log-events/2023$252F01$252F19$252F$255B$2524LATEST$255Db7c3089dad0b4b8ca7d590f804e88fa1) from VA Profile.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes