### PR TITLE
hotfix for latest twistlock merge - syntax fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: api build and push
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       environment:
         required: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: api build and push
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       environment:
         required: true
@@ -45,4 +45,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run -r master -F image-tag=${{ inputs.ref }}_${{ inputs.environment }} twistlock.yml
+          gh workflow run -r hotfix-twistlock-github-event -F image-tag=${{ inputs.ref }}_${{ inputs.environment }} twistlock.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,10 @@ jobs:
           file: ci/Dockerfile
           context: .
           push: true
-          tags: ${{ steps.login-ecr-vaec.outputs.registry }}/notification_api:${{ github.events.inputs.ref }}_${{ github.events.inputs.environment }}
+          tags: ${{ steps.login-ecr-vaec.outputs.registry }}/notification_api:${{ inputs.ref }}_${{ inputs.environment }}
 
       - name: Dispatch Twistlock Workflow
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run -r master -F image-tag=${{ github.events.inputs.ref }}_${{ github.events.inputs.environment }} twistlock.yml
+          gh workflow run -r master -F image-tag=${{ inputs.ref }}_${{ inputs.environment }} twistlock.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: api build and push
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       environment:
         required: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,4 +45,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run -r hotfix-twistlock-github-event -F image-tag=${{ inputs.ref }}_${{ inputs.environment }} twistlock.yml
+          gh workflow run -r master -F image-tag=${{ inputs.ref }}_${{ inputs.environment }} twistlock.yml

--- a/.github/workflows/twistlock.yml
+++ b/.github/workflows/twistlock.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.events.inputs.ref }}
+          ref: ${{ inputs.ref }}
 
       - name: Configure VAEC AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1.7.0
@@ -33,7 +33,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr-vaec.outputs.registry }}
           IMAGE_REPOSITORY: "notification_api"
-          IMAGE_TAG: "${{ github.events.inputs.image-tag }}"
+          IMAGE_TAG: "${{ inputs.image-tag }}"
         uses: ./.github/actions/run-commands-on-ec2
         with:
           instance-id-ssm-parameter-path: /utility/twistlock/instance


### PR DESCRIPTION
# Description
#1090 

hotfix for latest twistlock merge due to a confusion with a syntax change
Because build.yml uses
```
gh workflow run -r master -F image-tag=${{ inputs.ref }}_${{ inputs.environment }} twistlock.yml
```
this would cause a twistlock fail.  So, I ran twistlock manually and it's now running fine:

**Twistlock will fail because build.yml is calling twistlock from the master branch**
![image](https://user-images.githubusercontent.com/107153866/221219420-5d9f2bd1-ff37-4ecf-82af-0c1661926f22.png)

## Relevant Documentation

- In the [Github Actions Syntax documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions), none of the inputs use the github.event syntax, though previously this may have been the case. 
- In the [Events the Trigger Workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#providing-inputs) doc, it says to preserve boolean values means to exclude github.event from the syntax. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Successful deploy from branch

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
