### PR TITLE
#1134 Supply a timeout value with all requests calls

### DIFF
--- a/app/clients/performance_platform/performance_platform_client.py
+++ b/app/clients/performance_platform/performance_platform_client.py
@@ -1,9 +1,7 @@
 import base64
 import json
-
-from flask import current_app
 import requests
-
+from flask import current_app
 from notifications_utils.timezones import convert_utc_to_local_timezone
 
 
@@ -29,19 +27,19 @@ class PerformancePlatformClient:
             resp = requests.post(
                 self.performance_platform_url + payload['dataType'],
                 json=payload,
-                headers=headers
+                headers=headers,
+                timeout=(3.05, 1)
             )
 
             if resp.status_code == 200:
                 current_app.logger.info(
-                    "Updated performance platform successfully with payload {}".format(json.dumps(payload))
+                    "Updated performance platform successfully with payload %s", json.dumps(payload)
                 )
             else:
                 current_app.logger.error(
-                    "Performance platform update request failed for payload with response details: {} '{}'".format(
-                        json.dumps(payload),
-                        resp.status_code
-                    )
+                    "Performance platform update request failed for payload with response details: %s '%d'",
+                    json.dumps(payload),
+                    resp.status_code
                 )
                 resp.raise_for_status()
 

--- a/app/cronitor.py
+++ b/app/cronitor.py
@@ -1,6 +1,6 @@
 import requests
-from functools import wraps
 from flask import current_app
+from functools import wraps
 
 
 def cronitor(task_name):
@@ -13,7 +13,7 @@ def cronitor(task_name):
             task_slug = current_app.config['CRONITOR_KEYS'].get(task_name)
             if not task_slug:
                 current_app.logger.error(
-                    'Cronitor enabled but task_name {} not found in environment'.format(task_name)
+                    'Cronitor enabled but task_name %s not found in environment', task_name
                 )
                 return
 
@@ -26,14 +26,13 @@ def cronitor(task_name):
                     # cronitor limits msg to 1000 characters
                     params={
                         'host': current_app.config['API_HOST_NAME'],
-                    }
+                    },
+                    timeout=(3.05, 1)
                 )
                 resp.raise_for_status()
             except requests.RequestException as e:
-                current_app.logger.warning('Cronitor API failed for task {} due to {}'.format(
-                    task_name,
-                    repr(e)
-                ))
+                current_app.logger.warning('Cronitor API failed for task %s.', task_name)
+                current_app.logger.exception(e)
 
         @wraps(func)
         def inner_decorator(*args, **kwargs):

--- a/app/notifications/utils.py
+++ b/app/notifications/utils.py
@@ -1,5 +1,5 @@
-from flask import current_app
 import requests
+from flask import current_app
 
 
 def confirm_subscription(confirmation_request):
@@ -8,11 +8,11 @@ def confirm_subscription(confirmation_request):
         current_app.logger.warning("SubscribeURL does not exist or empty")
         return
 
-    response = requests.get(url)
     try:
+        response = requests.get(url, timeout=(3.05, 1))
         response.raise_for_status()
-    except Exception as e:
-        current_app.logger.warning("Response: {}".format(response.text))
+    except requests.RequestException as e:
+        current_app.logger.warning("Response: %s", response.text)
         raise e
 
     return confirmation_request['TopicArn']
@@ -20,6 +20,6 @@ def confirm_subscription(confirmation_request):
 
 def autoconfirm_subscription(req_json):
     if req_json.get('Type') == 'SubscriptionConfirmation':
-        current_app.logger.debug("SNS subscription confirmation url: {}".format(req_json['SubscribeURL']))
+        current_app.logger.debug("SNS subscription confirmation url: %s", req_json['SubscribeURL'])
         subscribed_topic = confirm_subscription(req_json)
         return subscribed_topic

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -8,7 +8,8 @@ from flask import (
     Blueprint,
     current_app,
     jsonify,
-    request)
+    request,
+)
 from flask_jwt_extended import current_user
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.pdf import extract_page_from_pdf
@@ -433,13 +434,15 @@ def _get_png_preview_or_overlaid_pdf(url, data, notification_id, json=True):
         resp = requests_post(
             url,
             json=data,
-            headers={'Authorization': 'Token {}'.format(current_app.config['TEMPLATE_PREVIEW_API_KEY'])}
+            headers={'Authorization': 'Token {}'.format(current_app.config['TEMPLATE_PREVIEW_API_KEY'])},
+            timeout=(3.05, 1)
         )
     else:
         resp = requests_post(
             url,
             data=data,
-            headers={'Authorization': 'Token {}'.format(current_app.config['TEMPLATE_PREVIEW_API_KEY'])}
+            headers={'Authorization': 'Token {}'.format(current_app.config['TEMPLATE_PREVIEW_API_KEY'])},
+            timeout=(3.05, 1)
         )
 
     if resp.status_code != 200:

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -5,8 +5,6 @@ from urllib.parse import urlencode
 import base64
 import pickle  # nosec
 import requests
-from requests.auth import HTTPBasicAuth
-
 from fido2 import cbor
 from fido2.client import ClientData
 from fido2.ctap2 import AuthenticatorData
@@ -450,7 +448,8 @@ def send_support_email(user_id):
     response = requests.post(
         "{}/api/v2/tickets".format(API_URL),
         json=ticket,
-        auth=HTTPBasicAuth(API_KEY, "x")
+        auth=requests.HTTPBasicAuth(API_KEY, "x"),
+        timeout=(3.05, 1)
     )
 
     if response.status_code != 201:

--- a/app/va/mpi/mpi.py
+++ b/app/va/mpi/mpi.py
@@ -7,7 +7,7 @@ from app.va.identifier import (
     transform_to_fhir_format,
     is_fhir_format,
     FHIR_FORMAT_SUFFIXES,
-    transform_from_fhir_format
+    transform_from_fhir_format,
 )
 from app.va.mpi import (
     MpiNonRetryableException,
@@ -16,8 +16,7 @@ from app.va.mpi import (
     NoSuchIdentifierException,
     IncorrectNumberOfIdentifiersException,
     MultipleActiveVaProfileIdsException,
-    BeneficiaryDeceasedException
-
+    BeneficiaryDeceasedException,
 )
 
 exception_code_mapping = {
@@ -75,13 +74,18 @@ class MpiClient:
         return va_profile_id
 
     def _make_request(self, fhir_identifier, notification_id):
-        self.logger.info(f"Querying MPI with {fhir_identifier} for notification {notification_id}")
+        self.logger.info(
+            "Querying MPI with %s for notification %s",
+            fhir_identifier,
+            notification_id
+        )
         start_time = monotonic()
         try:
             response = requests.get(
                 f"{self.base_url}/psim_webservice/fhir/Patient/{fhir_identifier}",
                 params={'-sender': self.SYSTEM_IDENTIFIER},
-                cert=(self.ssl_cert_path, self.ssl_key_path)
+                cert=(self.ssl_cert_path, self.ssl_key_path),
+                timeout=(3.05, 1)
             )
             response.raise_for_status()
         except requests.HTTPError as e:

--- a/app/va/va_onsite/va_onsite_client.py
+++ b/app/va/va_onsite/va_onsite_client.py
@@ -1,7 +1,7 @@
-import requests
-import jwt
-import time
 import json
+import jwt
+import requests
+import time
 
 
 class VAOnsiteClient:
@@ -29,12 +29,18 @@ class VAOnsiteClient:
         response = None
 
         try:
-            response = requests.post(url=f'{ self.url_base }/v0/onsite_notifications',
-                                     data=json.dumps(data),
-                                     headers=self._build_header())
+            response = requests.post(
+                url=f'{ self.url_base }/v0/onsite_notifications',
+                data=json.dumps(data),
+                headers=self._build_header(),
+                timeout=(3.05, 1)
+            )
 
-            self.logger.info("onsite_notifications POST response: status_code=%s, json=%s",
-                             response.status_code, response.json())
+            self.logger.info(
+                "onsite_notifications POST response: status_code=%d, json=%s",
+                response.status_code,
+                response.json()
+            )
 
         except Exception as e:
             self.logger.exception(e)

--- a/app/va/va_profile/va_profile_client.py
+++ b/app/va/va_profile/va_profile_client.py
@@ -1,16 +1,15 @@
-from enum import Enum
-
-import requests
 import iso8601
-from time import monotonic
-from http.client import responses
+import requests
 from app.va.va_profile import (
     NoContactInfoException,
     VAProfileNonRetryableException,
-    VAProfileRetryableException
+    VAProfileRetryableException,
 )
 from app.va.identifier import is_fhir_format, transform_from_fhir_format, transform_to_fhir_format, OIDS, IdentifierType
 from app.va.va_profile.exceptions import VAProfileIDNotFoundException
+from enum import Enum
+from http.client import responses
+from time import monotonic
 
 
 class CommunicationItemNotFoundException(Exception):
@@ -117,7 +116,7 @@ class VAProfileClient:
         self.logger.info(f"Querying VA Profile with ID {va_profile_id}")
 
         try:
-            response = requests.get(url, cert=(self.ssl_cert_path, self.ssl_key_path))
+            response = requests.get(url, cert=(self.ssl_cert_path, self.ssl_key_path), timeout=(3.05, 1))
             response.raise_for_status()
 
         except requests.HTTPError as e:

--- a/lambda_functions/user_flows/steps.py
+++ b/lambda_functions/user_flows/steps.py
@@ -44,7 +44,7 @@ def get_authenticated_request(url: str, jwt_token: str) -> Response:
         "Authorization": f"Bearer {jwt_token}",
     }
 
-    return requests.get(url, headers=headers)
+    return requests.get(url, headers=headers, timeout=(3.05, 1))
 
 
 def post_authenticated_request(url: str, jwt_token: str, payload: str = "{}") -> Response:
@@ -54,7 +54,7 @@ def post_authenticated_request(url: str, jwt_token: str, payload: str = "{}") ->
     }
 
     assert isinstance(payload, str), "Convert the payload to a string before calling this function."
-    return requests.post(url, headers=headers, data=payload)
+    return requests.post(url, headers=headers, data=payload, timeout=(3.05, 1))
 
 
 def revoke_service_api_keys(notification_url: str, admin_jwt_token: str, service_id: str) -> None:

--- a/lambda_functions/user_flows/test_retrieve_everything.py
+++ b/lambda_functions/user_flows/test_retrieve_everything.py
@@ -121,7 +121,7 @@ def service_test_api_key(notification_url, admin_jwt_token, service_id, user_id)
 
 
 def test_api_healthy(notification_url):
-    response = get(F"{notification_url}/_status")
+    response = get(F"{notification_url}/_status", timeout=(3.05, 1))
     assert response.status_code == 200
 
 

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -782,9 +782,12 @@ def test_sanitise_precompiled_pdf_passes_the_service_id_and_notification_id_to_t
     tp_mock.assert_called_once_with(
         'http://localhost:9999/precompiled/sanitise',
         data=b'old_pdf',
-        headers={'Authorization': 'Token my-secret-key',
-                 'Service-ID': service_id,
-                 'Notification-ID': notification_id}
+        headers={
+            'Authorization': 'Token my-secret-key',
+            'Service-ID': service_id,
+            'Notification-ID': notification_id
+        },
+        timeout=(3.05, 1)
     )
 
 

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -229,7 +229,11 @@ def test_ses_callback_should_log_if_notification_is_missing(client, notify_db, m
     with freeze_time('2017-11-17T12:34:03.646Z'):
         assert process_ses_receipts_tasks.process_ses_results(ses_notification_callback(reference='ref')) is None
         assert mock_retry.call_count == 0
-        mock_logger.assert_called_once_with('notification not found for reference: ref (update to delivered)')
+        mock_logger.assert_called_once_with(
+            'notification not found for reference: %s (update to %s)',
+            'ref',
+            'delivered'
+        )
 
 
 def test_ses_callback_should_not_retry_if_notification_is_old(client, notify_db, mocker):

--- a/tests/app/test_cronitor.py
+++ b/tests/app/test_cronitor.py
@@ -84,7 +84,7 @@ def test_cronitor_does_nothing_if_name_not_recognised(notify_api, rmock, caplog)
 
     error_log = caplog.records[0]
     assert error_log.levelname == 'ERROR'
-    assert error_log.msg == 'Cronitor enabled but task_name hello not found in environment'
+    assert error_log.getMessage() == 'Cronitor enabled but task_name hello not found in environment'
     assert not rmock.called
 
 


### PR DESCRIPTION
# Description

Supply a timeout value with all HTTP requests made using the Python "requests" package.  This should clear the associated code scan failures described in the ticket.  In some instances, I slightly modified the exception handling because a timeout raises an exception.  Note that requests.RequestException is the parent class of all exceptions raised in the requests package.

[timeout reference](https://requests.readthedocs.io/en/latest/user/advanced/?highlight=timeout)

I also cleaned up some of the logging, as we have been doing when we encounter it.

#1134

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] All unit tests pass
- [x] No code scan failures
- [x] [deployed](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/4494746906)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes