### PR TITLE
#1189 BUG: Standard pseudo-random generators are not suitable for security/cryptographic purposes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -430,9 +430,7 @@ def create_uuid():
 
 def create_random_identifier():
     # the random.choice is used for letter reference number; is not used in security context
-    return "".join(
-        random.choice(string.ascii_uppercase + string.digits) for _ in range(16)
-    )  # nosec
+    return "".join(random.choice(string.ascii_uppercase + string.digits) for _ in range(16))  # nosec
 
 
 def process_user_agent(user_agent_string):


### PR DESCRIPTION
# Description

This is just a quick fix to address bandit failing code scans with the error in the title. 

#1189

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Code scan now passes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
