### PR TITLE
Adjusted Payload Sent in Callbacks to Services' Endpoints

### DIFF
--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -42,7 +42,7 @@ def send_delivery_status_to_service(
     }
 
     if "status_reason" in status_update:
-        payload['status_reason'] = status_update
+        payload['status_reason'] = status_update['status_reason']
 
     if 'provider' in status_update:
         payload['provider'] = status_update['provider']

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -58,20 +58,22 @@ def send_delivery_status_to_service(
     except RetryableException as e:
         try:
             current_app.logger.warning(
-                f"Retrying: {self.name} failed for {logging_tags}, url {service_callback.url}. "
-                f"exc: {e}"
+                "Retrying: %s failed for %s, url %s.", self.name, logging_tags, service_callback.url
             )
+            current_app.logger.exception(e)
             self.retry(queue=QueueNames.RETRY)
         except self.MaxRetriesExceededError:
             current_app.logger.error(
-                f"Retry: {self.name} has retried the max num of times for {logging_tags}, url "
-                f"{service_callback.url}. exc: {e}")
+                "Retry: %s has retried the max num of times for %s, url %s.",
+                self.name, logging_tags, service_callback.url
+            )
+            current_app.logger.exception(e)
             raise e
     except NonRetryableException as e:
         current_app.logger.error(
-            f"Not retrying: {self.name} failed for {logging_tags}, url: {service_callback.url}. "
-            f"exc: {e}"
+            "Not retrying: %s failed for %s, url: %s. ", self.name, logging_tags, service_callback.url
         )
+        current_app.logger.exception(e)
         raise e
 
 

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -41,11 +41,8 @@ def send_delivery_status_to_service(
         "notification_type": status_update['notification_type'],
     }
 
-    if "status_reason" in status_update:
-        payload['status_reason'] = status_update['status_reason']
-
-    if 'provider' in status_update:
-        payload['provider'] = status_update['provider']
+    payload['status_reason'] = status_update.get('status_reason')
+    payload['provider'] = status_update.get('provider', 'pinpoint')
 
     # if the provider payload is found in the status_update object
     if 'provider_payload' in status_update:

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -78,7 +78,9 @@ def test_send_delivery_status_to_service_post_https_request_to_service_with_encr
         "created_at": datestr.strftime(DATETIME_FORMAT),
         "completed_at": datestr.strftime(DATETIME_FORMAT),
         "sent_at": datestr.strftime(DATETIME_FORMAT),
-        "notification_type": notification_type
+        "notification_type": notification_type,
+        "status_reason": None,
+        "provider": "pinpoint"
     }
 
     assert request_mock.call_count == 1


### PR DESCRIPTION
# Description
Status reason was coming through as the entire status_update object because it was missing a lookup on the dictionary. Additionally, `status_reason` and `provider` were supposed to be permanently added to the callbacks but there was logic to only add them if they existed. Changed the logic to set the `status_reason` to None if it's not set and to set `provider` to `pintpoint` if it's not set.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Code [pushed to Dev](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/4578628254). Verified fields are there. 
![image](https://user-images.githubusercontent.com/16893311/229219742-5cfcdfc0-479c-4015-ac89-f4bce8027d84.png)

And no hiccups with our existing pinpoint stuff:
![image](https://user-images.githubusercontent.com/16893311/229220402-1de0feaa-ecbe-4145-bbb2-f81bc3d31cd8.png)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
