### PR TITLE
#1209 decoded provider payload from twilio

### DIFF
--- a/app/clients/sms/twilio.py
+++ b/app/clients/sms/twilio.py
@@ -214,7 +214,7 @@ class TwilioSMSClient(SmsClient):
             ]
 
         translation = {
-            "payload": twilio_delivery_status_message,
+            "payload": decoded_msg,
             "reference": parsed_dict["MessageSid"][0],
             "record_status": notify_delivery_status,
         }

--- a/tests/app/clients/test_twilio.py
+++ b/tests/app/clients/test_twilio.py
@@ -317,7 +317,7 @@ def test_error_code_mapping(event, twilio_sms_client_mock):
     assert "reference" in translation
     assert "record_status" in translation
     assert translation["record_status"] == event["twilio_status"]
-    
+
 
 @pytest.mark.parametrize(
     "event",

--- a/tests/app/clients/test_twilio.py
+++ b/tests/app/clients/test_twilio.py
@@ -1,3 +1,5 @@
+
+import base64
 import pytest
 import requests_mock
 from app import twilio_sms_client
@@ -315,6 +317,20 @@ def test_error_code_mapping(event, twilio_sms_client_mock):
     assert "reference" in translation
     assert "record_status" in translation
     assert translation["record_status"] == event["twilio_status"]
+    
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        MESSAAGE_BODY_WITH_ACCEPTED_STATUS,
+        MESSAAGE_BODY_WITH_FAILED_STATUS_AND_ERROR_CODE_30010
+    ],
+)
+def test_returned_payload_is_decoded(event, twilio_sms_client_mock):
+    translation = twilio_sms_client_mock.translate_delivery_status(event["message"])
+
+    assert "payload" in translation
+    assert translation["payload"] == base64.b64decode(event["message"]).decode()
 
 
 def test_exception_on_empty_twilio_status_message(twilio_sms_client_mock):


### PR DESCRIPTION
# Description
The message passed into the translate_delivery_status method is an b64 encoded string.  It's b64 encoded in the lambda that enqueues the message on the SQS that feeds the ECS Delivery status task.  The callback that gets made needs to send the same message that is sent from Twilio.  That message is a URL encoded string that is encoded in the b64 message.  

This change passes the decoded message back as the payload for the service callback.  


#1209 

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Deployed to dev and tested to confirm that callback is now a URL encoded string.

Added a unit test that verifies the returned message is the decoded URL encoded string.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
