### PR TITLE
#1222 Update requirements.txt to use a newer version of notification-utils

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -266,7 +266,7 @@ fileignoreconfig:
     - filename: tests/app/notifications/test_validators.py
       checksum: efce5afc3015a7bdcae7e027da762acf1fefe782b30a5a92855b253cad6c3050
     - filename: requirements.txt
-      checksum: 4cd08981422546219b07315d07ac44e2f94aeb939772afc4c8e09b533196c183
+      checksum: 267c1396636dd30d55f9440e1a55446216355fcfa1e7b865754fc91c4cd422b2
     - filename: app/va/va_profile/va_profile_client.py
       checksum: 2942cb80f53433d4c129c2fbd43ba7b28f252d2daf30ad2c93bf8255d3d1e179
     - filename: ci/.docker-env.example

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ mistune==0.8.4
 monotonic==1.6
 multidict==6.0.4
 nanoid==2.0.0
-notification-utils @ git+https://github.com/department-of-veterans-affairs/notification-utils.git@637889997d0d584cc4e8b792abe9d51f4bac1c1b
+notification-utils @ git+https://github.com/department-of-veterans-affairs/notification-utils.git@aff06f864c0881563582960380ff08ac19a625dc
 notifications-python-client==8.0.0
 opentelemetry-api==1.17.0
 orderedset==2.0.3


### PR DESCRIPTION
# Description

Update requirements.txt to use a newer version of notification-utils that contains a [hotfix for logging errors](https://github.com/department-of-veterans-affairs/notification-utils/commit/e5d5a30479b20041503eaa901eec5fce102944cb).  This relates to, but does not close, #1222.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This is just a dependency upgrade to use a 2-line change in notification-utils that catches all exceptions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes