### PR TITLE
#1198 Upgrade the app image to use Alpine 3.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ This application defines Docker images for production, testing, and development 
 | Technology | End of Support | Notes | Affected Files in ci/ |
 |------------|----------------|-------|-----------------------|
 | Python 3.8 | 14 October 2024 | | Dockerfile, Dockerfile.local |
-| Alpine Linux 3.15 | 1 November 2023 | | Dockerfile, Dockerfile.local |
+| Alpine Linux 3.17 | 22 November 2024 | | Dockerfile, Dockerfile.local |
 | Postgres 11 | [9 November 2023](https://www.postgresql.org/support/versioning/) | | docker-compose.yml, docker-compose-local.yml, docker-compose-local-migrate.yml, docker-compose-test.yml |
 | localstack | None given.  The YAML files specifies v0.12.3.  As of March 2022, v0.14.1 is available. | As of March 2022, localstack requires Python 3.6-3.9. | docker-compose-local.yml |
 | bbyars/mountebank 2.4.0 | None given. | Newer versions are available. | docker-compose-local.yml |

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,6 +1,6 @@
 # Python 3.8 is supported until 14 October 2024.
-# Alpine Linux 3.15 is supported until 1 November 2023.
-FROM python:3.8-alpine3.15
+# Alpine Linux 3.17 is supported until 22 November 2024.
+FROM python:3.8-alpine3.17
 
 ARG GIT_SHA
 

--- a/ci/Dockerfile.local
+++ b/ci/Dockerfile.local
@@ -1,6 +1,6 @@
 # Python 3.8 is supported until 14 October 2024.
-# Alpine Linux 3.15 is supported until 1 November 2023.
-FROM python:3.8-alpine3.15
+# Alpine Linux 3.17 is supported until 22 November 2024.
+FROM python:3.8-alpine3.17
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     # https://flask.palletsprojects.com/en/2.2.x/config/?highlight=flask_debug#DEBUG


### PR DESCRIPTION
# Description

I upgrade the version of Alpine Linux used in our app images from v3.15 to v3.17 and updated existing documentation with the new "end of life" date.

#1198

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] [deployed](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/4919803215)
- [x] Run locally without issue
- [x] All unit tests pass
- [x] Regression suite passes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes