### PR TITLE
#1261 urllib Added to Requiements Files

### DIFF
--- a/lambda_functions/nightly_billing_bigquery_upload/requirements-lambda.txt
+++ b/lambda_functions/nightly_billing_bigquery_upload/requirements-lambda.txt
@@ -1,2 +1,3 @@
 # https://github.com/googleapis/python-bigquery/blob/main/CHANGELOG.md
 google-cloud-bigquery==3.10.0
+urllib3==1.26.15

--- a/lambda_functions/nightly_stats_bigquery_upload/requirements-lambda.txt
+++ b/lambda_functions/nightly_stats_bigquery_upload/requirements-lambda.txt
@@ -1,2 +1,3 @@
 # https://github.com/googleapis/python-bigquery/blob/main/CHANGELOG.md
 google-cloud-bigquery==3.10.0
+urllib3==1.26.15


### PR DESCRIPTION
# Description
The issue is that the lambda was updated with the latest urllib (2.x) but that breaks other modules. Using urllib 1.26.15 to ensure it does not use 2.x.

#1261 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
