### PR TITLE
#1217 Change a logging call from "warning" to "critical"

### DIFF
--- a/app/celery/process_delivery_status_result_tasks.py
+++ b/app/celery/process_delivery_status_result_tasks.py
@@ -138,7 +138,7 @@ def attempt_to_get_notification(
                 "Delivery Status callback event for reference %s was received less than five minutes ago.", reference)
             should_retry = True
         else:
-            current_app.logger.warning(
+            current_app.logger.critical(
                 "notification not found for reference: %s (update to %s)", reference, notification_status)
         statsd_client.incr("callback.delivery_status.no_notification_found")
         should_exit = True


### PR DESCRIPTION
# Description

When a status update callback cannot find the associated notification in the database for 5 minutes, log this condition as "critical" rather than "warning".

#1217 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have not tested this other than running unit tests.  It's just a log level change.  We will make sure the level is "critical" during the QA check.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes