### PR TITLE
#1270 lambda packaging for nightly stats and VA Profile integration

### DIFF
--- a/.github/workflows/lambda-functions.yml
+++ b/.github/workflows/lambda-functions.yml
@@ -80,6 +80,7 @@ jobs:
           zip -j two_way_sms_lambda two_way_sms/two_way_sms_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-two-way-sms-lambda --zip-file fileb://two_way_sms_lambda.zip
 
+        # This function uses lambda layers for dependencies.
       - name: Package and deploy Two Way SMS lambda function v2
         if: ${{ (inputs.lambdaName == 'TwoWaySMS') || (inputs.lambdaName == 'All') }}
         run: |
@@ -98,7 +99,7 @@ jobs:
           zip -j pinpoint_inbound_sms_lambda pinpoint_inbound_sms/pinpoint_inbound_sms_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-pinpoint-inbound-sms-lambda --zip-file fileb://pinpoint_inbound_sms_lambda.zip
 
-        # This function does not need to package psycopg2-binary, which is included as a lambda layer.  The AWS Lambda execution environment should include boto3 by default.
+        # This function uses lambda layers for dependencies.
       - name: Package and deploy VA Profile opt-in/out lambda function
         if: ${{ (inputs.lambdaName == 'ProfileOptInOut') || (inputs.lambdaName == 'All') }}
         run: |
@@ -114,41 +115,28 @@ jobs:
           zip -ugj va_profile_opt_in_out_lambda va_profile_opt_in_out_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-va-profile-opt-in-out-lambda --zip-file fileb://va_profile_opt_in_out_lambda.zip
 
-        # This function does not need to package psycopg2-binary, which is included as a lambda layer.  The AWS Lambda execution environment should include boto3 by default.
+        # This function uses lambda layers for dependencies.
       - name: Package and deploy VA Profile remove old opt-outs lambda function
         if: ${{ (inputs.lambdaName == 'ProfileRemoveOldOptOuts') || (inputs.lambdaName == 'All') }}
         run: |
           zip -j va_profile_remove_old_opt_outs_lambda va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-va-profile-remove-old-opt-outs-lambda --zip-file fileb://va_profile_remove_old_opt_outs_lambda.zip
 
+        # This function uses lambda layers for dependencies.
       - name: Package and deploy nightly stats bigquery upload lambda function
         if: ${{ (inputs.lambdaName == 'NightBigQueryUpload') || (inputs.lambdaName == 'All') }}
         run: |
-          cd nightly_stats_bigquery_upload/
-          python3 -m venv venv_nightly_stats_bigquery_upload
-          source venv_nightly_stats_bigquery_upload/bin/activate
-          pip install -r requirements-lambda.txt
-          deactivate
-          cd venv_nightly_stats_bigquery_upload/lib/python3.8/site-packages
-          zip -r9 ../../../../nightly_stats_bigquery_upload_lambda.zip .
-          cd ../../../../
-          zip -ugj nightly_stats_bigquery_upload_lambda nightly_stats_bigquery_upload_lambda.py
+          zip -j nightly_stats_bigquery_upload_lambda nightly_stats_bigquery_upload/nightly_stats_bigquery_upload_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-nightly-stats-bigquery-upload-lambda --zip-file fileb://nightly_stats_bigquery_upload_lambda.zip
 
+        # This function uses lambda layers for dependencies.
       - name: Package and deploy nightly billing stats upload lambda function
         if: ${{ (inputs.lambdaName == 'NightBillingBQUpload') || (inputs.lambdaName == 'All') }}
         run: |
-          cd nightly_billing_bigquery_upload/
-          python3 -m venv venv_nightly_billing_bigquery_upload
-          source venv_nightly_billing_bigquery_upload/bin/activate
-          pip install -r requirements-lambda.txt
-          deactivate
-          cd venv_nightly_billing_bigquery_upload/lib/python3.8/site-packages
-          zip -r9 ../../../../nightly_billing_stats_upload_lambda.zip .
-          cd ../../../../
-          zip -ugj nightly_billing_stats_upload_lambda nightly_billing_stats_upload_lambda.py
+          zip -j nightly_billing_stats_upload_lambda nightly_billing_bigquery_upload/nightly_billing_stats_upload_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-nightly-billing-stats-upload-lambda --zip-file fileb://nightly_billing_stats_upload_lambda.zip
 
+        # This function uses lambda layers for dependencies.
       - name: Package and deploy vetext incoming forwarder lambda
         if: ${{ (inputs.lambdaName == 'VetTextIncomingForwarder') || (inputs.lambdaName == 'All') }}
         run: |

--- a/.github/workflows/lambda-functions.yml
+++ b/.github/workflows/lambda-functions.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           python-version: "3.8"
 
+        # TODO notification-api#1286 - Use lambda layers for user-flows dependencies.
       - name: Package and deploy user-flows lambda function
         if: ${{ (inputs.lambdaName == 'UserFlows') || (inputs.lambdaName == 'All') }}
         run: |
@@ -68,12 +69,14 @@ jobs:
           zip -ugj user_flows_lambda.zip conftest.py steps.py test_retrieve_everything.py user_flows_lambda.py
           aws lambda update-function-code --function-name project-user-flows-lambda --zip-file fileb://user_flows_lambda.zip
 
+        # This function does not have any dependencies.
       - name: Package and deploy SES Callback lambda function
         if: ${{ (inputs.lambdaName == 'SESCallback') || (inputs.lambdaName == 'All') }}
         run: |
           zip -j ses_callback_lambda ses_callback/ses_callback_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-ses-callback-lambda --zip-file fileb://ses_callback_lambda.zip
 
+        # This function uses lambda layers for dependencies.
       - name: Package and deploy Two Way SMS lambda function v1
         if: ${{ (inputs.lambdaName == 'TwoWaySMS') || (inputs.lambdaName == 'All') }}
         run: |
@@ -87,12 +90,14 @@ jobs:
           zip -j two_way_sms two_way_sms/two_way_sms_v2.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-notify-incoming-sms-lambda --zip-file fileb://two_way_sms.zip
 
+        # This function does not have any dependencies.
       - name: Package and deploy pinpoint callback lambda function
         if: ${{ (inputs.lambdaName == 'PinPointCallback') || (inputs.lambdaName == 'All') }}
         run: |
           zip -j pinpoint_callback_lambda pinpoint_callback/pinpoint_callback_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-pinpoint-callback-lambda --zip-file fileb://pinpoint_callback_lambda.zip
 
+        # This function does not have any dependencies.
       - name: Package and deploy pinpoint inbound sms lambda function
         if: ${{ (inputs.lambdaName == 'PinPointInboundSMS') || (inputs.lambdaName == 'All') }}
         run: |
@@ -143,6 +148,7 @@ jobs:
           zip -j vetext_incoming_forwarder_lambda vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-vetext-incoming-forwarder-lambda --zip-file fileb://vetext_incoming_forwarder_lambda.zip
 
+        # This function does not have any dependencies.
       - name: Package and deploy delivery status processing lambda
         if: ${{ (inputs.lambdaName == 'DeliveryStatusProcessor') || (inputs.lambdaName == 'All') }}
         run: |

--- a/.github/workflows/lambda-functions.yml
+++ b/.github/workflows/lambda-functions.yml
@@ -98,13 +98,15 @@ jobs:
           zip -j pinpoint_inbound_sms_lambda pinpoint_inbound_sms/pinpoint_inbound_sms_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-pinpoint-inbound-sms-lambda --zip-file fileb://pinpoint_inbound_sms_lambda.zip
 
+        # This function does not need to package psycopg2-binary, which is included as a lambda layer.  The AWS Lambda execution environment should include boto3 by default.
       - name: Package and deploy VA Profile opt-in/out lambda function
         if: ${{ (inputs.lambdaName == 'ProfileOptInOut') || (inputs.lambdaName == 'All') }}
         run: |
           cd va_profile/
           python3 -m venv venv_va_profile_opt_in_out
           source venv_va_profile_opt_in_out/bin/activate
-          pip install -r requirements-lambda.txt
+          pip install PyJWT~=2.6.0
+          pip install cryptography~=37.0.4
           deactivate
           cd venv_va_profile_opt_in_out/lib/python3.8/site-packages
           zip -r9 ../../../../va_profile_opt_in_out_lambda.zip .
@@ -112,18 +114,11 @@ jobs:
           zip -ugj va_profile_opt_in_out_lambda va_profile_opt_in_out_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-va-profile-opt-in-out-lambda --zip-file fileb://va_profile_opt_in_out_lambda.zip
 
+        # This function does not need to package psycopg2-binary, which is included as a lambda layer.  The AWS Lambda execution environment should include boto3 by default.
       - name: Package and deploy VA Profile remove old opt-outs lambda function
         if: ${{ (inputs.lambdaName == 'ProfileRemoveOldOptOuts') || (inputs.lambdaName == 'All') }}
         run: |
-          cd va_profile_remove_old_opt_outs/
-          python3 -m venv venv_va_profile_remove_old_opt_outs
-          source venv_va_profile_remove_old_opt_outs/bin/activate
-          pip install -r requirements-lambda.txt
-          deactivate
-          cd venv_va_profile_remove_old_opt_outs/lib/python3.8/site-packages
-          zip -r9 ../../../../va_profile_remove_old_opt_outs_lambda.zip .
-          cd ../../../../
-          zip -ugj va_profile_remove_old_opt_outs_lambda va_profile_remove_old_opt_outs_lambda.py
+          zip -j va_profile_remove_old_opt_outs_lambda va_profile_remove_old_opt_outs/va_profile_remove_old_opt_outs_lambda.py
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-va-profile-remove-old-opt-outs-lambda --zip-file fileb://va_profile_remove_old_opt_outs_lambda.zip
 
       - name: Package and deploy nightly stats bigquery upload lambda function

--- a/lambda_functions/nightly_billing_bigquery_upload/requirements-lambda.txt
+++ b/lambda_functions/nightly_billing_bigquery_upload/requirements-lambda.txt
@@ -1,4 +1,2 @@
 # https://github.com/googleapis/python-bigquery/blob/main/CHANGELOG.md
 google-cloud-bigquery==3.10.0
-# urllib3 v2.0 only supports OpenSSL 1.1.1+, lambdas are compiled with ssl v1.0.x currently - ImportError
-urllib3==1.26.15

--- a/lambda_functions/nightly_stats_bigquery_upload/requirements-lambda.txt
+++ b/lambda_functions/nightly_stats_bigquery_upload/requirements-lambda.txt
@@ -1,4 +1,2 @@
 # https://github.com/googleapis/python-bigquery/blob/main/CHANGELOG.md
 google-cloud-bigquery==3.10.0
-# urllib3 v2.0 only supports OpenSSL 1.1.1+, lambdas are compiled with ssl v1.0.x currently - ImportError
-urllib3==1.26.15


### PR DESCRIPTION
# Description

These changes alter some lambda function packaging to rely on lambda layers for dependencies.  The affected lambda functions are the two for nightly stats generation and the two for VA Profile integration.  The stats-related layer was created by [vanotify-infra 568](https://github.com/department-of-veterans-affairs/vanotify-infra/issues/568).

The changes for VA Profile integration are a reintroduction of changes made in [c576a0e](https://github.com/department-of-veterans-affairs/notification-api/commit/c576a0e3eaa4e64b0be340d75fb5fc6827450001) that were inadvertently reverted by [caf6d6f](https://github.com/department-of-veterans-affairs/notification-api/commit/caf6d6f104ab65c0aa17197b314888290484010e#diff-701410510466de561d2b481763cd324e1cba4ff947f85447ff6a6ba55086bfeb).

The only top level dependency for the stats lambdas is `google-cloud-bigquery==3.10.0`.  The urllib subdependency was pinned to work around an upstream problem that seems to have been resolved with a downgrade.  The "bigquery" lambda layer actually contains `urllib3==1.26.15`.

#1270

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] [Deployed](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/5006139973)
- [x] The lambda source code shows up in lambda console for the 3 affected lambda functions that do not include any Python dependencies in their zip (If the zip contains more than the lambda code, Lambda console will say there is too much to display.)
- [x] Continued nightly stats generation verified

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes