### PR TITLE
#1251 Graceful Shutdown For Celery Tasks

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -7,17 +7,17 @@ from flask import current_app
 
 @worker_process_init.connect
 def pool_worker_started(*args, **kwargs):
-    current_app.logger.info(f'Pool worker started')
+    current_app.logger.info('Pool worker started')
 
 
 @worker_process_shutdown.connect
 def pool_worker_process_shutdown(pid, exitcode, *args, **kwargs):
-    current_app.logger.info(f'Pool worker shutdown: {pid=}, {exitcode=}')
+    current_app.logger.info('Pool worker shutdown: pid = %s, exitcode = %s', pid, exitcode)
 
 
 @worker_shutting_down.connect
 def main_proc_graceful_stop(signal, how, exitcode, *args, **kwargs):
-    current_app.logger.info(f'Main process worker graceful stop: {signal=}, {how=}, {exitcode=}')
+    current_app.logger.info('Main process worker graceful stop: signal = %s, how = %s, exitcode = %s', signal, how, exitcode)
 
 
 def make_task(app):

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -10,8 +10,8 @@ def worker_process_shutdown(sender, signal, pid, exitcode, **kwargs):
     current_app.logger.info('worker shutdown: PID: {} Exitcode: {}'.format(pid, exitcode))
 
 @worker_shutting_down.connect
-def worker_graceful_stop(sender, signal, pid, exitcode, **kwargs):
-    current_app.logger.info(f'worker graceful stop: {sender=}, {signal=}, {pid=}, {exitcode=}')
+def worker_graceful_stop(signal, how, exitcode, **kwargs):
+    current_app.logger.info(f'worker graceful stop: {signal=}, {how=}, {exitcode=}')
 
 def make_task(app):
     class NotifyTask(Task):

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -6,7 +6,7 @@ from flask import current_app
 
 
 @worker_process_shutdown.connect
-def worker_process_shutdown(sender, signal, pid, exitcode, **kwargs):
+def worker_process_shutdown(pid, exitcode, **kwargs):
     current_app.logger.info('worker shutdown: PID: {} Exitcode: {}'.format(pid, exitcode))
 
 @worker_shutting_down.connect

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -6,12 +6,12 @@ from flask import current_app
 
 
 @worker_process_shutdown.connect
-def worker_process_shutdown(pid, exitcode, **kwargs):
-    current_app.logger.info('worker shutdown: PID: {} Exitcode: {}'.format(pid, exitcode))
+def pool_worker_process_shutdown(pid, exitcode, **kwargs):
+    current_app.logger.info(f'Pool worker shutdown: {pid=}, {exitcode=}')
 
 @worker_shutting_down.connect
-def worker_graceful_stop(signal, how, exitcode, **kwargs):
-    current_app.logger.info(f'worker graceful stop: {signal=}, {how=}, {exitcode=}')
+def main_proc_graceful_stop(signal, how, exitcode, **kwargs):
+    current_app.logger.info(f'Main process worker graceful stop: {signal=}, {how=}, {exitcode=}')
 
 def make_task(app):
     class NotifyTask(Task):

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -1,7 +1,7 @@
 import time
 
 from celery import Celery, Task
-from celery.signals import worker_process_shutdown
+from celery.signals import worker_process_shutdown, worker_shutting_down
 from flask import current_app
 
 
@@ -9,6 +9,9 @@ from flask import current_app
 def worker_process_shutdown(sender, signal, pid, exitcode, **kwargs):
     current_app.logger.info('worker shutdown: PID: {} Exitcode: {}'.format(pid, exitcode))
 
+@worker_shutting_down.connect
+def worker_graceful_stop(sender, signal, pid, exitcode, **kwargs):
+    current_app.logger.info(f'worker graceful stop: {sender=}, {signal=}, {pid=}, {exitcode=}')
 
 def make_task(app):
     class NotifyTask(Task):

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -17,7 +17,7 @@ def pool_worker_process_shutdown(pid, exitcode, *args, **kwargs):
 
 @worker_shutting_down.connect
 def main_proc_graceful_stop(signal, how, exitcode, *args, **kwargs):
-    current_app.logger.info('Main process worker graceful stop: signal = %s, how = %s, exitcode = %s', 
+    current_app.logger.info('Main process worker graceful stop: signal = %s, how = %s, exitcode = %s',
                             signal, how, exitcode)
 
 

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -6,17 +6,17 @@ from flask import current_app
 
 
 @worker_process_init.connect
-def pool_worker_started():
+def pool_worker_started(*args, **kwargs):
     current_app.logger.info(f'Pool worker started')
 
 
 @worker_process_shutdown.connect
-def pool_worker_process_shutdown(pid, exitcode, **kwargs):
+def pool_worker_process_shutdown(pid, exitcode, *args, **kwargs):
     current_app.logger.info(f'Pool worker shutdown: {pid=}, {exitcode=}')
 
 
 @worker_shutting_down.connect
-def main_proc_graceful_stop(signal, how, exitcode, **kwargs):
+def main_proc_graceful_stop(signal, how, exitcode, *args, **kwargs):
     current_app.logger.info(f'Main process worker graceful stop: {signal=}, {how=}, {exitcode=}')
 
 

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -17,7 +17,8 @@ def pool_worker_process_shutdown(pid, exitcode, *args, **kwargs):
 
 @worker_shutting_down.connect
 def main_proc_graceful_stop(signal, how, exitcode, *args, **kwargs):
-    current_app.logger.info('Main process worker graceful stop: signal = %s, how = %s, exitcode = %s', signal, how, exitcode)
+    current_app.logger.info('Main process worker graceful stop: signal = %s, how = %s, exitcode = %s', 
+                            signal, how, exitcode)
 
 
 def make_task(app):

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -1,17 +1,24 @@
 import time
 
 from celery import Celery, Task
-from celery.signals import worker_process_shutdown, worker_shutting_down
+from celery.signals import worker_process_shutdown, worker_shutting_down, worker_process_init
 from flask import current_app
+
+
+@worker_process_init.connect
+def pool_worker_started():
+    current_app.logger.info(f'Pool worker started')
 
 
 @worker_process_shutdown.connect
 def pool_worker_process_shutdown(pid, exitcode, **kwargs):
     current_app.logger.info(f'Pool worker shutdown: {pid=}, {exitcode=}')
 
+
 @worker_shutting_down.connect
 def main_proc_graceful_stop(signal, how, exitcode, **kwargs):
     current_app.logger.info(f'Main process worker graceful stop: {signal=}, {how=}, {exitcode=}')
+
 
 def make_task(app):
     class NotifyTask(Task):

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-exec celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=10
+exec celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=4

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -2,4 +2,5 @@
 
 set -e
 
+# Necessary to run as exec so the PID is transferred to Celery for the `SIGTERM` sent from ECS
 exec celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=4

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-exec celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=4
+exec celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=10

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=4
+exec celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=4


### PR DESCRIPTION
# Description

This is a simple fix to make the celery worker kick off under the `exec` command. This ensures that the PID is transferred to the celery worker, so the `SIGTERM` signal is actually received. It was tested and observed that the `SIGTERM` does not pass through celery without calling with `exec`.

This does not fix the connection timeout but should prevent the task from terminating before completion.

#1251 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This was [deployed](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/5007818954) to dev. It was observed that the hooks were being called, as shown in our logs (documented in #1251). Forced redeploy showed that the workers were receiving `SIGTERM` as expected. Prior to this change the hooks were not being called. 

17:16:50 the service was force redeployed
17:18:32 the `SIGTERM` was processed
17:18:32 the workers were shut down because they had no tasks running

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
