### PR TITLE
#1284 Use Alpine Linux v3.16 for the Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ This application defines Docker images for production, testing, and development 
 | Technology | End of Support | Notes | Affected Files in ci/ |
 |------------|----------------|-------|-----------------------|
 | Python 3.8 | 14 October 2024 | | Dockerfile, Dockerfile.local |
-| Alpine Linux 3.17 | 22 November 2024 | | Dockerfile, Dockerfile.local |
+| Alpine Linux 3.16 | 23 May 2024 | | Dockerfile, Dockerfile.local |
 | Postgres 11 | [9 November 2023](https://www.postgresql.org/support/versioning/) | | docker-compose.yml, docker-compose-local.yml, docker-compose-local-migrate.yml, docker-compose-test.yml |
 | localstack | None given.  The YAML files specifies v0.12.3.  As of March 2022, v0.14.1 is available. | As of March 2022, localstack requires Python 3.6-3.9. | docker-compose-local.yml |
 | bbyars/mountebank 2.4.0 | None given. | Newer versions are available. | docker-compose-local.yml |

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,5 +1,8 @@
 # Python 3.8 is supported until 14 October 2024.
-# Alpine Linux 3.16 is supported until 23 May 2024.
+# Alpine Linux 3.16 is supported until 23 May 2024 and packages OpenSSL v1.1.1.  Newer versions of Alpine package
+# OpenSSL v3.x, which will not work with notification-api until the Python "requests" package is upgrade to
+# >=2.30.0 and "urllib3" to >=2.0.0.  As of 18 May 2023, the notification-api top level dependency "botocore"
+# does not support urllib3>=2.0.0.
 FROM python:3.8-alpine3.16
 
 ARG GIT_SHA

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,6 +1,6 @@
 # Python 3.8 is supported until 14 October 2024.
-# Alpine Linux 3.17 is supported until 22 November 2024.
-FROM python:3.8-alpine3.17
+# Alpine Linux 3.16 is supported until 23 May 2024.
+FROM python:3.8-alpine3.16
 
 ARG GIT_SHA
 

--- a/ci/Dockerfile.local
+++ b/ci/Dockerfile.local
@@ -1,6 +1,6 @@
 # Python 3.8 is supported until 14 October 2024.
-# Alpine Linux 3.17 is supported until 22 November 2024.
-FROM python:3.8-alpine3.17
+# Alpine Linux 3.16 is supported until 23 May 2024.
+FROM python:3.8-alpine3.16
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     # https://flask.palletsprojects.com/en/2.2.x/config/?highlight=flask_debug#DEBUG

--- a/ci/Dockerfile.local
+++ b/ci/Dockerfile.local
@@ -1,5 +1,8 @@
 # Python 3.8 is supported until 14 October 2024.
-# Alpine Linux 3.16 is supported until 23 May 2024.
+# Alpine Linux 3.16 is supported until 23 May 2024 and packages OpenSSL v1.1.1.  Newer versions of Alpine package
+# OpenSSL v3.x, which will not work with notification-api until the Python "requests" package is upgrade to
+# >=2.30.0 and "urllib3" to >=2.0.0.  As of 18 May 2023, the notification-api top level dependency "botocore"
+# does not support urllib3>=2.0.0.
 FROM python:3.8-alpine3.16
 
 ENV PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
# Description

Alpine v3.16 uses OpenSSL v1.1.1, whereas Alpine v3.17 uses OpenSSL v3.0.8.  The newer OpenSSL version causes problems with our Twilio integration until we can upgrade the "requests" and "urllib3" Python packages. #1284

#1284 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

@cris-oddball Deployed this branch to Perf and tested.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes