### PR TITLE
#1252 Add the default_send_indicator column to the CommunicationItem table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2179,8 +2179,9 @@ class CommunicationItem(db.Model):
     __tablename__ = "communication_items"
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    va_profile_item_id = db.Column(db.Integer, nullable=False)
+    default_send_indicator = db.Column(db.Boolean, nullable=False, default=True)
     name = db.Column(db.Text(), nullable=False)
+    va_profile_item_id = db.Column(db.Integer, nullable=False)
 
 
 class VAProfileLocalCache(db.Model):

--- a/migrations/versions/0358_default_send_field.py
+++ b/migrations/versions/0358_default_send_field.py
@@ -1,0 +1,19 @@
+"""
+Revision ID: 0358_default_send_field
+Revises: 0357_promoted_templates_table
+Create Date: 2023-05-19 18:21:53.942613
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0358_default_send_field"
+down_revision = "0357_promoted_templates_table"
+
+
+def upgrade():
+    op.add_column("communication_items", sa.Column("default_send_indicator", sa.Boolean(), nullable=False, server_default=sa.true()))
+
+
+def downgrade():
+    op.drop_column("communication_items", "default_send_indicator")

--- a/tests/app/communication_item/test_rest.py
+++ b/tests/app/communication_item/test_rest.py
@@ -21,6 +21,4 @@ def test_get_communication_items(mocker, admin_request, sample_email_template):
         assert isinstance(communication_item["name"], str) and communication_item["name"]
         assert isinstance(communication_item["va_profile_item_id"], int)
         assert isinstance(communication_item["id"], str)
-
-        # If this raises ValueError (or any other exception), the ID is not a valid UUID.
-        _ = UUID(communication_item["id"])
+        assert isinstance(UUID(communication_item["id"], UUID), communication_item["id"]

--- a/tests/app/communication_item/test_rest.py
+++ b/tests/app/communication_item/test_rest.py
@@ -1,23 +1,26 @@
-from app.models import CommunicationItem
+from uuid import UUID
 
 
-class TestGetCommunicationItems:
+def test_get_communication_items(mocker, admin_request, sample_email_template):
+    """
+    The fixture "sample_email_template" has the side-effect of creating and
+    persisting a CommunicationItem instance that uses the default value for
+    default_send_indicator, which is True.
+    """
 
-    def test_get_communication_items(self, mocker, admin_request):
-        communication_item = CommunicationItem(name='some name', va_profile_item_id=1)
+    response = admin_request.get(
+        'communication_item.get_communication_items'
+    )
 
-        mock_get_communication_items = mocker.Mock(return_value=[communication_item])
-        mock_communication_item_dao = mocker.Mock(get_communication_items=mock_get_communication_items)
-        mocker.patch('app.communication_item.rest.communication_item_dao', new=mock_communication_item_dao)
+    assert isinstance(response["data"], list)
 
-        response = admin_request.get(
-            'communication_item.get_communication_items'
-        )
+    for communication_item in response["data"]:
+        assert isinstance(communication_item, dict)
+        assert isinstance(communication_item["default_send_indicator"], bool) and \
+            communication_item["default_send_indicator"], "Should be True by default."
+        assert isinstance(communication_item["name"], str) and communication_item["name"]
+        assert isinstance(communication_item["va_profile_item_id"], int)
+        assert isinstance(communication_item["id"], str)
 
-        assert response['data'] == [
-            {
-                'id': communication_item.id,
-                'name': 'some name',
-                'va_profile_item_id': 1
-            }
-        ]
+        # If this raises ValueError (or any other exception), the ID is not a valid UUID.
+        _ = UUID(communication_item["id"])

--- a/tests/app/communication_item/test_rest.py
+++ b/tests/app/communication_item/test_rest.py
@@ -21,4 +21,9 @@ def test_get_communication_items(mocker, admin_request, sample_email_template):
         assert isinstance(communication_item["name"], str) and communication_item["name"]
         assert isinstance(communication_item["va_profile_item_id"], int)
         assert isinstance(communication_item["id"], str)
-        assert isinstance(UUID(communication_item["id"], UUID), communication_item["id"]
+
+        try:
+            assert isinstance(UUID(communication_item["id"]), UUID)
+        except ValueError as e:
+            print(communication_item["id"], "is not a valid uuid4.")
+            raise

--- a/tests/app/communication_item/test_rest.py
+++ b/tests/app/communication_item/test_rest.py
@@ -1,3 +1,4 @@
+import logging
 from uuid import UUID
 
 
@@ -25,5 +26,5 @@ def test_get_communication_items(mocker, admin_request, sample_email_template):
         try:
             assert isinstance(UUID(communication_item["id"]), UUID)
         except ValueError as e:
-            print(communication_item["id"], "is not a valid uuid4.")
+            logging.exception(e)
             raise


### PR DESCRIPTION
# Description

These changes add the boolean column `default_send_indicator` to CommunicationItem table with a default value of True and modify an existing unit test.

#1252

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Run app locally, and inspect the database container's CommunicationItems table
- [x] [Deploy](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/5048542541) the branch Dev, and inspect the Dev database's CommunicationItems table

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes