### PR TITLE
1277 Implement Celery Serverhooks

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -1,14 +1,7 @@
 import time
 
 from celery import Celery, Task
-from celery.signals import (
-    worker_process_shutdown,
-    worker_shutting_down,
-    worker_process_init,
-    task_received,
-    task_success,
-    task_failure
-)
+from celery.signals import worker_process_shutdown, worker_shutting_down, worker_process_init
 from flask import current_app
 
 

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -28,13 +28,13 @@ def make_task(app):
 
         def on_success(self, retval, task_id, args, kwargs):
             elapsed_time = time.time() - self.start
-            app.logger.info("celery task success: %s took %.4f", self.name, elapsed_time)
+            app.logger.info("celery task success: %s took %.4f seconds", self.name, elapsed_time)
 
         def on_failure(self, exc, task_id, args, kwargs, einfo):
             elapsed_time = time.time() - self.start
 
             # ensure task will log exceptions to correct handlers
-            app.logger.exception("celery task failure: %s took %.4f", self.name, elapsed_time)
+            app.logger.exception("celery task failure: %s took %.4f seconds", self.name, elapsed_time)
             super().on_failure(exc, task_id, args, kwargs, einfo)
 
         def __call__(self, *args, **kwargs):

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -1,7 +1,14 @@
 import time
 
 from celery import Celery, Task
-from celery.signals import worker_process_shutdown, worker_shutting_down, worker_process_init
+from celery.signals import (
+    worker_process_shutdown,
+    worker_shutting_down,
+    worker_process_init,
+    task_received,
+    task_success,
+    task_failure
+)
 from flask import current_app
 
 
@@ -19,6 +26,27 @@ def pool_worker_process_shutdown(pid, exitcode, *args, **kwargs):
 def main_proc_graceful_stop(signal, how, exitcode, *args, **kwargs):
     current_app.logger.info('Main process worker graceful stop: signal = %s, how = %s, exitcode = %s',
                             signal, how, exitcode)
+
+
+@task_received.connect()
+def celery_task_received(**kwargs):
+    print('celery_task_received check kwargs:')
+    print(kwargs)
+    current_app.logger.info('logger celery_task_received')
+
+
+@task_success.connect()
+def celery_task_succeded(**kwargs):
+    print('celery_task_succeded check kwargs:')
+    print(kwargs)
+    current_app.logger.info('logger celery_task_succeded')
+
+
+@task_failure.connect()
+def celery_task_failed(**kwargs):
+    print('celery_task_failed check kwargs:')
+    print(kwargs)
+    current_app.logger.info('logger celery_task_failed')
 
 
 def make_task(app):

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -28,27 +28,6 @@ def main_proc_graceful_stop(signal, how, exitcode, *args, **kwargs):
                             signal, how, exitcode)
 
 
-@task_received.connect()
-def celery_task_received(**kwargs):
-    print('celery_task_received check kwargs:')
-    print(kwargs)
-    current_app.logger.info('logger celery_task_received')
-
-
-@task_success.connect()
-def celery_task_succeded(**kwargs):
-    print('celery_task_succeded check kwargs:')
-    print(kwargs)
-    current_app.logger.info('logger celery_task_succeded')
-
-
-@task_failure.connect()
-def celery_task_failed(**kwargs):
-    print('celery_task_failed check kwargs:')
-    print(kwargs)
-    current_app.logger.info('logger celery_task_failed')
-
-
 def make_task(app):
     class NotifyTask(Task):
         abstract = True
@@ -56,15 +35,13 @@ def make_task(app):
 
         def on_success(self, retval, task_id, args, kwargs):
             elapsed_time = time.time() - self.start
-            app.logger.info(
-                "{task_name} took {time}".format(
-                    task_name=self.name, time="{0:.4f}".format(elapsed_time)
-                )
-            )
+            app.logger.info("celery task success: %s took %.4f", self.name, elapsed_time)
 
         def on_failure(self, exc, task_id, args, kwargs, einfo):
+            elapsed_time = time.time() - self.start
+
             # ensure task will log exceptions to correct handlers
-            app.logger.exception('Celery task: {} failed'.format(self.name))
+            app.logger.exception("celery task failure: %s took %.4f", self.name, elapsed_time)
             super().on_failure(exc, task_id, args, kwargs, einfo)
 
         def __call__(self, *args, **kwargs):


### PR DESCRIPTION
# Description

The scope of this ticket was updated to just standardize the format of the celery messages for success and failure. 

#1277

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This is tested by sending a message or doing something that will trigger a celery task to run. We can then check the cloudwatch logs for the messages that start will "celery task success" and "celery task failure" to check how long they ran.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
