### PR TITLE
#737 Update Setuptools

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -31,6 +31,7 @@ COPY --chown=vanotify requirements.txt .
 RUN apk add --no-cache --virtual .build-deps gcc musl-dev rust cargo \
   && python -m pip install --upgrade pip \
   && python -m pip install wheel \
+  && pip install --upgrade setuptools==65.5.1 \
   && pip install --no-cache-dir -r requirements.txt \
   # Remove build dependencies.
   && apk del --no-cache .build-deps

--- a/ci/Dockerfile.local
+++ b/ci/Dockerfile.local
@@ -19,6 +19,7 @@ RUN apk add --no-cache bash build-base postgresql-dev libffi-dev libmagic libcur
   # Install Python dependencies.
   && python -m pip install --upgrade pip \
   && python -m pip install wheel \
+  &&  pip install --upgrade setuptools==65.5.1 \
   && pip install --no-cache-dir -r requirements-app.txt \
   # Remove build dependencies.
   && rm requirements-app.txt \

--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -7,6 +7,7 @@ COPY requirements_for_test.txt .
 RUN apk add --no-cache --virtual .build-deps gcc musl-dev rust cargo \
   && python -m pip install --upgrade pip \
   && python -m pip install wheel \
+  && pip install --upgrade setuptools==65.5.1 \
   && pip install --no-cache-dir -r requirements_for_test.txt \
   && apk del .build-deps
 


### PR DESCRIPTION
* upgrade setuptools to 65.5.1

# Description

We want to update setuptools to 65.5.1
 
[#737](https://app.zenhub.com/workspaces/va-notify-620d21369d810a00146ed9c8/issues/gh/department-of-veterans-affairs/vanotify-team/737)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] All Local Test Cases pass
- [x] Twistlock does not find any vulnerabilities

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
