### PR TITLE
#1227 Explicit Logic for Communication Items

### DIFF
--- a/app/celery/lookup_recipient_communication_permissions_task.py
+++ b/app/celery/lookup_recipient_communication_permissions_task.py
@@ -98,5 +98,5 @@ def recipient_has_given_permission(
     # sqlalchemy.orm.exc.MultipleResultsFound
     except Exception as e:
         current_app.logger.exception('There was an unexpected exception when attempting to check '
-                                     'recipient_has_given_permission see exception:\n%s', e)
+                                     'recipient_has_given_permission see exception: %s', e)
         raise e

--- a/app/celery/lookup_recipient_communication_permissions_task.py
+++ b/app/celery/lookup_recipient_communication_permissions_task.py
@@ -84,13 +84,6 @@ def recipient_has_given_permission(
         is_allowed = va_profile_client.get_is_communication_allowed(
             identifier, communication_item.va_profile_item_id, notification_id, notification_type
         )
-
-        current_app.logger.info('Value of permission for item %s for recipient %s for notification %s: %s',
-                                communication_item.va_profile_item_id if communication_item else None,
-                                id_value, notification_id, is_allowed)
-
-        # return status reason message if message should not be sent
-        return None if is_allowed else "Contact preferences set to false"
     except VAProfileRetryableException as e:
         current_app.logger.exception(e)
         try:
@@ -110,5 +103,8 @@ def recipient_has_given_permission(
         current_app.logger.info('Communication item for recipient %s not found on notification %s',
                                 id_value, notification_id)
 
-        # return status reason message if message should not be sent
-        return None if default_send_flag else "No recipient opt-in found for explicit preference"
+    current_app.logger.info('Value of permission for item %s for recipient %s for notification %s: %s',
+                            communication_item.va_profile_item_id, id_value, notification_id, is_allowed)
+
+    # return status reason message if message should not be sent
+    return None if default_send_flag else "No recipient opt-in found for explicit preference"

--- a/app/celery/lookup_recipient_communication_permissions_task.py
+++ b/app/celery/lookup_recipient_communication_permissions_task.py
@@ -103,8 +103,11 @@ def recipient_has_given_permission(
         current_app.logger.info('Communication item for recipient %s not found on notification %s',
                                 id_value, notification_id)
 
+        # return status reason message if message should not be sent
+        return None if default_send_flag else "No recipient opt-in found for explicit preference"
+
     current_app.logger.info('Value of permission for item %s for recipient %s for notification %s: %s',
                             communication_item.va_profile_item_id, id_value, notification_id, is_allowed)
 
     # return status reason message if message should not be sent
-    return None if default_send_flag else "No recipient opt-in found for explicit preference"
+    return None if is_allowed else "Contact preferences set to false"

--- a/app/dao/communication_item_dao.py
+++ b/app/dao/communication_item_dao.py
@@ -15,4 +15,4 @@ def get_communication_items() -> List[CommunicationItem]:
 
 
 def get_communication_item(communication_item_id) -> CommunicationItem:
-    return CommunicationItem.query.filter_by(id=communication_item_id).one()
+    return CommunicationItem.query.filter_by(id=communication_item_id).one_or_none()

--- a/app/dao/communication_item_dao.py
+++ b/app/dao/communication_item_dao.py
@@ -15,4 +15,4 @@ def get_communication_items() -> List[CommunicationItem]:
 
 
 def get_communication_item(communication_item_id) -> CommunicationItem:
-    return CommunicationItem.query.filter_by(id=communication_item_id).one_or_none()
+    return CommunicationItem.query.filter_by(id=communication_item_id).one()

--- a/app/va/va_profile/va_profile_client.py
+++ b/app/va/va_profile/va_profile_client.py
@@ -157,9 +157,9 @@ class VAProfileClient:
                 raise exception from e
 
         except requests.RequestException as e:
-            self.statsd_client.incr(f"clients.va-profile.error.request_exception")
+            self.statsd_client.incr("clients.va-profile.error.request_exception")
 
-            failure_message = f'VA Profile returned RequestException while querying for VA Profile ID'
+            failure_message = 'VA Profile returned RequestException while querying for VA Profile ID'
 
             exception = VAProfileRetryableException(failure_message)
             exception.failure_reason = failure_message

--- a/tests/app/celery/test_lookup_recipient_communication_permissions_task.py
+++ b/tests/app/celery/test_lookup_recipient_communication_permissions_task.py
@@ -100,7 +100,7 @@ def test_lookup_recipient_communication_permissions_updates_notification_status_
     )
 
 
-def test_recipient_has_given_permission_should_return_false_if_user_denies_permissions(
+def test_recipient_has_given_permission_should_return_status_message_if_user_denies_permissions(
         client, mocker, mock_communication_item
 ):
     mocked_va_profile_client = mocker.Mock(VAProfileClient)
@@ -117,7 +117,7 @@ def test_recipient_has_given_permission_should_return_false_if_user_denies_permi
     assert permission_message == "Contact preferences set to false"
 
 
-def test_recipient_has_given_permission_should_return_true_if_user_grants_permissions(
+def test_recipient_has_given_permission_should_return_none_if_user_grants_permissions(
         client, mocker, mock_communication_item
 ):
     mocked_va_profile_client = mocker.Mock(VAProfileClient)
@@ -134,7 +134,7 @@ def test_recipient_has_given_permission_should_return_true_if_user_grants_permis
     assert permission_message is None
 
 
-def test_recipient_has_given_permission_should_return_true_if_user_permissions_not_set_and_no_com_item(
+def test_recipient_has_given_permission_should_return_none_if_user_permissions_not_set_and_no_com_item(
         client, mocker, fake_uuid
 ):
     mocked_va_profile_client = mocker.Mock(VAProfileClient)
@@ -174,12 +174,12 @@ def test_recipient_has_given_permission_with_default_send_indicator_and_no_prefe
         new=mocked_va_profile_client
     )
 
-    mock_communication_item = mocker.Mock(CommunicationItem)
-    mock_communication_item.default_send_indicator = send_indicator
+    test_communication_item = CommunicationItem
+    test_communication_item.default_send_indicator = send_indicator
 
     mocker.patch(
         'app.celery.lookup_recipient_communication_permissions_task.get_communication_item',
-        return_value=mock_communication_item
+        return_value=test_communication_item
     )
 
     mock_task = mocker.Mock()

--- a/tests/app/celery/test_lookup_recipient_communication_permissions_task.py
+++ b/tests/app/celery/test_lookup_recipient_communication_permissions_task.py
@@ -174,8 +174,12 @@ def test_recipient_has_given_permission_with_default_send_indicator_and_no_prefe
         new=mocked_va_profile_client
     )
 
-    test_communication_item = CommunicationItem
-    test_communication_item.default_send_indicator = send_indicator
+    test_communication_item = CommunicationItem(
+        id=uuid.uuid4(),
+        va_profile_item_id=1,
+        name="name",
+        default_send_indicator=send_indicator
+    )
 
     mocker.patch(
         'app.celery.lookup_recipient_communication_permissions_task.get_communication_item',


### PR DESCRIPTION
# Description

This PR is to add logic that will change when notifications are sent depending on the "default send" preference set in the communication item attached to the template. 

#1227

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Deployed to dev and notifications sent with below parameters.
User’s VA Profile ID 43627 has no selection for any communication items
- [x] TC01 EMAIL: template “Email Default Send True”; expect a successful send and CommunicationItemNotFoundException is seen in logs.
- [x] TC02 EMAIL: template “Email Default Send False”; expect an unsuccessful send, the status is set to "preference-declined" with status "No recipient opt-in found for explicit preference", and CommunicationItemNotFoundException is seen in logs.
- [x] TC03 SMS: template “SMS Default Send True”; expect a successful send and CommunicationItemNotFoundException is seen in logs.
- [x] TC04 SMS: template “SMS Default Send False”; expect an unsuccessful send, the status is set to "preference-declined" with status "No recipient opt-in found for explicit preference", and CommunicationItemNotFoundException is seen in logs.
- [x] TC13 EMAIL: template "Email with custom reply-to"; expect a successful send and CommunicationItemNotFoundException is seen in logs.

User’s VA Profile 112491 has the above communication items set to “allowed”: “true”
- [x] TC05 EMAIL: template “Email Default Send True”; expect a successful send.
- [x] TC06 EMAIL: template “Email Default Send False”; expect a successful send.
- [x] TC07 SMS: template “SMS Default Send True”; expect a successful send.
- [x] TC08 SMS: template “SMS Default Send False”; expect a successful send.

User’s VA Profile 37459 has the has the above communication items set to “allowed”: “false”
- [x] TC09 EMAIL: template “Email Default Send True”; expect an unsuccessful send, with status preference-declined.
- [x] TC11 EMAIL: template “Email Default Send False”; expect an unsuccessful send, with status preference-declined.
- [x] TC10 SMS: template “SMS Default Send True”; expect an unsuccessful send, with status preference-declined.
- [x] TC12 SMS: template “SMS Default Send False”; expect an unsuccessful send, with status preference-declined.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
