### PR TITLE
#1253 Added routes and unit tests for CommunicationItem

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -331,3 +331,5 @@ fileignoreconfig:
       checksum: ae4a406af9f5ccd0c8b7d2439076327fb131760d29043f8488a22f6eff26a27e
     - filename: certs/DigiCert-Global-G2-TLS-RSA-SHA256-2020-CA1.cer
       checksum: 120ea4457eac8216580853c44751a329b74cc29fafc9064105ee73d9a9c2bdc8
+    - filename: migrations/versions/0359_communication_items_unique.py
+      checksum: 1c963f08a88caf7de46e27f89fdc7af37b38a61bb62b10498bfca26bc29d792e

--- a/.talismanrc
+++ b/.talismanrc
@@ -3,10 +3,6 @@ fileignoreconfig:
       checksum: 92acfa31554b7ea857d6e901b6c10a3833d96f63b3b96e17e13c7a33b4aab6b7
     - filename: .github/workflows/deployment-tw.yaml
       checksum: c1078dacbed33c89a46462d290465902e267f9fb6f44218654406a4072a0a37b
-    - filename: scripts/postman/development.postman_environment.json
-      checksum: 8c45546e8fdf3bd3e2185e1f37c1a6eda6bec75b78f10913e4408641ffbd9e2c
-    - filename: scripts/postman/staging.postman_environment.json
-      checksum: 61421aaa6298a36f7f8a65a573b216be3b23e68655958ee1a4da24ebc30782f8
     - filename: certs/VA-Internal-S2-RCA1-v1.crt
       checksum: b3cdaa6e2a9961ba935379fc4d21dcdd70478b027b9efadbd20a4ae9faaf13a0
     - filename: certs/VA-Internal-S2-RCA2.cer
@@ -21,8 +17,6 @@ fileignoreconfig:
       checksum: cdd8fc418af65b72fa3c770bd949aea93960432dbf423e91bd347d9dbfda4c55
     - filename: ci/docker-compose-local.yml
       checksum: bfa2ed19d0b33d303b96e29cb925c2b0dccd5efcdaa988b6c5ddc163ae812d1a
-    - filename: scripts/postman/notification-api.postman_collection.json
-      checksum: 32ab98203b010a45ced5b99588795ed1f542bb350c2a90fb8eee4c4bd2b11535
     - filename: README.md
       checksum: 32935f617721f8cf06be7cd4f36d35cc303ba19dd6b6e025bf0660f628e4a55a
     - filename: ci/docker-compose-local.yml
@@ -69,12 +63,6 @@ fileignoreconfig:
       checksum: b39ef7a0044d1e2ab82f622133b06eb62ac69caf4d0462e0bd8b7ebf61be6c28
     - filename: lambda_functions/two_way_sms/two_way_sms_lambda.py
       checksum: 7197ce16e4fab1bcfac696a586650ad98635796734c727040471662c32623550
-    - filename: scripts/postman/development.postman_environment.json
-      checksum: 9b843c8a5f3b8e46b9bd1579eced2f20101cf02fe57d1b00cfcb3124b7638e19
-    - filename: scripts/postman/staging.postman_environment.json
-      checksum: a6516139f1f50cc6be42e3b46aae3a8fa92ca91e3ff684eabc1b1e5df4a17372
-    - filename: scripts/postman/development.postman_environment.json
-      checksum: e8241f0b65159a875f285f288be114bf0933c5e44c4cafaf3e1ea08c9683e5ca
     - filename: cd/application-deployment/perf/vaec-celery-beat-task-definition.json
       checksum: fcf1951af4ebff100eaaac98a756f4871afa9a2196cc7d43036302eaa11478eb
     - filename: cd/application-deployment/perf/vaec-api-task-definition.json
@@ -235,24 +223,14 @@ fileignoreconfig:
       checksum: 469f814f2ba74fab665e05ac7a9a3da235a991e0403e8c62d4c692a42ac9cff0
     - filename: app/template/rest.py
       checksum: 4f300f5136873066acede094b788ccca6707c05f14c22979adb64ea2e60569eb
-    - filename: scripts/postman/development.postman_environment.json
-      checksum: a1debc4234ef557d8dc130fb366b542b195c4344e309172485ea4e74c6627507
-    - filename: scripts/postman/performance.postman_environment.json
-      checksum: 58ff1624306779c58e8fa9fbc4320f3a27f84b380cbbd9dffb3381448ed8d1b6
-    - filename: scripts/postman/staging.postman_environment.json
-      checksum: d17fbba8b74445cc2cbc6e1e73bd0888d235aa010d13614a7138f40dbe299333
     - filename: scripts/postman/notification-api.postman_collection.json
-      checksum: 2d814aacc0f4025c92ccc7aa512d4db7d2136d038fc01c1b294c657ab5293c7a
-    - filename: scripts/postman/development.postman_environment.json
-      checksum: 430f84dec469ac7dba882cb836815a6bbdb4234615afccac37169345b56d42c8
-    - filename: scripts/postman/performance.postman_environment.json
-      checksum: 7d8ed1eb0bb17c7f72f30bdfce8150c20d75f3d570d4df65f45ed4ed307c5201
-    - filename: scripts/postman/staging.postman_environment.json
-      checksum: eee906c2ae08f8ea152af26d655364785493d0d3a743f684dd06649793dc43df
+      checksum: b92b55a7835796a97a71be623282911b3e4fb65dfe2e9eb831625a5d236a2800
     - filename: scripts/postman/development.postman_environment.json
       checksum: 750e0712ccb3fe0e07f9ba73dbe83998ec71d70b88d852100cc27ca8e6fcd58e
     - filename: scripts/postman/performance.postman_environment.json
       checksum: da23e04452219ad6a3c968fa851702068c7cb5873aa8765370817c035503d080
+    - filename: scripts/postman/staging.postman_environment.json
+      checksum: eee906c2ae08f8ea152af26d655364785493d0d3a743f684dd06649793dc43df
     - filename: app/models.py
       checksum: 633be5f925209c984dcd89d6b6267986b0f30f385a22d1afb56de74a18ac2970
     - filename: app/models.py

--- a/app/communication_item/communication_item_schemas.py
+++ b/app/communication_item/communication_item_schemas.py
@@ -3,10 +3,13 @@ communication_item_base_schema = {
     "type": "object",
     "properties": {
         "default_send_indicator": {"type": "boolean"},
-        "name": {"type": "string"},
+        "name": {
+            "type": "string",
+            "minLength": 1
+        },
         "va_profile_item_id": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 1
         }
     },
     "additionalProperties": False

--- a/app/communication_item/communication_item_schemas.py
+++ b/app/communication_item/communication_item_schemas.py
@@ -1,0 +1,21 @@
+communication_item_base_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "default_send_indicator": {"type": "boolean"},
+        "name": {"type": "string"},
+        "va_profile_item_id": {
+            "type": "integer",
+            "minimum": 0
+        }
+    },
+    "additionalProperties": False
+}
+
+
+communication_item_post_schema = communication_item_base_schema.copy()
+communication_item_post_schema["required"] = ["name", "va_profile_item_id"]
+
+
+communication_item_patch_schema = communication_item_base_schema.copy()
+communication_item_patch_schema["minProperties"] = 1

--- a/app/communication_item/rest.py
+++ b/app/communication_item/rest.py
@@ -1,19 +1,158 @@
-from flask import Blueprint, jsonify
+""" Implement CRUD endpoints for the CommunicationItem model. """
 
-from app.dao import communication_item_dao
-from app.errors import register_errors
-from app.schemas import communication_item_schema
-
-communication_item_blueprint = Blueprint(
-    'communication_item',
-    __name__,
-    url_prefix='/communication-item'
+import psycopg2
+from app import db
+from app.communication_item.communication_item_schemas import (
+    communication_item_patch_schema,
+    communication_item_post_schema,
 )
+from app.errors import register_errors
+from app.models import CommunicationItem
+from app.schemas import communication_item_schema
+from flask import Blueprint, current_app, jsonify, request
+from jsonschema import validate, ValidationError
+from sqlalchemy.exc import SQLAlchemyError
 
+communication_item_blueprint = Blueprint("communication_item", __name__, url_prefix="/communication-item")
 register_errors(communication_item_blueprint)
 
 
-@communication_item_blueprint.route('', methods=['GET'])
-def get_communication_items():
-    communication_items = communication_item_dao.get_communication_items()
+#############
+# Create
+#############
+
+@communication_item_blueprint.route('', methods=["POST"])
+def create_communication_item():
+    request_data = request.get_json()
+
+    try:
+        validate(request_data, communication_item_post_schema)
+    except ValidationError as e:
+        return {
+            "errors": [
+                {
+                    "error": "ValidationError",
+                    "message": e.message,
+                }
+            ]
+        }, 400
+
+    communication_item = CommunicationItem(**request_data)
+    db.session.add(communication_item)
+
+    try:
+        db.session.commit()
+    except SQLAlchemyError as e:
+        return {
+            "errors": [
+                {
+                    "error": e.__class__.__name__,
+                    "message": str(e.orig).split('\n')[0],
+                }
+            ]
+        }, 400
+    except psycopg2.Error as e:
+        return {
+            "errors": [
+                {
+                    "error": e.__class__.__name__,
+                    "message": e.pgerror,
+                }
+            ]
+        }, 400
+    except Exception as e:
+        current_app.logger.exception(e)
+        raise
+
+    return communication_item_schema.dump(communication_item).data, 201
+
+
+#############
+# Retrieve
+#############
+
+@communication_item_blueprint.route('', methods=["GET"])
+def get_all_communication_items():
+    communication_items = CommunicationItem.query.all()
     return jsonify(data=communication_item_schema.dump(communication_items, many=True).data)
+
+
+@communication_item_blueprint.route("/<communication_item_id>", methods=["GET"])
+def get_communication_item(communication_item_id):
+    communication_item = CommunicationItem.query.get(communication_item_id)
+    return communication_item_schema.dump(communication_item).data, 404 if (communication_item is None) else 200
+
+
+#############
+# Update
+#############
+
+@communication_item_blueprint.route("/<communication_item_id>", methods=["PATCH"])
+def partially_update_communication_item(communication_item_id):
+    request_data = request.get_json()
+
+    try:
+        validate(request_data, communication_item_patch_schema)
+    except ValidationError as e:
+        return {
+            "errors": [
+                {
+                    "error": "ValidationError",
+                    "message": e.message,
+                }
+            ]
+        }, 400
+
+    communication_item = CommunicationItem.query.get(communication_item_id)
+    assert communication_item is not None, \
+        "The framework should have returned 404 instead of calling this route handler."
+    db.session.add(communication_item)
+
+    for key, value in request.get_json().items():
+        setattr(communication_item, key, value)
+
+    try:
+        db.session.commit()
+    except SQLAlchemyError as e:
+        return {
+            "errors": [
+                {
+                    "error": e.__class__.__name__,
+                    "message": str(e.orig).split('\n')[0],
+                }
+            ]
+        }, 400
+    except psycopg2.Error as e:
+        return {
+            "errors": [
+                {
+                    "error": e.__class__.__name__,
+                    "message": e.pgerror,
+                }
+            ]
+        }, 400
+    except Exception as e:
+        current_app.logger.exception(e)
+        raise
+
+    return communication_item_schema.dump(communication_item).data, 200
+
+
+#############
+# Delete
+#############
+
+@communication_item_blueprint.route("/<communication_item_id>", methods=["DELETE"])
+def delete_communication_item(communication_item_id):
+    rows_deleted = CommunicationItem.query.filter_by(id=communication_item_id).delete()
+    db.session.commit()
+
+    if rows_deleted:
+        return {}, 202
+
+    current_app.logger.warning(
+        f"Failed to delete CommunicationItem {communication_item_id} and returned status code 200."
+        "  The framework should have returned 404 instead of calling the route handler."
+    )
+
+    return {}, 200

--- a/app/communication_item/rest.py
+++ b/app/communication_item/rest.py
@@ -86,7 +86,7 @@ def get_communication_item(communication_item_id):
             "errors": [
                 {
                     "error": "NotFound",
-                    "message": f"Communication item {communication_item_id} does not exist.",
+                    "message": "That communication item does not exist.",
                 }
             ]
         }, 404
@@ -121,7 +121,7 @@ def partially_update_communication_item(communication_item_id):
             "errors": [
                 {
                     "error": "NotFound",
-                    "message": f"Communication item {communication_item_id} does not exist.",
+                    "message": "That communication item does not exist.",
                 }
             ]
         }, 404
@@ -174,7 +174,7 @@ def delete_communication_item(communication_item_id):
         "errors": [
             {
                 "error": "NotFound",
-                "message": f"Communication item {communication_item_id} does not exist.",
+                "message": "That communication item does not exist.",
             }
         ]
     }, 404

--- a/app/communication_item/rest.py
+++ b/app/communication_item/rest.py
@@ -174,7 +174,7 @@ def delete_communication_item(communication_item_id):
         "errors": [
             {
                 "error": "NotFound",
-                "message": f"Communication item {communication_item_id} was not deleted.",
+                "message": f"Communication item {communication_item_id} does not exist.",
             }
         ]
     }, 404

--- a/app/models.py
+++ b/app/models.py
@@ -2180,8 +2180,8 @@ class CommunicationItem(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     default_send_indicator = db.Column(db.Boolean, nullable=False, default=True)
-    name = db.Column(db.Text(), nullable=False)
-    va_profile_item_id = db.Column(db.Integer, nullable=False)
+    name = db.Column(db.Text(), nullable=False, unique=True)
+    va_profile_item_id = db.Column(db.Integer, nullable=False, unique=True)
 
 
 class VAProfileLocalCache(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -2180,8 +2180,7 @@ class CommunicationItem(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     default_send_indicator = db.Column(db.Boolean, nullable=False, default=True)
-    name = db.Column(db.Text(), nullable=False, unique=True)
-    # name = db.Column(db.String(255), nullable=False, unique=True)
+    name = db.Column(db.String(255), nullable=False, unique=True)
     va_profile_item_id = db.Column(db.Integer, nullable=False, unique=True)
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -2181,6 +2181,7 @@ class CommunicationItem(db.Model):
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     default_send_indicator = db.Column(db.Boolean, nullable=False, default=True)
     name = db.Column(db.Text(), nullable=False, unique=True)
+    # name = db.Column(db.String(255), nullable=False, unique=True)
     va_profile_item_id = db.Column(db.Integer, nullable=False, unique=True)
 
 

--- a/migrations/versions/0359_communication_items_unique.py
+++ b/migrations/versions/0359_communication_items_unique.py
@@ -1,0 +1,33 @@
+"""
+Revision ID: 0359_communication_items_unique
+Revises: 0358_default_send_field
+Create Date: 2023-06-07 21:53:38.930162
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0359_communication_items_unique"
+down_revision = "0358_default_send_field"
+
+
+def upgrade():
+    op.alter_column(
+        "communication_items", "name",
+        existing_type=sa.VARCHAR(),
+        type_=sa.Text(),
+        existing_nullable=False
+    )
+    op.create_unique_constraint(None, "communication_items", ["name"])
+    op.create_unique_constraint(None, "communication_items", ["va_profile_item_id"])
+
+
+def downgrade():
+    op.drop_constraint(None, "communication_items", type_="unique")
+    op.drop_constraint(None, "communication_items", type_="unique")
+    op.alter_column(
+        "communication_items", "name",
+        existing_type=sa.Text(),
+        type_=sa.VARCHAR(),
+        existing_nullable=False
+    )

--- a/migrations/versions/0359_communication_items_unique.py
+++ b/migrations/versions/0359_communication_items_unique.py
@@ -18,13 +18,20 @@ def upgrade():
         type_=sa.Text(),
         existing_nullable=False
     )
-    op.create_unique_constraint(None, "communication_items", ["name"])
-    op.create_unique_constraint(None, "communication_items", ["va_profile_item_id"])
+    op.create_unique_constraint("communication_items_unique_name", "communication_items", ["name"])
+    op.create_unique_constraint(
+        "communication_items_unique_va_profile_item_id",
+        "communication_items",
+        ["va_profile_item_id"]
+    )
 
 
 def downgrade():
-    op.drop_constraint(None, "communication_items", type_="unique")
-    op.drop_constraint(None, "communication_items", type_="unique")
+    # op.drop_constraint("communication_items_unique_va_profile_item_id", "communication_items", type_="unique")
+    # op.drop_constraint("communication_items_unique_name", "communication_items", type_="unique")
+    # TODO - These names are the ones automatically created.  Delete them after the downgrade.
+    op.drop_constraint("communication_items_va_profile_item_id_key", "communication_items", type_="unique")
+    op.drop_constraint("communication_items_name_key", "communication_items", type_="unique")
     op.alter_column(
         "communication_items", "name",
         existing_type=sa.Text(),

--- a/migrations/versions/0359_communication_items_unique.py
+++ b/migrations/versions/0359_communication_items_unique.py
@@ -12,12 +12,6 @@ down_revision = "0358_default_send_field"
 
 
 def upgrade():
-    op.alter_column(
-        "communication_items", "name",
-        existing_type=sa.VARCHAR(),
-        type_=sa.Text(),
-        existing_nullable=False
-    )
     op.create_unique_constraint("communication_items_unique_name", "communication_items", ["name"])
     op.create_unique_constraint(
         "communication_items_unique_va_profile_item_id",
@@ -27,14 +21,5 @@ def upgrade():
 
 
 def downgrade():
-    # op.drop_constraint("communication_items_unique_va_profile_item_id", "communication_items", type_="unique")
-    # op.drop_constraint("communication_items_unique_name", "communication_items", type_="unique")
-    # TODO - These names are the ones automatically created.  Delete them after the downgrade.
-    op.drop_constraint("communication_items_va_profile_item_id_key", "communication_items", type_="unique")
-    op.drop_constraint("communication_items_name_key", "communication_items", type_="unique")
-    op.alter_column(
-        "communication_items", "name",
-        existing_type=sa.Text(),
-        type_=sa.VARCHAR(),
-        existing_nullable=False
-    )
+    op.drop_constraint("communication_items_unique_va_profile_item_id", "communication_items", type_="unique")
+    op.drop_constraint("communication_items_unique_name", "communication_items", type_="unique")

--- a/scripts/postman/notification-api.postman_collection.json
+++ b/scripts/postman/notification-api.postman_collection.json
@@ -5391,7 +5391,108 @@
 			"name": "/communication-item",
 			"item": [
 				{
-					"name": "get communication items",
+					"name": "create communication item",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// JWT generation script adapted from",
+									"// https://gist.github.com/corbanb/",
+									"",
+									"var jwtSecret = pm.environment.get('notification-client-secret') || ''",
+									"",
+									"// Set headers for JWT",
+									"var header = {",
+									"\t'typ': 'JWT',",
+									"\t'alg': 'HS256'",
+									"};",
+									"",
+									"// Prepare timestamp in seconds",
+									"var currentTimestamp = Math.floor(Date.now() / 1000)",
+									"",
+									"var data = {",
+									"\t'iss': pm.environment.get(\"notification-admin-id\") || '',",
+									"\t'iat': currentTimestamp,",
+									"\t'exp': currentTimestamp + 30, // expiry time is 30 seconds from time of creation",
+									"\t'jti': 'jwt_nonce'",
+									"}",
+									"",
+									"",
+									"function base64url(source) {",
+									"    // Encode in classical base64",
+									"    encodedSource = CryptoJS.enc.Base64.stringify(source)",
+									"    ",
+									"    // Remove padding equal characters",
+									"    encodedSource = encodedSource.replace(/=+$/, '')",
+									"    ",
+									"    // Replace characters according to base64url specifications",
+									"    encodedSource = encodedSource.replace(/\\+/g, '-')",
+									"    encodedSource = encodedSource.replace(/\\//g, '_')",
+									"    ",
+									"    return encodedSource",
+									"}",
+									"",
+									"// encode header",
+									"var stringifiedHeader = CryptoJS.enc.Utf8.parse(JSON.stringify(header))",
+									"var encodedHeader = base64url(stringifiedHeader)",
+									"",
+									"// encode data",
+									"var stringifiedData = CryptoJS.enc.Utf8.parse(JSON.stringify(data))",
+									"var encodedData = base64url(stringifiedData)",
+									"",
+									"// build token",
+									"var token = `${encodedHeader}.${encodedData}`",
+									"",
+									"// sign token",
+									"var signature = CryptoJS.HmacSHA256(token, jwtSecret)",
+									"signature = base64url(signature)",
+									"var signedToken = `${token}.${signature}`",
+									"",
+									"pm.environment.set('jwt_signed', signedToken)",
+									"console.log('Signed and encoded JWT', signedToken)"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt_signed}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"default_send_indicator\": true,\n    \"name\": \"\",\n    \"va_profile_item_id\": \n}"
+						},
+						"url": {
+							"raw": "{{notification-api-url}}/communication-item",
+							"host": [
+								"{{notification-api-url}}"
+							],
+							"path": [
+								"communication-item"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get all communication items",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -5482,6 +5583,304 @@
 							],
 							"path": [
 								"communication-item"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get communication item",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// JWT generation script adapted from",
+									"// https://gist.github.com/corbanb/",
+									"",
+									"var jwtSecret = pm.environment.get('notification-client-secret') || ''",
+									"",
+									"// Set headers for JWT",
+									"var header = {",
+									"\t'typ': 'JWT',",
+									"\t'alg': 'HS256'",
+									"};",
+									"",
+									"// Prepare timestamp in seconds",
+									"var currentTimestamp = Math.floor(Date.now() / 1000)",
+									"",
+									"var data = {",
+									"\t'iss': pm.environment.get(\"notification-admin-id\") || '',",
+									"\t'iat': currentTimestamp,",
+									"\t'exp': currentTimestamp + 30, // expiry time is 30 seconds from time of creation",
+									"\t'jti': 'jwt_nonce'",
+									"}",
+									"",
+									"",
+									"function base64url(source) {",
+									"    // Encode in classical base64",
+									"    encodedSource = CryptoJS.enc.Base64.stringify(source)",
+									"    ",
+									"    // Remove padding equal characters",
+									"    encodedSource = encodedSource.replace(/=+$/, '')",
+									"    ",
+									"    // Replace characters according to base64url specifications",
+									"    encodedSource = encodedSource.replace(/\\+/g, '-')",
+									"    encodedSource = encodedSource.replace(/\\//g, '_')",
+									"    ",
+									"    return encodedSource",
+									"}",
+									"",
+									"// encode header",
+									"var stringifiedHeader = CryptoJS.enc.Utf8.parse(JSON.stringify(header))",
+									"var encodedHeader = base64url(stringifiedHeader)",
+									"",
+									"// encode data",
+									"var stringifiedData = CryptoJS.enc.Utf8.parse(JSON.stringify(data))",
+									"var encodedData = base64url(stringifiedData)",
+									"",
+									"// build token",
+									"var token = `${encodedHeader}.${encodedData}`",
+									"",
+									"// sign token",
+									"var signature = CryptoJS.HmacSHA256(token, jwtSecret)",
+									"signature = base64url(signature)",
+									"var signedToken = `${token}.${signature}`",
+									"",
+									"pm.environment.set('jwt_signed', signedToken)",
+									"console.log('Signed and encoded JWT', signedToken)"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt_signed}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{notification-api-url}}/communication-item/{{communication-item-id}}",
+							"host": [
+								"{{notification-api-url}}"
+							],
+							"path": [
+								"communication-item",
+								"{{communication-item-id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "partially update communication item",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// JWT generation script adapted from",
+									"// https://gist.github.com/corbanb/",
+									"",
+									"var jwtSecret = pm.environment.get('notification-client-secret') || ''",
+									"",
+									"// Set headers for JWT",
+									"var header = {",
+									"\t'typ': 'JWT',",
+									"\t'alg': 'HS256'",
+									"};",
+									"",
+									"// Prepare timestamp in seconds",
+									"var currentTimestamp = Math.floor(Date.now() / 1000)",
+									"",
+									"var data = {",
+									"\t'iss': pm.environment.get(\"notification-admin-id\") || '',",
+									"\t'iat': currentTimestamp,",
+									"\t'exp': currentTimestamp + 30, // expiry time is 30 seconds from time of creation",
+									"\t'jti': 'jwt_nonce'",
+									"}",
+									"",
+									"",
+									"function base64url(source) {",
+									"    // Encode in classical base64",
+									"    encodedSource = CryptoJS.enc.Base64.stringify(source)",
+									"    ",
+									"    // Remove padding equal characters",
+									"    encodedSource = encodedSource.replace(/=+$/, '')",
+									"    ",
+									"    // Replace characters according to base64url specifications",
+									"    encodedSource = encodedSource.replace(/\\+/g, '-')",
+									"    encodedSource = encodedSource.replace(/\\//g, '_')",
+									"    ",
+									"    return encodedSource",
+									"}",
+									"",
+									"// encode header",
+									"var stringifiedHeader = CryptoJS.enc.Utf8.parse(JSON.stringify(header))",
+									"var encodedHeader = base64url(stringifiedHeader)",
+									"",
+									"// encode data",
+									"var stringifiedData = CryptoJS.enc.Utf8.parse(JSON.stringify(data))",
+									"var encodedData = base64url(stringifiedData)",
+									"",
+									"// build token",
+									"var token = `${encodedHeader}.${encodedData}`",
+									"",
+									"// sign token",
+									"var signature = CryptoJS.HmacSHA256(token, jwtSecret)",
+									"signature = base64url(signature)",
+									"var signedToken = `${token}.${signature}`",
+									"",
+									"pm.environment.set('jwt_signed', signedToken)",
+									"console.log('Signed and encoded JWT', signedToken)"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt_signed}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"default_send_indicator\": true,\n    \"name\": \"\",\n    \"va_profile_item_id\": \n}"
+						},
+						"url": {
+							"raw": "{{notification-api-url}}/communication-item/{{communication-item-id}}",
+							"host": [
+								"{{notification-api-url}}"
+							],
+							"path": [
+								"communication-item",
+								"{{communication-item-id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete communication item",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"// JWT generation script adapted from",
+									"// https://gist.github.com/corbanb/",
+									"",
+									"var jwtSecret = pm.environment.get('notification-client-secret') || ''",
+									"",
+									"// Set headers for JWT",
+									"var header = {",
+									"\t'typ': 'JWT',",
+									"\t'alg': 'HS256'",
+									"};",
+									"",
+									"// Prepare timestamp in seconds",
+									"var currentTimestamp = Math.floor(Date.now() / 1000)",
+									"",
+									"var data = {",
+									"\t'iss': pm.environment.get(\"notification-admin-id\") || '',",
+									"\t'iat': currentTimestamp,",
+									"\t'exp': currentTimestamp + 30, // expiry time is 30 seconds from time of creation",
+									"\t'jti': 'jwt_nonce'",
+									"}",
+									"",
+									"",
+									"function base64url(source) {",
+									"    // Encode in classical base64",
+									"    encodedSource = CryptoJS.enc.Base64.stringify(source)",
+									"    ",
+									"    // Remove padding equal characters",
+									"    encodedSource = encodedSource.replace(/=+$/, '')",
+									"    ",
+									"    // Replace characters according to base64url specifications",
+									"    encodedSource = encodedSource.replace(/\\+/g, '-')",
+									"    encodedSource = encodedSource.replace(/\\//g, '_')",
+									"    ",
+									"    return encodedSource",
+									"}",
+									"",
+									"// encode header",
+									"var stringifiedHeader = CryptoJS.enc.Utf8.parse(JSON.stringify(header))",
+									"var encodedHeader = base64url(stringifiedHeader)",
+									"",
+									"// encode data",
+									"var stringifiedData = CryptoJS.enc.Utf8.parse(JSON.stringify(data))",
+									"var encodedData = base64url(stringifiedData)",
+									"",
+									"// build token",
+									"var token = `${encodedHeader}.${encodedData}`",
+									"",
+									"// sign token",
+									"var signature = CryptoJS.HmacSHA256(token, jwtSecret)",
+									"signature = base64url(signature)",
+									"var signedToken = `${token}.${signature}`",
+									"",
+									"pm.environment.set('jwt_signed', signedToken)",
+									"console.log('Signed and encoded JWT', signedToken)"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt_signed}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{notification-api-url}}/communication-item/{{communication-item-id}}",
+							"host": [
+								"{{notification-api-url}}"
+							],
+							"path": [
+								"communication-item",
+								"{{communication-item-id}}"
 							]
 						}
 					},

--- a/tests/app/communication_item/test_rest.py
+++ b/tests/app/communication_item/test_rest.py
@@ -1,30 +1,200 @@
-import logging
-from uuid import UUID
+""" Test CRUD endpoints for the CommunicationItem model. """
+
+import pytest
+from app.models import CommunicationItem
+from uuid import UUID, uuid4
 
 
-def test_get_communication_items(mocker, admin_request, sample_email_template):
+#############
+# Create
+#############
+
+@pytest.mark.parametrize("post_data,expected_status", [
+    ({}, 400),
+    ({"id": "invalid uuid4"}, 400),
+    ({"id": "39247cfc-a52d-4b2b-b9a9-2ef8a20190cb"}, 400),
+    ({"name": "name"}, 400),
+    ({"va_profile_item_id": 1}, 400),
+    ({"name": "name", "va_profile_item_id": 1}, 201),
+    ({"default_send_indicator": False, "name": "name", "va_profile_item_id": 1}, 201),
+    ({"default_send_indicator": False, "name": "name", "va_profile_item_id": -5}, 400),
+    (
+        {
+            "default_send_indicator": False,
+            "id": "39247cfc-a52d-4b2b-b9a9-2ef8a20190cb",
+            "name": "name",
+            "va_profile_item_id": 1,
+        },
+        400
+    ),
+])
+def test_create_communication_item(notify_db_session, admin_request, post_data, expected_status):
     """
-    The fixture "sample_email_template" has the side-effect of creating and
-    persisting a CommunicationItem instance that uses the default value for
-    default_send_indicator, which is True.
+    The post data must contain "name" and "va_profile_item_id".  "default_send_indicatior" is optional.
+    The post data must not contain "id".
     """
 
-    response = admin_request.get(
-        'communication_item.get_communication_items'
+    response = admin_request.post(
+        "communication_item.create_communication_item",
+        post_data,
+        expected_status
     )
 
+    if expected_status == 201:
+        assert isinstance(response, dict), response
+        assert response["default_send_indicator"] is post_data.get("default_send_indicator", True)
+        assert response["name"] == "name"
+        assert response["va_profile_item_id"] == 1
+        assert isinstance(UUID(response["id"]), UUID)
+        if "id" in post_data:
+            assert response["id"] == post_data["id"]
+    elif expected_status == 400:
+        assert isinstance(response, dict) and "errors" in response, response
+        assert isinstance(response["errors"], list) and len(response["errors"]) == 1
+        assert isinstance(response["errors"][0], dict)
+        assert response["errors"][0]["error"] in ("DataError", "IntegrityError", "ValidationError")
+        assert "message" in response["errors"][0]
+    else:
+        raise RuntimeError("This is a programming error.")
+
+
+#############
+# Retrieve
+#############
+
+def test_get_all_communication_items(notify_db_session, admin_request):
+    """
+    This test creates a CommunicationItem instance to ensure at least one instance is in the
+    database, but it doesn't assume that only one instance exists because fixtures create them.
+    """
+
+    communication_item = CommunicationItem(id=uuid4(), va_profile_item_id=1, name="name")
+    notify_db_session.session.add(communication_item)
+    notify_db_session.session.commit()
+
+    response = admin_request.get("communication_item.get_all_communication_items", 200)
     assert isinstance(response["data"], list)
 
     for communication_item in response["data"]:
         assert isinstance(communication_item, dict)
-        assert isinstance(communication_item["default_send_indicator"], bool) and \
-            communication_item["default_send_indicator"], "Should be True by default."
+        assert isinstance(communication_item["default_send_indicator"], bool)
+        assert communication_item["default_send_indicator"], "Should be True by default."
         assert isinstance(communication_item["name"], str) and communication_item["name"]
         assert isinstance(communication_item["va_profile_item_id"], int)
-        assert isinstance(communication_item["id"], str)
+        assert isinstance(UUID(communication_item["id"]), UUID)
 
-        try:
-            assert isinstance(UUID(communication_item["id"]), UUID)
-        except ValueError as e:
-            logging.exception(e)
-            raise
+
+def test_get_communication_item(notify_db_session, admin_request):
+    communication_item = CommunicationItem(id=uuid4(), va_profile_item_id=1, name="name")
+    notify_db_session.session.add(communication_item)
+    notify_db_session.session.commit()
+
+    response = admin_request.get(
+        "communication_item.get_communication_item",
+        200,
+        communication_item_id=communication_item.id
+    )
+
+    assert isinstance(response, dict), response
+    assert isinstance(response["default_send_indicator"], bool)
+    assert response["default_send_indicator"], "Should be True by default."
+    assert response["name"] == "name"
+    assert response["va_profile_item_id"] == 1
+    assert isinstance(UUID(response["id"]), UUID)
+
+
+def test_get_communication_item_not_found(notify_db_session, admin_request):
+    response = admin_request.get(
+        "communication_item.get_communication_item",
+        404,
+        communication_item_id="doesn't exist"
+    )
+
+    assert isinstance(response, dict), response
+    assert response["message"] == "No result found"
+    assert response["result"] == "error"
+
+
+#############
+# Update
+#############
+
+@pytest.mark.parametrize("post_data,expected_status", [
+    ({}, 400),
+    ({"name": 1}, 400),
+    ({"va_profile_item_id": "not a number"}, 400),
+    ({"va_profile_item_id": -5}, 400),
+    ({"name": "different name"}, 200),
+    ({"va_profile_item_id": 2}, 200),
+    ({"default_send_indicator": False}, 200),
+    ({"name": "different name", "va_profile_item_id": 2, "default_send_indicator": False}, 200),
+])
+def test_partially_update_communication_item(notify_db_session, admin_request, post_data, expected_status):
+    communication_item = CommunicationItem(id=uuid4(), va_profile_item_id=1, name="name")
+    notify_db_session.session.add(communication_item)
+    notify_db_session.session.commit()
+    assert communication_item.default_send_indicator, "Should be True by default."
+
+    response = admin_request.patch(
+        "communication_item.partially_update_communication_item",
+        post_data,
+        expected_status,
+        communication_item_id=str(communication_item.id)
+    )
+
+    assert isinstance(response, dict), response
+
+    if expected_status == 200:
+        if "name" in post_data:
+            assert communication_item.name == post_data["name"]
+            assert response["name"] == post_data["name"]
+        if "va_profile_item_id" in post_data:
+            assert communication_item.va_profile_item_id == post_data["va_profile_item_id"]
+            assert response["va_profile_item_id"] == post_data["va_profile_item_id"]
+        if "default_send_indicator" in post_data:
+            assert isinstance(communication_item.default_send_indicator, bool)
+            assert communication_item.default_send_indicator is post_data["default_send_indicator"]
+            assert response["default_send_indicator"] is post_data["default_send_indicator"]
+    elif expected_status == 400:
+        assert response["errors"][0]["error"] in ("DataError", "IntegrityError", "ValidationError")
+        assert "message" in response["errors"][0]
+
+
+def test_partially_update_communication_item_not_found(notify_db_session, admin_request):
+    admin_request.patch(
+        "communication_item.partially_update_communication_item",
+        {"va_profile_item_id": 2},
+        404,
+        communication_item_id="doesn't exist"
+    )
+
+
+#############
+# Delete
+#############
+
+def test_delete_communication_item(notify_db_session, admin_request):
+    communication_item = CommunicationItem(id=uuid4(), va_profile_item_id=1, name="name")
+    communication_item_id = communication_item.id
+    notify_db_session.session.add(communication_item)
+    notify_db_session.session.commit()
+
+    # Ensure the new CommunicationItem instance is in the database.
+    assert CommunicationItem.query.get(communication_item_id) is not None
+
+    admin_request.delete(
+        "communication_item.delete_communication_item",
+        202,
+        communication_item_id=communication_item_id
+    )
+
+    # Ensure communication_item1 is not in the database.
+    assert CommunicationItem.query.get(communication_item_id) is None
+
+
+def test_delete_communication_item_not_found(notify_db_session, admin_request):
+    admin_request.delete(
+        "communication_item.delete_communication_item",
+        404,
+        communication_item_id="doesn't exist"
+    )

--- a/tests/app/communication_item/test_rest.py
+++ b/tests/app/communication_item/test_rest.py
@@ -46,8 +46,6 @@ def test_create_communication_item(notify_db_session, admin_request, post_data, 
         assert response["name"] == "name"
         assert response["va_profile_item_id"] == 1
         assert isinstance(UUID(response["id"]), UUID)
-        if "id" in post_data:
-            assert response["id"] == post_data["id"]
     elif expected_status == 400:
         assert isinstance(response, dict) and "errors" in response, response
         assert isinstance(response["errors"], list) and len(response["errors"]) == 1

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1449,9 +1449,9 @@ def admin_request(client):
                 url_for(endpoint, **(endpoint_kwargs or {})),
                 headers=[create_authorization_header()]
             )
-            json_resp = resp.json
+
             assert resp.status_code == _expected_status
-            return json_resp
+            return resp.json
 
         @staticmethod
         def post(endpoint, _data=None, _expected_status=200, **endpoint_kwargs):
@@ -1460,12 +1460,20 @@ def admin_request(client):
                 data=json.dumps(_data),
                 headers=[('Content-Type', 'application/json'), create_authorization_header()]
             )
-            if resp.get_data():
-                json_resp = resp.json
-            else:
-                json_resp = None
+
             assert resp.status_code == _expected_status
-            return json_resp
+            return resp.json if resp.get_data() else None
+
+        @staticmethod
+        def patch(endpoint, _data=None, _expected_status=200, **endpoint_kwargs):
+            resp = client.patch(
+                url_for(endpoint, **(endpoint_kwargs or {})),
+                data=json.dumps(_data),
+                headers=[('Content-Type', 'application/json'), create_authorization_header()]
+            )
+
+            assert resp.status_code == _expected_status
+            return resp.json if resp.get_data() else None
 
         @staticmethod
         def delete(endpoint, _expected_status=204, **endpoint_kwargs):
@@ -1473,12 +1481,9 @@ def admin_request(client):
                 url_for(endpoint, **(endpoint_kwargs or {})),
                 headers=[create_authorization_header()]
             )
-            if resp.get_data():
-                json_resp = resp.json
-            else:
-                json_resp = None
-            assert resp.status_code == _expected_status, json_resp
-            return json_resp
+
+            assert resp.status_code == _expected_status
+            return resp.json if resp.get_data() else None
 
     return AdminRequest
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -198,7 +198,14 @@ def create_template(
         reply_to_email=None,
         onsite_notification=False
 ):
-    communication_item = CommunicationItem(id=uuid.uuid4(), va_profile_item_id=1, name='some name')
+    # The CommunicationItem fields "va_profile_item_id" and "name" must be unique.  Using a UUID for
+    # "name" is very unlikely to cause a collision.  If a test fails with a duplicate "va_profile_item_id",
+    # rerun the test.  See #1106 for a more elegant solution.
+    communication_item = CommunicationItem(
+        id=uuid.uuid4(),
+        va_profile_item_id=random.randint(1, 100000),
+        name=uuid.uuid4()
+    )
     dao_create_communication_item(communication_item)
 
     data = {


### PR DESCRIPTION
# Description

These changes:
- Complete the CRUD implementation for the CommunicationItem model
- Include a migration to force uniqueness for two CommunicationItem columns
- Update the Postman collection to include all CommunicationItem routes
- Removes redundant lines in .talismanrc

I initially planned to make database queries using the newer SQLAlchemy v2.0 query syntax.  (We use version 1.4, which supports the new and legacy syntax.)  However, I came to understand that the syntax used throughout the app (i.e. ModelName.query.get(<id>), etc.) is actually provided by [flask-sqlalchemy](https://flask-sqlalchemy.palletsprojects.com/en/3.0.x/quickstart/#query-the-data), which [supports SQLAlchemy >= 1.4.18](https://flask-sqlalchemy.palletsprojects.com/en/3.0.x/changes/#version-3-0-0).

#1253

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] New unit tests pass
- [x] Manually tested in local environment with Postman
- [x] [Deployed](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/5213957332)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes