### PR TITLE
Configure Gunicorn's keepalive value to 70 seconds

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -7,6 +7,7 @@ worker_class = "eventlet"
 worker_connections = 256
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 accesslog = '-'
+keepalive = 70
 
 
 def on_starting(server):

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -22,7 +22,7 @@ eventlet ~= 0.33.3
 # https://developers.yubico.com/WebAuthn/
 fido2 >= 1.1.1
 
-Flask >= 2.2.3
+Flask >= 2.2.5
 Flask-Bcrypt >= 1.0.1
 Flask-Cors >= 3.0.10
 Flask-JWT-Extended >= 4.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ envier==0.4.0
 eventlet==0.33.3
 exceptiongroup==1.1.1
 fido2==1.1.1
-Flask==2.2.3
+Flask==2.2.5
 Flask-Bcrypt==1.0.1
 Flask-Cors==3.0.10
 Flask-JWT-Extended==4.4.4


### PR DESCRIPTION
# Description

Configure Gunicorn's keepalive value to 70 seconds.  There is no associated ticket.

https://docs.gunicorn.org/en/stable/settings.html#keepalive

These changes also perform a patch upgrade of Flask from v2.2.3 to v2.2.5 because the former has a vulnerability flagged by Safety.  The patch upgrade is explicitly to fix the vulnerability. There's no risk.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] [Deployed to Dev](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/5204618346)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes