### PR TITLE
#1268 Updated the OpenAPI specification and Postman collection for CommunicationItem

### DIFF
--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: VA Notify API Documentation
-  version: 1.0.1
+  version: 1.0.2
   description: |
     <p>This documents the API schemas for consumption by internal VA developers.</p>
     <h1>Authorization header</h1>
@@ -887,21 +887,6 @@ paths:
   /communication-item/{communication_item_id}:
     parameters:
       - $ref: "#/components/parameters/CommunicationItemId"
-    delete:
-      summary: Delete a communication item by ID
-      tags:
-        - communication-item
-      responses:
-        "202":
-          description: Accepted
-          content:
-            application/json:
-              schema:
-                type: object
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
     get:
       summary: Retrieve a communication item by ID
       tags:
@@ -936,6 +921,21 @@ paths:
                 $ref: "#/components/schemas/CommunicationItem"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      summary: Delete a communication item by ID
+      tags:
+        - communication-item
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                type: object
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -843,13 +843,14 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
   /communication-item:
     get:
-      summary: Get a list of all communication items
+      summary: Retrieve a list of all communication items
       tags:
         - communication-item
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -860,6 +861,85 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/CommunicationItem'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      summary: Create a new communication item
+      tags:
+        - communication-item
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommunicationItemCreate"
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunicationItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /communication-item/{communication_item_id}:
+    parameters:
+      - $ref: "#/components/parameters/CommunicationItemId"
+    delete:
+      summary: Delete a communication item by ID
+      tags:
+        - communication-item
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                type: object
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    get:
+      summary: Retrieve a communication item by ID
+      tags:
+        - communication-item
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunicationItem"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      summary: Update a communication item by ID
+      tags:
+        - communication-item
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommunicationItemUpdate"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommunicationItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   /service/{service_id}/api-key:
     post:
@@ -1390,6 +1470,14 @@ components:
         $ref: '#/components/schemas/Id'
       required: true
       description: Service SMS sender identifier
+    CommunicationItemId:
+      name: communication_item_id
+      in: path
+      schema:
+        $ref: '#/components/schemas/Id'
+      required: true
+      description: CommunicationItem identifier
+      example: e925b547-8195-4ed2-83c5-0633a74d780a
   responses:
     BadRequest:
       description: Bad Request
@@ -2041,12 +2129,52 @@ components:
     CommunicationItem:
       type: object
       properties:
+        default_send_indicator:
+          type: boolean
+          nullable: false
         id:
-          type: string
+          $ref: "#/components/schemas/Id"
         name:
           type: string
+          minLength: 1
+          nullable: false
         va_profile_item_id:
-          type: number
+          type: integer
+          minimum: 1
+          nullable: false
+      additionalProperties: false
+    CommunicationItemUpdate:
+      type: object
+      properties:
+        default_send_indicator:
+          type: boolean
+          nullable: false
+        name:
+          type: string
+          minLength: 1
+          nullable: false
+        va_profile_item_id:
+          type: integer
+          minimum: 1
+          nullable: false
+      additionalProperties: false
+      minProperties: 1
+    CommunicationItemCreate:
+      type: object
+      properties:
+        default_send_indicator:
+          type: boolean
+          nullable: false
+        name:
+          type: string
+          minLength: 1
+          nullable: false
+        va_profile_item_id:
+          type: integer
+          minimum: 1
+          nullable: false
+      additionalProperties: false
+      required: [name, va_profile_item_id]
     NotificationRequest:
       type: object
       properties:

--- a/scripts/postman/notification-api.postman_collection.json
+++ b/scripts/postman/notification-api.postman_collection.json
@@ -5477,7 +5477,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"default_send_indicator\": true,\n    \"name\": \"\",\n    \"va_profile_item_id\": \n}"
+							"raw": "{\n    \"default_send_indicator\": true,\n    \"name\": \"\",\n    \"va_profile_item_id\": <positive integer>\n}"
 						},
 						"url": {
 							"raw": "{{notification-api-url}}/communication-item",
@@ -5773,7 +5773,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"default_send_indicator\": true,\n    \"name\": \"\",\n    \"va_profile_item_id\": \n}"
+							"raw": "{\n    \"default_send_indicator\": true,\n    \"name\": \"\",\n    \"va_profile_item_id\": <positive integer>\n}"
 						},
 						"url": {
 							"raw": "{{notification-api-url}}/communication-item/{{communication-item-id}}",


### PR DESCRIPTION
# Description

These changes:
1. Add all CommunicationItem routes to [our OpenAPI specification](https://github.com/department-of-veterans-affairs/notification-api/tree/master/documents/openapi)
2. Make a minor tweak to a default request body in the Postman collection that I should have made for #1253
3. Use `nullable: false` to create documentation that shows up in the Swagger Editor.  `nullable` isn't part of the OpenAPI or JSON Schema specifications, but our specification uses it extensively.

These changes do not make any updates to [openapi-with-push.yaml](https://github.com/department-of-veterans-affairs/notification-api/blob/master/documents/openapi/openapi-with-push.yaml), which is not discussed in README.md and does not seem to be in use.

Useful documentation and tools:
1. [OpenAPI specification](https://spec.openapis.org/oas/latest.html)
2. [Understanding JSON Schema](https://json-schema.org/understanding-json-schema/)
4. [Swagger Editor](https://editor-next.swagger.io/)

#1268

## Type of change

- [x] Documentation changes only

## How Has This Been Tested?

- [x] Verified that everything looks correct in [Swagger Editor](https://editor-next.swagger.io/) by opening [this URL](https://raw.githubusercontent.com/department-of-veterans-affairs/notification-api/1268-api-docs/documents/openapi/openapi.yaml)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes