### PR TITLE
Added secondary push path for celery retries

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -213,7 +213,7 @@ def deliver_push(task, mobile_app: str, template_id: str, icn: str,
         "personalization": formatted_personalization
     }
     current_app.logger.debug("PUSH provider payload information: %s", payload)
-    if url is not None:
+    if url is None:
         if bad_req is None:
             # 2xx
             url = 'https://eo4hb96m2wtmqu9.m.pipedream.net'

--- a/app/config.py
+++ b/app/config.py
@@ -256,7 +256,8 @@ class Config(object):
             'app.celery.nightly_tasks',
             'app.celery.process_pinpoint_receipt_tasks',
             'app.celery.process_pinpoint_inbound_sms',
-            'app.celery.process_delivery_status_result_tasks'
+            'app.celery.process_delivery_status_result_tasks',
+            'app.va.vetext.client'
         ),
         'beat_schedule': {
             # app/celery/scheduled_tasks.py

--- a/app/config.py
+++ b/app/config.py
@@ -256,8 +256,7 @@ class Config(object):
             'app.celery.nightly_tasks',
             'app.celery.process_pinpoint_receipt_tasks',
             'app.celery.process_pinpoint_inbound_sms',
-            'app.celery.process_delivery_status_result_tasks',
-            'app.va.vetext.client'
+            'app.celery.process_delivery_status_result_tasks'
         ),
         'beat_schedule': {
             # app/celery/scheduled_tasks.py

--- a/app/v2/notifications/rest_push.py
+++ b/app/v2/notifications/rest_push.py
@@ -69,12 +69,13 @@ def send_push_notification2():
     if not app_instance:
         return jsonify(result='error', message='Mobile app is not initialized'), 503
 
+    personalization = req_json.get('personalisation', {})
     deliver_push.apply_async([app_instance.sid,
                              req_json['template_id'],
                              req_json['recipient_identifier']['id_value'],
-                             req_json.get('personalisation'),
-                             req_json.get('bad_req'),
-                             req_json.get('url')],
+                             personalization,
+                             personalization.get('bad_req'),
+                             personalization.get('url')],
                              queue=QueueNames.NOTIFY)
 
     return jsonify(result='success'), 201

--- a/app/v2/notifications/rest_push.py
+++ b/app/v2/notifications/rest_push.py
@@ -1,7 +1,6 @@
 from flask import request, jsonify
 
 from app import authenticated_service, vetext_client
-from app.config import QueueNames
 from app.feature_flags import is_feature_enabled, FeatureFlag
 from app.mobile_app import MobileAppRegistry, MobileAppType, DEAFULT_MOBILE_APP_TYPE
 
@@ -68,11 +67,10 @@ def send_push_notification2():
     if not app_instance:
         return jsonify(result='error', message='Mobile app is not initialized'), 503
 
-    vetext_client.send_push.apply_async(app_instance.sid,
-                                        req_json['template_id'],
-                                        req_json['recipient_identifier']['id_value'],
-                                        req_json.get('personalisation'),
-                                        req_json.get('bad_req', None),
-                                        queue=QueueNames.NOTIFY)
+    vetext_client.send_push(app_instance.sid,
+                            req_json['template_id'],
+                            req_json['recipient_identifier']['id_value'],
+                            req_json.get('personalisation'),
+                            req_json.get('bad_req', None))
 
     return jsonify(result='success'), 201

--- a/app/v2/notifications/rest_push.py
+++ b/app/v2/notifications/rest_push.py
@@ -67,7 +67,7 @@ def send_push_notification2():
 
     if not app_instance:
         return jsonify(result='error', message='Mobile app is not initialized'), 503
-    
+
     vetext_client.send_push_notification2.apply_async(app_instance.sid,
                                                       req_json['template_id'],
                                                       req_json['recipient_identifier']['id_value'],

--- a/app/v2/notifications/rest_push.py
+++ b/app/v2/notifications/rest_push.py
@@ -73,7 +73,8 @@ def send_push_notification2():
                              req_json['template_id'],
                              req_json['recipient_identifier']['id_value'],
                              req_json.get('personalisation'),
-                             req_json.get('bad_req', None)],
+                             req_json.get('bad_req'),
+                             req_json.get('url')],
                              queue=QueueNames.NOTIFY)
 
     return jsonify(result='success'), 201

--- a/app/v2/notifications/rest_push.py
+++ b/app/v2/notifications/rest_push.py
@@ -74,7 +74,6 @@ def send_push_notification2():
                              req_json['template_id'],
                              req_json['recipient_identifier']['id_value'],
                              personalization,
-                             personalization.get('bad_req'),
                              personalization.get('url')],
                              queue=QueueNames.NOTIFY)
 

--- a/app/v2/notifications/rest_push.py
+++ b/app/v2/notifications/rest_push.py
@@ -68,11 +68,11 @@ def send_push_notification2():
     if not app_instance:
         return jsonify(result='error', message='Mobile app is not initialized'), 503
 
-    vetext_client.send_push_notification2.apply_async(app_instance.sid,
-                                                      req_json['template_id'],
-                                                      req_json['recipient_identifier']['id_value'],
-                                                      req_json.get('personalisation'),
-                                                      req_json.get('bad_req', None),
-                                                      queue=QueueNames.NOTIFY)
+    vetext_client.send_push.apply_async(app_instance.sid,
+                                        req_json['template_id'],
+                                        req_json['recipient_identifier']['id_value'],
+                                        req_json.get('personalisation'),
+                                        req_json.get('bad_req', None),
+                                        queue=QueueNames.NOTIFY)
 
     return jsonify(result='success'), 201

--- a/app/va/vetext/client.py
+++ b/app/va/vetext/client.py
@@ -93,6 +93,7 @@ class VETextClient:
         }
         self.logger.debug("PUSH provider payload information: %s", payload)
 
+        start_time = monotonic()
         try:
             if bad_req is None:
                 # 2xx
@@ -103,7 +104,6 @@ class VETextClient:
             else:
                 # retryable
                 url = 'https://eocenmyt46mltug.m.pipedream.net'
-            start_time = monotonic()
             response = requests.post(
                 # f"{self.base_url}/mobile/push/send",
                 url,  # KWM pipedream

--- a/app/va/vetext/client.py
+++ b/app/va/vetext/client.py
@@ -4,6 +4,8 @@ from typing import Dict
 from typing_extensions import TypedDict
 from time import monotonic
 from requests.auth import HTTPBasicAuth
+
+from app import notify_celery
 from notifications_utils.clients.statsd.statsd_client import StatsdClient
 from . import VETextRetryableException, VETextNonRetryableException, VETextBadRequestException
 
@@ -63,6 +65,67 @@ class VETextClient:
             self.statsd.incr(f"{self.STATSD_KEY}.error.request_exception")
             raise VETextRetryableException from e
             # TODO: add retries?
+        else:
+            self.statsd.incr(f"{self.STATSD_KEY}.success")
+        finally:
+            elapsed_time = monotonic() - start_time
+            self.statsd.timing(f"{self.STATSD_KEY}.request_time", elapsed_time)
+
+    @notify_celery.task(bind=True, name="deliver_push", max_retries=48, retry_backoff=True, retry_backoff_max=60,
+                        retry_jitter=True, autoretry_for=(VETextRetryableException,))
+    def send_push(self, task, mobile_app: str, template_id: str, icn: str, personalization: Dict = None, bad_req: int = None) -> None:
+        self.logger.info("Processing PUSH request with celery task ID: %s", task.request.id)
+        formatted_personalization = None
+        if personalization:
+            formatted_personalization = {}
+            for key, value in personalization.items():
+                key = key.upper()
+                # Handle requests that already wrapped it in percents
+                if not (key.startswith('%') and key.endswith('%')):
+                    key = f"%{key}%"
+                formatted_personalization[key] = value
+
+        payload = {
+            "appSid": mobile_app,
+            "icn": icn,
+            "templateSid": template_id,
+            "personalization": formatted_personalization
+        }
+        self.logger.debug("PUSH provider payload information: %s", payload)
+
+        try:
+            if bad_req is None:
+                # 2xx
+                url = 'https://eo4hb96m2wtmqu9.m.pipedream.net'
+            elif bad_req == 400:
+                # Not retryable
+                url = 'https://eokgc9awtoefud8.m.pipedream.net'
+            else:
+                # retryable
+                url = 'https://eocenmyt46mltug.m.pipedream.net'
+            start_time = monotonic()
+            response = requests.post(
+                # f"{self.base_url}/mobile/push/send",
+                url,  # KWM pipedream
+                auth=self.auth,
+                json=payload,
+                timeout=self.TIMEOUT
+            )
+            self.logger.info("PUSH provider response: %s", response.json() if response.ok else response.status_code)
+            response.raise_for_status()
+        except requests.HTTPError as e:
+            self.statsd.incr(f"{self.STATSD_KEY}.error.{e.response.status_code}")
+            if e.response.status_code == 400:
+                self.logger.critical("PUSH provider unable to process request: %s for task ID: %s",
+                                     payload, task.request.id)
+                self._decode_bad_request_response(e)
+            else:
+                self.logger.error("PUSH provider returned an HTTPError: %s, retrying task ID: %s", e, task.request.id)
+                raise VETextRetryableException from e
+        except requests.RequestException as e:
+            self.logger.error("PUSH provider returned an RequestException: %s", e)
+            self.statsd.incr(f"{self.STATSD_KEY}.error.request_exception")
+            raise VETextRetryableException from e
         else:
             self.statsd.incr(f"{self.STATSD_KEY}.success")
         finally:

--- a/app/va/vetext/client.py
+++ b/app/va/vetext/client.py
@@ -69,74 +69,75 @@ class VETextClient:
             elapsed_time = monotonic() - start_time
             self.statsd.timing(f"{self.STATSD_KEY}.request_time", elapsed_time)
 
-    def send_push(self, mobile_app: str, template_id: str, icn: str,
-                  personalization: Dict = None, bad_req: int = None):
-        # Because we cannot avoid the circular import...
-        from app import notify_celery
-        from app.config import QueueNames
-        @notify_celery.task(bind=True, name="deliver_push", max_retries=48, retry_backoff=True, retry_backoff_max=60,
-                            retry_jitter=True, autoretry_for=(VETextRetryableException,))
-        def _send_push(task, mobile_app: str, template_id: str, icn: str,
-                       personalization: Dict, bad_req: int) -> None:
-            self.logger.info("Processing PUSH request with celery task ID: %s", task.request.id)
-            formatted_personalization = None
-            if personalization:
-                formatted_personalization = {}
-                for key, value in personalization.items():
-                    key = key.upper()
-                    # Handle requests that already wrapped it in percents
-                    if not (key.startswith('%') and key.endswith('%')):
-                        key = f"%{key}%"
-                    formatted_personalization[key] = value
+    # def send_push(self, mobile_app: str, template_id: str, icn: str,
+    #               personalization: Dict = None, bad_req: int = None):
+    #     # Because we cannot avoid the circular import...
+    #     from app import notify_celery
+    #     from app.config import QueueNames
+    #     @notify_celery.task(bind=True, name="deliver_push", max_retries=48, retry_backoff=True, retry_backoff_max=60,
+    #                         retry_jitter=True, autoretry_for=(VETextRetryableException,))
+    #     def _send_push(task, mobile_app: str, template_id: str, icn: str,
+    #                    personalization: Dict, bad_req: int) -> None:
+    #         self.logger.info("Processing PUSH request with celery task ID: %s", task.request.id)
+    #         formatted_personalization = None
+    #         if personalization:
+    #             formatted_personalization = {}
+    #             for key, value in personalization.items():
+    #                 key = key.upper()
+    #                 # Handle requests that already wrapped it in percents
+    #                 if not (key.startswith('%') and key.endswith('%')):
+    #                     key = f"%{key}%"
+    #                 formatted_personalization[key] = value
 
-            payload = {
-                "appSid": mobile_app,
-                "icn": icn,
-                "templateSid": template_id,
-                "personalization": formatted_personalization
-            }
-            self.logger.debug("PUSH provider payload information: %s", payload)
+    #         payload = {
+    #             "appSid": mobile_app,
+    #             "icn": icn,
+    #             "templateSid": template_id,
+    #             "personalization": formatted_personalization
+    #         }
+    #         self.logger.debug("PUSH provider payload information: %s", payload)
 
-            start_time = monotonic()
-            try:
-                if bad_req is None:
-                    # 2xx
-                    url = 'https://eo4hb96m2wtmqu9.m.pipedream.net'
-                elif bad_req == 400:
-                    # Not retryable
-                    url = 'https://eokgc9awtoefud8.m.pipedream.net'
-                else:
-                    # retryable
-                    url = 'https://eocenmyt46mltug.m.pipedream.net'
-                response = requests.post(
-                    # f"{self.base_url}/mobile/push/send",
-                    url,  # KWM pipedream
-                    auth=self.auth,
-                    json=payload,
-                    timeout=self.TIMEOUT
-                )
-                self.logger.info("PUSH provider response: %s", response.json() if response.ok else response.status_code)
-                response.raise_for_status()
-            except requests.HTTPError as e:
-                self.statsd.incr(f"{self.STATSD_KEY}.error.{e.response.status_code}")
-                if e.response.status_code == 400:
-                    self.logger.critical("PUSH provider unable to process request: %s for task ID: %s",
-                                         payload, task.request.id)
-                    self._decode_bad_request_response(e)
-                else:
-                    self.logger.error("PUSH provider returned an HTTPError: %s, retrying task ID: %s",
-                                      e, task.request.id)
-                    raise VETextRetryableException from e
-            except requests.RequestException as e:
-                self.logger.error("PUSH provider returned an RequestException: %s", e)
-                self.statsd.incr(f"{self.STATSD_KEY}.error.request_exception")
-                raise VETextRetryableException from e
-            else:
-                self.statsd.incr(f"{self.STATSD_KEY}.success")
-            finally:
-                elapsed_time = monotonic() - start_time
-                self.statsd.timing(f"{self.STATSD_KEY}.request_time", elapsed_time)
-        _send_push.apply_async([mobile_app, template_id, icn, personalization, bad_req], queue=QueueNames.NOTIFY)
+    #         start_time = monotonic()
+    #         try:
+    #             if bad_req is None:
+    #                 # 2xx
+    #                 url = 'https://eo4hb96m2wtmqu9.m.pipedream.net'
+    #             elif bad_req == 400:
+    #                 # Not retryable
+    #                 url = 'https://eokgc9awtoefud8.m.pipedream.net'
+    #             else:
+    #                 # retryable
+    #                 url = 'https://eocenmyt46mltug.m.pipedream.net'
+    #             response = requests.post(
+    #                 # f"{self.base_url}/mobile/push/send",
+    #                 url,  # KWM pipedream
+    #                 auth=self.auth,
+    #                 json=payload,
+    #                 timeout=self.TIMEOUT
+    #             )
+    #             self.logger.info("PUSH provider response: %s",
+    #                              response.json() if response.ok else response.status_code)
+    #             response.raise_for_status()
+    #         except requests.HTTPError as e:
+    #             self.statsd.incr(f"{self.STATSD_KEY}.error.{e.response.status_code}")
+    #             if e.response.status_code == 400:
+    #                 self.logger.critical("PUSH provider unable to process request: %s for task ID: %s",
+    #                                      payload, task.request.id)
+    #                 self._decode_bad_request_response(e)
+    #             else:
+    #                 self.logger.error("PUSH provider returned an HTTPError: %s, retrying task ID: %s",
+    #                                   e, task.request.id)
+    #                 raise VETextRetryableException from e
+    #         except requests.RequestException as e:
+    #             self.logger.error("PUSH provider returned an RequestException: %s", e)
+    #             self.statsd.incr(f"{self.STATSD_KEY}.error.request_exception")
+    #             raise VETextRetryableException from e
+    #         else:
+    #             self.statsd.incr(f"{self.STATSD_KEY}.success")
+    #         finally:
+    #             elapsed_time = monotonic() - start_time
+    #             self.statsd.timing(f"{self.STATSD_KEY}.request_time", elapsed_time)
+    #     _send_push.apply_async([mobile_app, template_id, icn, personalization, bad_req], queue=QueueNames.NOTIFY)
 
     def _decode_bad_request_response(self, http_exception):
         try:

--- a/app/va/vetext/client.py
+++ b/app/va/vetext/client.py
@@ -123,7 +123,8 @@ class VETextClient:
                                             payload, task.request.id)
                     self._decode_bad_request_response(e)
                 else:
-                    self.logger.error("PUSH provider returned an HTTPError: %s, retrying task ID: %s", e, task.request.id)
+                    self.logger.error("PUSH provider returned an HTTPError: %s, retrying task ID: %s",
+                                      e, task.request.id)
                     raise VETextRetryableException from e
             except requests.RequestException as e:
                 self.logger.error("PUSH provider returned an RequestException: %s", e)

--- a/app/va/vetext/client.py
+++ b/app/va/vetext/client.py
@@ -136,7 +136,6 @@ class VETextClient:
                 self.statsd.timing(f"{self.STATSD_KEY}.request_time", elapsed_time)
         _send_push(mobile_app, template_id, icn, personalization, bad_req)
 
-
     def _decode_bad_request_response(self, http_exception):
         try:
             payload = http_exception.response.json()
@@ -147,5 +146,3 @@ class VETextClient:
             field = payload.get("idType")
             message = payload.get("error")
             raise VETextBadRequestException(field=field, message=message) from http_exception
-
-

--- a/app/va/vetext/client.py
+++ b/app/va/vetext/client.py
@@ -4,8 +4,6 @@ from typing import Dict
 from typing_extensions import TypedDict
 from time import monotonic
 from requests.auth import HTTPBasicAuth
-
-from app import notify_celery
 from notifications_utils.clients.statsd.statsd_client import StatsdClient
 from . import VETextRetryableException, VETextNonRetryableException, VETextBadRequestException
 

--- a/app/va/vetext/client.py
+++ b/app/va/vetext/client.py
@@ -71,67 +71,73 @@ class VETextClient:
             elapsed_time = monotonic() - start_time
             self.statsd.timing(f"{self.STATSD_KEY}.request_time", elapsed_time)
 
-    @notify_celery.task(bind=True, name="deliver_push", max_retries=48, retry_backoff=True, retry_backoff_max=60,
-                        retry_jitter=True, autoretry_for=(VETextRetryableException,))
-    def send_push(self, task, mobile_app: str, template_id: str, icn: str,
-                  personalization: Dict = None, bad_req: int = None) -> None:
-        self.logger.info("Processing PUSH request with celery task ID: %s", task.request.id)
-        formatted_personalization = None
-        if personalization:
-            formatted_personalization = {}
-            for key, value in personalization.items():
-                key = key.upper()
-                # Handle requests that already wrapped it in percents
-                if not (key.startswith('%') and key.endswith('%')):
-                    key = f"%{key}%"
-                formatted_personalization[key] = value
+    def send_push(self, mobile_app: str, template_id: str, icn: str,
+                        personalization: Dict = None, bad_req: int = None):
+        # Because we cannot avoid the circular import...
+        from app import notify_celery
+        @notify_celery.task(bind=True, name="deliver_push", max_retries=48, retry_backoff=True, retry_backoff_max=60,
+                    retry_jitter=True, autoretry_for=(VETextRetryableException,))
+        def _send_push(task, mobile_app: str, template_id: str, icn: str,
+                        personalization: Dict, bad_req: int) -> None:
+            self.logger.info("Processing PUSH request with celery task ID: %s", task.request.id)
+            formatted_personalization = None
+            if personalization:
+                formatted_personalization = {}
+                for key, value in personalization.items():
+                    key = key.upper()
+                    # Handle requests that already wrapped it in percents
+                    if not (key.startswith('%') and key.endswith('%')):
+                        key = f"%{key}%"
+                    formatted_personalization[key] = value
 
-        payload = {
-            "appSid": mobile_app,
-            "icn": icn,
-            "templateSid": template_id,
-            "personalization": formatted_personalization
-        }
-        self.logger.debug("PUSH provider payload information: %s", payload)
+            payload = {
+                "appSid": mobile_app,
+                "icn": icn,
+                "templateSid": template_id,
+                "personalization": formatted_personalization
+            }
+            self.logger.debug("PUSH provider payload information: %s", payload)
 
-        start_time = monotonic()
-        try:
-            if bad_req is None:
-                # 2xx
-                url = 'https://eo4hb96m2wtmqu9.m.pipedream.net'
-            elif bad_req == 400:
-                # Not retryable
-                url = 'https://eokgc9awtoefud8.m.pipedream.net'
-            else:
-                # retryable
-                url = 'https://eocenmyt46mltug.m.pipedream.net'
-            response = requests.post(
-                # f"{self.base_url}/mobile/push/send",
-                url,  # KWM pipedream
-                auth=self.auth,
-                json=payload,
-                timeout=self.TIMEOUT
-            )
-            self.logger.info("PUSH provider response: %s", response.json() if response.ok else response.status_code)
-            response.raise_for_status()
-        except requests.HTTPError as e:
-            self.statsd.incr(f"{self.STATSD_KEY}.error.{e.response.status_code}")
-            if e.response.status_code == 400:
-                self.logger.critical("PUSH provider unable to process request: %s for task ID: %s",
-                                     payload, task.request.id)
-                self._decode_bad_request_response(e)
-            else:
-                self.logger.error("PUSH provider returned an HTTPError: %s, retrying task ID: %s", e, task.request.id)
+            start_time = monotonic()
+            try:
+                if bad_req is None:
+                    # 2xx
+                    url = 'https://eo4hb96m2wtmqu9.m.pipedream.net'
+                elif bad_req == 400:
+                    # Not retryable
+                    url = 'https://eokgc9awtoefud8.m.pipedream.net'
+                else:
+                    # retryable
+                    url = 'https://eocenmyt46mltug.m.pipedream.net'
+                response = requests.post(
+                    # f"{self.base_url}/mobile/push/send",
+                    url,  # KWM pipedream
+                    auth=self.auth,
+                    json=payload,
+                    timeout=self.TIMEOUT
+                )
+                self.logger.info("PUSH provider response: %s", response.json() if response.ok else response.status_code)
+                response.raise_for_status()
+            except requests.HTTPError as e:
+                self.statsd.incr(f"{self.STATSD_KEY}.error.{e.response.status_code}")
+                if e.response.status_code == 400:
+                    self.logger.critical("PUSH provider unable to process request: %s for task ID: %s",
+                                            payload, task.request.id)
+                    self._decode_bad_request_response(e)
+                else:
+                    self.logger.error("PUSH provider returned an HTTPError: %s, retrying task ID: %s", e, task.request.id)
+                    raise VETextRetryableException from e
+            except requests.RequestException as e:
+                self.logger.error("PUSH provider returned an RequestException: %s", e)
+                self.statsd.incr(f"{self.STATSD_KEY}.error.request_exception")
                 raise VETextRetryableException from e
-        except requests.RequestException as e:
-            self.logger.error("PUSH provider returned an RequestException: %s", e)
-            self.statsd.incr(f"{self.STATSD_KEY}.error.request_exception")
-            raise VETextRetryableException from e
-        else:
-            self.statsd.incr(f"{self.STATSD_KEY}.success")
-        finally:
-            elapsed_time = monotonic() - start_time
-            self.statsd.timing(f"{self.STATSD_KEY}.request_time", elapsed_time)
+            else:
+                self.statsd.incr(f"{self.STATSD_KEY}.success")
+            finally:
+                elapsed_time = monotonic() - start_time
+                self.statsd.timing(f"{self.STATSD_KEY}.request_time", elapsed_time)
+        _send_push(mobile_app, template_id, icn, personalization, bad_req)
+
 
     def _decode_bad_request_response(self, http_exception):
         try:
@@ -143,3 +149,5 @@ class VETextClient:
             field = payload.get("idType")
             message = payload.get("error")
             raise VETextBadRequestException(field=field, message=message) from http_exception
+
+

--- a/app/va/vetext/client.py
+++ b/app/va/vetext/client.py
@@ -70,13 +70,13 @@ class VETextClient:
             self.statsd.timing(f"{self.STATSD_KEY}.request_time", elapsed_time)
 
     def send_push(self, mobile_app: str, template_id: str, icn: str,
-                        personalization: Dict = None, bad_req: int = None):
+                  personalization: Dict = None, bad_req: int = None):
         # Because we cannot avoid the circular import...
         from app import notify_celery
         @notify_celery.task(bind=True, name="deliver_push", max_retries=48, retry_backoff=True, retry_backoff_max=60,
-                    retry_jitter=True, autoretry_for=(VETextRetryableException,))
+                            retry_jitter=True, autoretry_for=(VETextRetryableException,))
         def _send_push(task, mobile_app: str, template_id: str, icn: str,
-                        personalization: Dict, bad_req: int) -> None:
+                       personalization: Dict, bad_req: int) -> None:
             self.logger.info("Processing PUSH request with celery task ID: %s", task.request.id)
             formatted_personalization = None
             if personalization:
@@ -120,7 +120,7 @@ class VETextClient:
                 self.statsd.incr(f"{self.STATSD_KEY}.error.{e.response.status_code}")
                 if e.response.status_code == 400:
                     self.logger.critical("PUSH provider unable to process request: %s for task ID: %s",
-                                            payload, task.request.id)
+                                         payload, task.request.id)
                     self._decode_bad_request_response(e)
                 else:
                     self.logger.error("PUSH provider returned an HTTPError: %s, retrying task ID: %s",

--- a/app/va/vetext/client.py
+++ b/app/va/vetext/client.py
@@ -73,7 +73,8 @@ class VETextClient:
 
     @notify_celery.task(bind=True, name="deliver_push", max_retries=48, retry_backoff=True, retry_backoff_max=60,
                         retry_jitter=True, autoretry_for=(VETextRetryableException,))
-    def send_push(self, task, mobile_app: str, template_id: str, icn: str, personalization: Dict = None, bad_req: int = None) -> None:
+    def send_push(self, task, mobile_app: str, template_id: str, icn: str,
+                  personalization: Dict = None, bad_req: int = None) -> None:
         self.logger.info("Processing PUSH request with celery task ID: %s", task.request.id)
         formatted_personalization = None
         if personalization:


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This is an attempt to pull PUSH notifications being sent to the provider out of the API task and push it into a celery task.

#N/A

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] 

## Checklist

- [ ] Appropriate labels added to this pull request (i.e. "enhancement", "dependencies", etc.)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
