### PR TITLE
Exception Retry Hotfix

### DIFF
--- a/app/celery/common.py
+++ b/app/celery/common.py
@@ -4,6 +4,7 @@ from flask import current_app
 
 
 RETRIES_EXCEEDED = "Retries exceeded"
+TECHNICAL_ERROR = "VA Notify non-retryable technical error"
 
 
 def can_retry(retries: int, max_retries: int, notification_id: str) -> bool:
@@ -22,5 +23,18 @@ def handle_max_retries_exceeded(notification_id: str, method_name: str) -> str:
         notification_id,
         NOTIFICATION_TECHNICAL_FAILURE,
         status_reason=RETRIES_EXCEEDED
+    )
+    return message
+
+
+def handle_non_retryable(notification_id: str, method_name: str) -> str:
+    """ Handles sms/email deliver requests that failed in a non-retryable manner """
+    current_app.logger.critical("%s: Notification %s encountered a non-retryable exception",
+                                method_name, notification_id)
+    message = "Notification has been updated to technical-failure due to a non-retryable exception"
+    update_notification_status_by_id(
+        notification_id,
+        NOTIFICATION_TECHNICAL_FAILURE,
+        status_reason=TECHNICAL_ERROR
     )
     return message

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -53,7 +53,7 @@ def deliver_sms(self, notification_id, sms_sender_id=None):
         notification = notifications_dao.get_notification_by_id(notification_id)
         check_and_queue_callback_task(notification)
     except NullValueForNonConditionalPlaceholderException:
-        msg = handle_non_retryable(notification_id, 'deliver_email')
+        msg = handle_non_retryable(notification_id, 'deliver_sms')
         raise NotificationTechnicalFailureException(msg)
     except Exception as e:
         current_app.logger.exception(

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -1,5 +1,5 @@
 from app import notify_celery
-from app.celery.common import can_retry, handle_max_retries_exceeded
+from app.celery.common import can_retry, handle_max_retries_exceeded, handle_non_retryable
 from app.celery.exceptions import NonRetryableException, AutoRetryException
 from app.celery.service_callback_tasks import check_and_queue_callback_task
 from app.clients.email.aws_ses import AwsSesClientThrottlingSendRateException
@@ -12,6 +12,7 @@ from app.exceptions import NotificationTechnicalFailureException, MalwarePending
 from app.models import NOTIFICATION_TECHNICAL_FAILURE, NOTIFICATION_PERMANENT_FAILURE
 from app.v2.errors import RateLimitError
 from flask import current_app
+from notifications_utils.field import NullValueForNonConditionalPlaceholderException
 from notifications_utils.recipients import InvalidEmailError
 from notifications_utils.statsd_decorators import statsd
 
@@ -51,6 +52,9 @@ def deliver_sms(self, notification_id, sms_sender_id=None):
         )
         notification = notifications_dao.get_notification_by_id(notification_id)
         check_and_queue_callback_task(notification)
+    except NullValueForNonConditionalPlaceholderException:
+        msg = handle_non_retryable(notification_id, 'deliver_email')
+        raise NotificationTechnicalFailureException(msg)
     except Exception as e:
         current_app.logger.exception(
             "SMS delivery for notification id: %s failed", notification_id
@@ -106,6 +110,9 @@ def deliver_sms_with_rate_limiting(self, notification_id, sms_sender_id=None):
         )
 
         self.retry(queue=QueueNames.RATE_LIMIT_RETRY, max_retries=None, countdown=retry_time)
+    except NullValueForNonConditionalPlaceholderException:
+        msg = handle_non_retryable(notification_id, 'deliver_sms_with_rate_limiting')
+        raise NotificationTechnicalFailureException(msg)
     except Exception as e:
         current_app.logger.exception(
             "Rate Limit SMS notification delivery for id: %s failed", notification_id
@@ -155,6 +162,9 @@ def deliver_email(self, notification_id: str, sms_sender_id=None):
             status_reason="Email provider configuration invalid"
         )
         raise NotificationTechnicalFailureException(str(e))
+    except NullValueForNonConditionalPlaceholderException:
+        msg = handle_non_retryable(notification_id, 'deliver_email')
+        raise NotificationTechnicalFailureException(msg)
     except Exception as e:
         current_app.logger.exception(
             "Email delivery for notification id: %s failed", notification_id


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This fixes an exception that the utils repo was throwing due to a bug. In the API the Celery `autoretry_for` code replaced anywhere the previous team(s) called `task.retry()`. This in itself was fine but we increased the retry time to 24 hours. This caused a little-known feature to raise an infinitely growing number of requests. Every 4 hours and 15 minutes the system checks for any notifications in the "created" status and tries to send them again. This happens every 15 minutes. There is another method that moves `created` tasks to `technical-failure` if they are not processed in time, so there was a second exception being thrown for those. Those were a result of the utils bug, so nothing was changed for that. 

When retries were limited to 4 hours that was not an issue. When we gave it the ability to retry for 24 hours it would see the error'ing notification stuck in the `created` status and it would try to send it again (queue a task) every 15 minutes. This caused our queues to grow huge and they would have never stopped. 

The utils repo issue is being fixed in a separate ticket. This ticket exists to ensure it cannot happen in prod while we fix utils. 


# (issue) N/A

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
This was [deployed to Dev](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/5789723890) and the offending exception is now handled and not retried:
![image](https://github.com/department-of-veterans-affairs/notification-api/assets/16893311/c9ef046e-e2a9-48c1-aaca-6ac10534d72c)

Queue purged and not refilling:
![image](https://github.com/department-of-veterans-affairs/notification-api/assets/16893311/bd8772cf-0a77-44fc-a416-a427463f4abf)

## Checklist

- [x] Appropriate labels added to this pull request (i.e. "enhancement", "dependencies", etc.)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
