### PR TITLE
Upgrade Postgres containers from v11 to v15

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11
+        image: postgres:15
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ This application defines Docker images for production, testing, and development 
 |------------|----------------|-------|-----------------------|
 | Python 3.8 | 14 October 2024 | | Dockerfile, Dockerfile.local |
 | Alpine Linux 3.16 | 23 May 2024 | | Dockerfile, Dockerfile.local |
-| Postgres 11 | [9 November 2023](https://www.postgresql.org/support/versioning/) | | docker-compose.yml, docker-compose-local.yml, docker-compose-local-migrate.yml, docker-compose-test.yml |
+| Postgres 15 | [11 November 2027](https://www.postgresql.org/support/versioning/) | | docker-compose.yml, docker-compose-local.yml, docker-compose-local-migrate.yml, docker-compose-test.yml |
 | localstack | None given.  The YAML files specifies v0.12.3.  As of March 2022, v0.14.1 is available. | As of March 2022, localstack requires Python 3.6-3.9. | docker-compose-local.yml |
 | bbyars/mountebank 2.4.0 | None given. | Newer versions are available. | docker-compose-local.yml |
 | redis | | No version specified. | docker-compose-local.yml |

--- a/ci/docker-compose-local-migrate.yml
+++ b/ci/docker-compose-local-migrate.yml
@@ -14,7 +14,7 @@ services:
       - localstack
     command: ["bash", "-c", "flask db migrate"]
   db:
-    image: postgres:11
+    image: postgres:15
     restart: unless-stopped
     ports:
       - 5432:5432

--- a/ci/docker-compose-local.yml
+++ b/ci/docker-compose-local.yml
@@ -15,7 +15,7 @@ services:
       - migrations
       - localstack
   db:
-    image: postgres:11
+    image: postgres:15
     restart: unless-stopped
     ports:
       - 5432:5432

--- a/ci/docker-compose-test.yml
+++ b/ci/docker-compose-test.yml
@@ -28,7 +28,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres:11
+    image: postgres:15
     restart: unless-stopped
     ports:
       - 5432:5432

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres:11
+    image: postgres:15
     restart: unless-stopped
     ports:
       - 5432:5432

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -757,7 +757,7 @@ def test_create_service_and_history_is_transactional(notify_db_session):
     with pytest.raises(IntegrityError) as excinfo:
         dao_create_service(service, user)
 
-    assert 'column "name" violates not-null constraint' in str(excinfo.value)
+    assert 'column "name" of relation "services_history" violates not-null constraint' in str(excinfo.value)
     assert Service.query.count() == 0
     assert Service.get_history_model().query.count() == 0
 


### PR DESCRIPTION
# Description

Upgrade Postgres containers from v11 to v15.  This is part of [vanotify-infra 528](https://github.com/department-of-veterans-affairs/vanotify-infra/issues/528).

I made a minor change to one unit test that looks for specific error output from the database.  The newer version of Postgres slightly modifies this output by providing more information.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Ran all unit tests locally

## Checklist

- [x] Appropriate labels added to this pull request (i.e. "enhancement", "dependencies", etc.)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes