### PR TITLE
#1419 Hotfix AttributeError and  RuntimeError catch

### DIFF
--- a/app/celery/common.py
+++ b/app/celery/common.py
@@ -27,7 +27,7 @@ def handle_max_retries_exceeded(notification_id: str, method_name: str) -> str:
     return message
 
 
-def handle_non_retryable(notification_id: str, method_name: str):
+def handle_non_retryable(notification_id: str, method_name: str) -> None:
     """ Handles sms/email deliver requests that failed in a non-retryable manner """
     current_app.logger.critical("%s: Notification %s encountered a non-retryable exception and "
                                 "has been updated to a technical-failure",

--- a/app/celery/common.py
+++ b/app/celery/common.py
@@ -30,7 +30,7 @@ def handle_max_retries_exceeded(notification_id: str, method_name: str) -> str:
 def handle_non_retryable(notification_id: str, method_name: str):
     """ Handles sms/email deliver requests that failed in a non-retryable manner """
     current_app.logger.critical("%s: Notification %s encountered a non-retryable exception and "
-                                "has been updated to a technical-failure due to a non-retryable exception",
+                                "has been updated to a technical-failure",
                                 method_name, notification_id)
     update_notification_status_by_id(
         notification_id,

--- a/app/celery/common.py
+++ b/app/celery/common.py
@@ -27,14 +27,13 @@ def handle_max_retries_exceeded(notification_id: str, method_name: str) -> str:
     return message
 
 
-def handle_non_retryable(notification_id: str, method_name: str) -> str:
+def handle_non_retryable(notification_id: str, method_name: str):
     """ Handles sms/email deliver requests that failed in a non-retryable manner """
-    current_app.logger.critical("%s: Notification %s encountered a non-retryable exception",
+    current_app.logger.critical("%s: Notification %s encountered a non-retryable exception and "
+                                "has been updated to a technical-failure due to a non-retryable exception",
                                 method_name, notification_id)
-    message = "Notification has been updated to technical-failure due to a non-retryable exception"
     update_notification_status_by_id(
         notification_id,
         NOTIFICATION_TECHNICAL_FAILURE,
         status_reason=TECHNICAL_ERROR
     )
-    return message

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -52,9 +52,9 @@ def deliver_sms(self, notification_id, sms_sender_id=None):
         )
         notification = notifications_dao.get_notification_by_id(notification_id)
         check_and_queue_callback_task(notification)
-    except NullValueForNonConditionalPlaceholderException:
-        msg = handle_non_retryable(notification_id, 'deliver_sms')
-        raise NotificationTechnicalFailureException(msg)
+    except (NullValueForNonConditionalPlaceholderException, AttributeError, RuntimeError) as e:
+        handle_non_retryable(notification_id, 'deliver_sms')
+        raise NotificationTechnicalFailureException(f'Found {type(e).__name__}, NOT retrying...', e, e.args)
     except Exception as e:
         current_app.logger.exception(
             "SMS delivery for notification id: %s failed", notification_id
@@ -110,9 +110,9 @@ def deliver_sms_with_rate_limiting(self, notification_id, sms_sender_id=None):
         )
 
         self.retry(queue=QueueNames.RATE_LIMIT_RETRY, max_retries=None, countdown=retry_time)
-    except NullValueForNonConditionalPlaceholderException:
-        msg = handle_non_retryable(notification_id, 'deliver_sms_with_rate_limiting')
-        raise NotificationTechnicalFailureException(msg)
+    except (NullValueForNonConditionalPlaceholderException, AttributeError, RuntimeError) as e:
+        handle_non_retryable(notification_id, 'deliver_sms_with_rate_limiting')
+        raise NotificationTechnicalFailureException(f'Found {type(e).__name__}, NOT retrying...', e, e.args)
     except Exception as e:
         current_app.logger.exception(
             "Rate Limit SMS notification delivery for id: %s failed", notification_id
@@ -162,9 +162,9 @@ def deliver_email(self, notification_id: str, sms_sender_id=None):
             status_reason="Email provider configuration invalid"
         )
         raise NotificationTechnicalFailureException(str(e))
-    except NullValueForNonConditionalPlaceholderException:
-        msg = handle_non_retryable(notification_id, 'deliver_email')
-        raise NotificationTechnicalFailureException(msg)
+    except (NullValueForNonConditionalPlaceholderException, AttributeError, RuntimeError) as e:
+        handle_non_retryable(notification_id, 'deliver_email')
+        raise NotificationTechnicalFailureException(f'Found {type(e).__name__}, NOT retrying...', e, e.args)
     except Exception as e:
         current_app.logger.exception(
             "Email delivery for notification id: %s failed", notification_id


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This hotfix enables us to catch `AttributeError` and `RuntimeError` exceptions thrown by the `deliver_sms_with_rate_limiting()`, `deliver_sms()`, and `deliver_email()` methods. The cause of these exceptions are being investigated still, but a fix should be coming. This is a hotfix so that regardless of Attribute or Runtime error we do not retry, as those are errors that should never allow retries. There is a related bugfix being worked to address the cause of the AttributeError appearing in the first place.

#1419 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Workaround - does not fix the bug that caused `AttributeError`s and `RuntimeError`s to be raised
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

This same code was deployed to stop the flood of retries that were happening. A [second deploy](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/5868488933) was made as well. QA Regression ran against the Dev Deploy and all tests passed.

## Checklist

- [x] Appropriate labels added to this pull request (i.e. "enhancement", "dependencies", etc.)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
