### PR TITLE
1344 - Authenticate via Reader instance

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,6 +52,7 @@ jobs:
           NOTIFY_ENVIRONMENT: test
           RETRY_SQS_URL: RETRY_SQS_URL
           SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@localhost/test_notification_api
+          SQLALCHEMY_DATABASE_URI_READ: postgresql://postgres:postgres@localhost/test_notification_api
           TIMEOUT: 10
           VA_PROFILE_DOMAIN: int.vaprofile.va.gov
           VETEXT_API_AUTH_SSM_PATH: test

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -97,7 +97,11 @@ def create_app(application, worker_id=None):
     if notify_environment == "test":
         assert worker_id is not None
         application.config["SQLALCHEMY_DATABASE_URI"] += f"_{worker_id}"
+        # set read-db to be the same as write/default instance for testing
+        application.config["SQLALCHEMY_BINDS"] = {"read-db": application.config["SQLALCHEMY_DATABASE_URI"]}
         assert "test_notification_api" in application.config["SQLALCHEMY_DATABASE_URI"], \
+            "Don't run tests against the main database."
+        assert "test_notification_api" in application.config["SQLALCHEMY_DATABASE_URI_READ"], \
             "Don't run tests against the main database."
 
     application.config["NOTIFY_APP_NAME"] = application.name

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -101,7 +101,7 @@ def create_app(application, worker_id=None):
         application.config["SQLALCHEMY_BINDS"] = {"read-db": application.config["SQLALCHEMY_DATABASE_URI"]}
         assert "test_notification_api" in application.config["SQLALCHEMY_DATABASE_URI"], \
             "Don't run tests against the main database."
-        assert "test_notification_api" in application.config["SQLALCHEMY_DATABASE_URI_READ"], \
+        assert "test_notification_api" in application.config["SQLALCHEMY_BINDS"]["read-db"], \
             "Don't run tests against the main database."
 
     application.config["NOTIFY_APP_NAME"] = application.name

--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -15,6 +15,7 @@ def extract_cloudfoundry_config():
 def set_config_env_vars(vcap_services):
     # Postgres config
     os.environ['SQLALCHEMY_DATABASE_URI'] = vcap_services['postgres'][0]['credentials']['uri']
+    os.environ['SQLALCHEMY_DATABASE_URI_READ'] = vcap_services['postgres'][0]['credentials']['uri']
 
     vcap_application = json.loads(os.environ['VCAP_APPLICATION'])
     os.environ['NOTIFY_ENVIRONMENT'] = vcap_application['space_name']

--- a/app/config.py
+++ b/app/config.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 from fido2.server import Fido2Server
 from fido2.webauthn import PublicKeyCredentialRpEntity
 from kombu import Exchange, Queue
+import logging
 
 
 load_dotenv()
@@ -593,6 +594,10 @@ class Staging(Config):
     FROM_NUMBER = '+18555420534'
 
     SESSION_COOKIE_SECURE = True
+    SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI')
+    SQLALCHEMY_BINDS = {"read-db": os.getenv("SQLALCHEMY_DATABASE_URI_READ")}
+    if SQLALCHEMY_BINDS['read-db'] is None:
+        logging.critical("Missing SQLALCHEMY_DATABASE_URI_READ")
 
 
 class Production(Config):
@@ -611,6 +616,11 @@ class Production(Config):
     FROM_NUMBER = '+18334981539'
 
     SESSION_COOKIE_SECURE = True
+
+    SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI')
+    SQLALCHEMY_BINDS = {"read-db": os.getenv("SQLALCHEMY_DATABASE_URI_READ")}
+    if SQLALCHEMY_BINDS['read-db'] is None:
+        logging.critical("Missing SQLALCHEMY_DATABASE_URI_READ")
 
 
 configs = {

--- a/app/config.py
+++ b/app/config.py
@@ -108,6 +108,7 @@ class Config(object):
 
     # DB conection string
     SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI')
+    SQLALCHEMY_BINDS = {"read-db": os.getenv('SQLALCHEMY_DATABASE_URI_READ')}
 
     # MMG API Key
     MMG_API_KEY = os.getenv('MMG_API_KEY')
@@ -514,6 +515,10 @@ class Development(Config):
         "SQLALCHEMY_DATABASE_URI",
         'postgresql://postgres@localhost/notification_api')
 
+    SQLALCHEMY_BINDS = {"read-db": os.getenv(
+        "SQLALCHEMY_DATABASE_URI_READ",
+        'postgresql://postgres@localhost/notification_api')}
+
     ANTIVIRUS_ENABLED = os.getenv('ANTIVIRUS_ENABLED') == '1'
 
     for queue in QueueNames.all_queues():
@@ -543,6 +548,9 @@ class Test(Development):
         'SQLALCHEMY_DATABASE_URI',
         'postgresql://postgres@localhost/test_notification_api'
     )
+    SQLALCHEMY_BINDS = {"read-db": os.getenv(
+        "SQLALCHEMY_DATABASE_URI_READ",
+        'postgresql://postgres@localhost/notification_api')}
 
     CELERY_SETTINGS = {
         'broker_url': 'you-forgot-to-mock-celery-in-your-tests://'

--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -17,7 +17,8 @@ from sqlalchemy import or_, func
 def save_model_api_key(api_key):
     if not api_key.id:
         api_key.id = uuid.uuid4()  # must be set now so version history model can use same id
-    api_key.secret = uuid.uuid4()
+    if not api_key.secret:
+        api_key.secret = uuid.uuid4()
     db.session.add(api_key)
 
 

--- a/app/dao/dao_utils.py
+++ b/app/dao/dao_utils.py
@@ -2,6 +2,8 @@ import itertools
 from app import db
 from app.history_meta import create_history
 from functools import wraps
+from contextlib import contextmanager
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 
 def transactional(func):
@@ -79,3 +81,26 @@ def version_class(*version_options):
 
 def dao_rollback():
     db.session.rollback()
+
+
+@contextmanager
+def get_reader_session():
+    """
+    This context manager is used to abstract the connection to the read-only database engine
+    in order to execute read queries. By using a scoped session, it ensures that the session
+    is thread-local and can be reused if needed. It ensures proper handling of the session's
+    lifecycle by closing it when the context is exited.
+
+    Yields:
+        session (scoped_session): A session connected to the read-only database engine.
+
+    Example Usage:
+        with get_reader_session() as session:
+            result = session.query(Service).filter_by(id=service_id).one()
+    """
+    engine = db.engines['read-db']
+    session = scoped_session(sessionmaker(bind=engine))
+    try:
+        yield session
+    finally:
+        session.close()

--- a/app/models.py
+++ b/app/models.py
@@ -34,7 +34,7 @@ from sqlalchemy.dialects.postgresql import JSON, JSONB, UUID
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm.collections import attribute_mapped_collection
+from sqlalchemy.orm.collections import attribute_mapped_collection, InstrumentedList
 
 
 SMS_TYPE = 'sms'
@@ -448,8 +448,20 @@ class Service(db.Model, Versioned):
         default_letter_contact = [x for x in self.letter_contacts if x.is_default]
         return default_letter_contact[0].contact_block if default_letter_contact else None
 
-    def has_permission(self, permission):
-        return permission in [p.permission for p in self.permissions]
+    def has_permissions(self, permissions_to_check_for):
+        if isinstance(permissions_to_check_for, InstrumentedList):
+            _permissions_to_check_for = [p.permission for p in permissions_to_check_for]
+        elif not isinstance(permissions_to_check_for, list):
+            _permissions_to_check_for = [permissions_to_check_for]
+        else:
+            _permissions_to_check_for = permissions_to_check_for
+
+        if isinstance(self.permissions, InstrumentedList):
+            _permissions = [p.permission for p in self.permissions]
+        else:
+            _permissions = self.permissions
+
+        return frozenset(_permissions_to_check_for).issubset(frozenset(_permissions))
 
     def serialize_for_org_dashboard(self):
         return {

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -96,7 +96,6 @@ def persist_notification(
         template_version=template_version,
         to=recipient,
         service_id=service.id,
-        service=service,
         personalisation=personalisation,
         notification_type=notification_type,
         api_key_id=api_key_id,

--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -223,7 +223,7 @@ def fetch_potential_service(inbound_number: str, provider_name: str) -> Service:
         current_app.logger.error(message)
         raise NoSuitableServiceForInboundSms(message)
 
-    elif not has_inbound_sms_permissions(service.permissions):
+    elif not service.has_permissions([INBOUND_SMS_TYPE, SMS_TYPE]):
         statsd_client.incr(f"inbound.{provider_name}.failed")
         message = f'Service "{service.id}" does not allow inbound SMS'
         current_app.logger.error(message)
@@ -231,11 +231,6 @@ def fetch_potential_service(inbound_number: str, provider_name: str) -> Service:
 
     else:
         return service
-
-
-def has_inbound_sms_permissions(permissions):
-    str_permissions = [p.permission for p in permissions]
-    return set([INBOUND_SMS_TYPE, SMS_TYPE]).issubset(set(str_permissions))
 
 
 def strip_leading_forty_four(number):

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -23,7 +23,6 @@ from app.service.utils import service_allowed_to_send_to
 from app.v2.errors import TooManyRequestsError, BadRequestError, RateLimitError
 from app import redis_store
 from app.notifications.process_notifications import create_content_for_notification
-from app.utils import get_public_notify_type_text
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
 from app.dao.service_letter_contact_dao import dao_get_letter_contact_by_id
 
@@ -108,16 +107,12 @@ def service_can_send_to_recipient(send_to, key_type, service, allow_whitelisted_
         raise BadRequestError(message=message)
 
 
+# TODO #1410 clean up and remove
 def service_has_permission(notify_type, permissions):
     return notify_type in [p.permission for p in permissions]
 
 
-def check_service_has_permission(notify_type, permissions):
-    if not service_has_permission(notify_type, permissions):
-        raise BadRequestError(message="Service is not allowed to send {}".format(
-            get_public_notify_type_text(notify_type, plural=True)))
-
-
+# TODO #1410 clean up and remove
 def check_service_can_schedule_notification(permissions, scheduled_for):
     if scheduled_for:
         if not service_has_permission(SCHEDULE_NOTIFICATIONS, permissions):
@@ -131,15 +126,14 @@ def validate_and_format_recipient(send_to, key_type, service, notification_type,
     service_can_send_to_recipient(send_to, key_type, service, allow_whitelisted_recipients)
 
     if notification_type == SMS_TYPE:
-        international_phone_info = get_international_phone_info(send_to)
+        phone_info = get_international_phone_info(send_to)
 
-        if international_phone_info.international and \
-                INTERNATIONAL_SMS_TYPE not in [p.permission for p in service.permissions]:
+        if phone_info.international and not service.has_permissions(INTERNATIONAL_SMS_TYPE):
             raise BadRequestError(message="Cannot send to international mobile numbers")
 
         return validate_and_format_phone_number(
             number=send_to,
-            international=international_phone_info.international
+            international=phone_info.international
         )
     elif notification_type == EMAIL_TYPE:
         return validate_and_format_email_address(email_address=send_to)

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -8,7 +8,6 @@ from app.dao.notifications_dao import _update_notification_status
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
 from app.dao.service_sms_sender_dao import dao_get_service_sms_sender_by_id
 from app.notifications.validators import (
-    check_service_has_permission,
     check_service_over_daily_message_limit,
     validate_and_format_recipient,
     validate_template
@@ -35,6 +34,7 @@ from app.letters.utils import (
     move_uploaded_pdf_to_letters_bucket,
 )
 from app.v2.errors import BadRequestError
+from app.utils import get_public_notify_type_text
 
 
 def validate_created_by(service, created_by_id):
@@ -135,8 +135,14 @@ def get_reply_to_text(notification_type, sender_id, service, template):
 def send_pdf_letter_notification(service_id, post_data):
     service = dao_fetch_service_by_id(service_id)
 
-    check_service_has_permission(LETTER_TYPE, service.permissions)
-    check_service_has_permission(UPLOAD_LETTERS, service.permissions)
+    if not service.has_permissions(LETTER_TYPE):
+        raise BadRequestError(message="Service is not allowed to send {}".format(
+            get_public_notify_type_text(LETTER_TYPE, plural=True)))
+
+    if not service.has_permissions(UPLOAD_LETTERS):
+        raise BadRequestError(message="Service is not allowed to send {}".format(
+            get_public_notify_type_text(UPLOAD_LETTERS, plural=True)))
+
     check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
     validate_created_by(service, post_data['created_by'])
 

--- a/app/service/service_data.py
+++ b/app/service/service_data.py
@@ -1,0 +1,215 @@
+import json
+from types import SimpleNamespace
+from typing import List, Union
+
+from app.models import Service
+
+
+class ServiceDataException(Exception):
+    """
+    Custom exception class for handling specific errors related to the ServiceData class.
+
+    Attributes:
+        message (str): A custom message describing the error.
+
+    Usage:
+        raise ServiceDataException("Description...")
+    """
+
+    def __init__(
+        self,
+        message="Unable to create ServiceData object.",
+        *args,
+        **kwargs
+    ):
+        super().__init__(message, *args, **kwargs)
+
+
+class ServiceDataApiKey:
+    """
+    A class to encapsulate information related to an authenticated service's API key.
+
+    This class serves as a data structure to hold the essential properties of an API key
+    associated with an authenticated service. It includes a simplified representation of
+    related service attributes (research mode, restricted, and active status).
+
+    This is needed to deal with circular dependency and multilevel nesting in previously
+    created SQLAlchemy model.
+
+    Creating simple namespance to preseve dot notation used in calling functions.
+
+    Attributes:
+        created_at (datetime): The timestamp when the API key was created.
+        created_by (User): The user who created the API key.
+        created_by_id (str): The ID of the user who created the API key.
+        expiry_date (datetime): The expiry date of the API key.
+        id (str): The unique identifier of the API key.
+        key_type (str): The type of the API key (e.g., "normal").
+        name (str): The name of the API key.
+        secret (str): The secret string associated with the API key.
+        service (SimpleNamespace): A namespace containing the 'research_mode',
+            'restricted', and 'active' attributes of the related service.
+        service_id (str): The ID of the related service.
+        updated_at (datetime): The timestamp when the API key was last updated.
+    """
+
+    def __init__(self, key) -> None:
+        """
+        Args:
+            key (object): The object containing the necessary attributes for the API key.
+        """
+        self.created_at = key.created_at
+        self.created_by = key.created_by
+        self.created_by_id = key.created_by_id
+        self.expiry_date = key.expiry_date
+        self.id = key.id
+        self.key_type = key.key_type
+        self.name = key.name
+        self.secret = key.secret
+
+        _service = {
+            "research_mode": key.service.research_mode,
+            "restricted": key.service.restricted,
+            "active": key.service.active,
+        }
+        self.service = SimpleNamespace(**_service)
+        self.service_id = key.service_id
+        self.updated_at = key.updated_at
+
+    def __eq__(self, other: 'ServiceDataApiKey') -> bool:
+        """
+        Determines equality between two instances of ServiceDataApiKey.
+
+        Two instances of ServiceDataApiKey are considered equal if they have the same values for
+        the following attributes:
+            - id
+            - name
+            - key_type
+            - created_by_id
+            - service_id
+            - secret
+
+        Args:
+            other (ServiceDataApiKey): The object to compare against.
+
+        Returns:
+            bool: True if the instances have the same values for the relevant attributes, False otherwise.
+        """
+        if isinstance(other, ServiceDataApiKey):
+            return self.id == other.id\
+                and self.key_type == other.key_type\
+                and self.name == other.name\
+                and self.service_id == other.service_id\
+                and self.created_by_id == other.created_by_id\
+                and self.secret == other.secret
+        return False
+
+
+class ServiceData:
+    """
+    Represents the relevant information extracted from an SQLAlchemy query result.
+
+    This class was created to allow for reading from multiple databases and to facilitate caching.
+    By extracting only the necessary information from the query result, it ensures compatibility
+    across different database connections and enables efficient serialization for caching purposes.
+    The extraction of specific information rather than working with entire query results provides a
+    more controlled and optimized way to handle the data.
+
+    Attributes:
+        active (bool): A flag indicating whether the service is active.
+        permissions (list): A list of permissions associated with the service.
+        api_keys (list): A list of API keys associated with the service.
+        id (int): The unique identifier of the service.
+        research_mode (bool): A flag indicating whether the service is in research mode.
+        restricted (bool): A flag indicating whether the service is restricted.
+        rate_limit (int): The rate limit applied to the service.
+        service_sms_senders (list): A list of SMS senders associated with the service.
+        message_limit (int): The message limit applied to the service.
+        users (list): A list of users associated with the service.
+        whitelist (list): A list of whitelisted entities for the service.
+
+    Methods:
+        <List the methods here, if applicable>
+    """
+
+    def __init__(self, result=None):
+        self.active = None
+        self.permissions = None
+        self.api_keys = None
+        self.id = None
+        self.research_mode = None
+        self.restricted = None
+        self.rate_limit = None
+        self.service_sms_senders = None
+        self.message_limit = None
+        self.users = None
+        self.whitelist = None
+        if result is not None:
+            try:
+                self.extract(result)
+            except Exception as err:
+                raise ServiceDataException(err)
+
+    def extract(self, result: Service) -> None:
+        """
+        Extracts the necessary data from an authenticated service ORM object.
+
+        Args:
+            result: The ORM object containing the data. WARNING it's not pure Service
+                object, but Service augmented with api_keys
+
+        Returns:
+            None
+        """
+        self.active = result.active
+        self.permissions = [p.permission for p in result.permissions]
+        self.api_keys = [ServiceDataApiKey(key) for key in result.api_keys]
+        self.id = result.id
+        self.research_mode = result.research_mode
+        self.restricted = result.restricted
+        self.rate_limit = result.rate_limit
+        self.service_sms_senders = result.service_sms_senders
+        self.message_limit = result.message_limit
+        self.users = [u for u in result.users]
+        self.whitelist = [w for w in result.whitelist]
+
+    def serialize(self) -> str:
+        """
+        Serializes the object into a JSON string.
+        This method might be used for caching, allowing the object to be easily stored and retrieved.
+
+        Returns:
+            str: A JSON string.
+        """
+        return json.dumps(self.__dict__)
+
+    def has_permissions(self, permissions_to_check_for: Union[str, List[str]]) -> bool:
+        """
+        Checks if the object has the specified permissions.
+
+        Args:
+            permissions_to_check_for (list): A list or a single permission to check for.
+
+        Returns:
+            bool: True if all specified permissions are present, False otherwise.
+        """
+        if not isinstance(permissions_to_check_for, list):
+            tmp = permissions_to_check_for
+            permissions_to_check_for = [tmp]
+        return frozenset(permissions_to_check_for).issubset(frozenset(self.permissions))
+
+    @classmethod
+    def deserialize(cls, json_string: str) -> 'ServiceData':
+        """
+        Creates a new instance of the class using a JSON string.
+        This method might be used after retrieval from caching, allowing the object to be reconstructed.
+
+        Args:
+            json_string (str): A JSON string representing the object.
+
+        Returns:
+            ServiceData: A new instance of the class populated with the data from the JSON string.
+        """
+        result = cls()
+        result.__dict__ = json.loads(json_string)
+        return result

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -98,6 +98,7 @@ def create_template(service_id):
         errors = {'content': [message]}
         raise InvalidRequest(errors, status_code=400)
 
+    # TODO #1410 clean up validator, use class method instead.
     if not service_has_permission(new_template.template_type, permissions):
         message = "Creating {} templates is not allowed".format(
             get_public_notify_type_text(new_template.template_type))

--- a/app/v2/notifications/rest_push.py
+++ b/app/v2/notifications/rest_push.py
@@ -7,9 +7,6 @@ from app.mobile_app import MobileAppRegistry, MobileAppType, DEAFULT_MOBILE_APP_
 from app.models import (
     PUSH_TYPE
 )
-from app.notifications.validators import (
-    check_service_has_permission
-)
 from app.schema_validation import validate
 from app.v2.errors import BadRequestError
 from app.v2.notifications import v2_notification_blueprint
@@ -17,6 +14,7 @@ from app.v2.notifications.notification_schemas import (
     push_notification_request
 )
 from app.va.vetext import (VETextRetryableException, VETextNonRetryableException, VETextBadRequestException)
+from app.utils import get_public_notify_type_text
 
 
 @v2_notification_blueprint.route('/push', methods=['POST'])
@@ -24,7 +22,10 @@ def send_push_notification():
     if not is_feature_enabled(FeatureFlag.PUSH_NOTIFICATIONS_ENABLED):
         raise NotImplementedError()
 
-    check_service_has_permission(PUSH_TYPE, authenticated_service.permissions)
+    if not authenticated_service.has_permissions(PUSH_TYPE):
+        raise BadRequestError(message="Service is not allowed to send {}".format(
+            get_public_notify_type_text(PUSH_TYPE, plural=True)))
+
     req_json = validate(request.get_json(), push_notification_request)
     registry = MobileAppRegistry()
 

--- a/cd/application-deployment/dev/vaec-api-task-definition.json
+++ b/cd/application-deployment/dev/vaec-api-task-definition.json
@@ -257,6 +257,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/database/uri_read"
+        },
+        {
           "name": "TWILIO_ACCOUNT_SID",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/twilio/account-sid"
         },

--- a/cd/application-deployment/dev/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/dev/vaec-celery-beat-task-definition.json
@@ -211,6 +211,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/database/uri_read"
+        },
+        {
           "name": "TWILIO_ACCOUNT_SID",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/twilio/account-sid"
         },

--- a/cd/application-deployment/dev/vaec-celery-task-definition.json
+++ b/cd/application-deployment/dev/vaec-celery-task-definition.json
@@ -239,6 +239,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/database/uri_read"
+        },
+        {
           "name": "TWILIO_ACCOUNT_SID",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/twilio/account-sid"
         },

--- a/cd/application-deployment/dev/vaec-db-downgrade-task-definition.json
+++ b/cd/application-deployment/dev/vaec-db-downgrade-task-definition.json
@@ -46,6 +46,10 @@
                     "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/database/uri"
                 },
                 {
+                    "name": "SQLALCHEMY_DATABASE_URI_READ",
+                    "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/database/uri_read"
+                },
+                {
                   "name": "SECRET_KEY",
                   "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/secret-key"
                 }

--- a/cd/application-deployment/dev/vaec-db-migrations-task-definition.json
+++ b/cd/application-deployment/dev/vaec-db-migrations-task-definition.json
@@ -46,6 +46,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/database/uri_read"
+        },
+        {
           "name": "SECRET_KEY",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/secret-key"
         }

--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -205,6 +205,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/database/uri_read"
+        },
+        {
           "name": "ADMIN_CLIENT_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/admin-client-secret"
         },

--- a/cd/application-deployment/perf/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-beat-task-definition.json
@@ -179,6 +179,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/database/uri_read"
+        },
+        {
           "name": "SECRET_KEY",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/secret-key"
         },

--- a/cd/application-deployment/perf/vaec-celery-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-task-definition.json
@@ -179,6 +179,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/database/uri_read"
+        },
+        {
           "name": "SECRET_KEY",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/secret-key"
         },

--- a/cd/application-deployment/perf/vaec-db-downgrade-task-definition.json
+++ b/cd/application-deployment/perf/vaec-db-downgrade-task-definition.json
@@ -46,6 +46,10 @@
                     "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/database/uri"
                 },
                 {
+                    "name": "SQLALCHEMY_DATABASE_URI_READ",
+                    "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/database/uri_read"
+                  },
+                {
                   "name": "SECRET_KEY",
                   "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/secret-key"
                 }

--- a/cd/application-deployment/perf/vaec-db-migrations-task-definition.json
+++ b/cd/application-deployment/perf/vaec-db-migrations-task-definition.json
@@ -46,6 +46,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/database/uri_read"
+        },
+        {
           "name": "SECRET_KEY",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/secret-key"
         }

--- a/cd/application-deployment/prod/vaec-api-task-definition.json
+++ b/cd/application-deployment/prod/vaec-api-task-definition.json
@@ -221,6 +221,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/database/uri_read"
+        },
+        {
           "name": "ADMIN_CLIENT_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/admin-client-secret"
         },

--- a/cd/application-deployment/prod/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/prod/vaec-celery-beat-task-definition.json
@@ -187,6 +187,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/database/uri_read"
+        },
+        {
           "name": "SECRET_KEY",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/secret-key"
         },

--- a/cd/application-deployment/prod/vaec-celery-task-definition.json
+++ b/cd/application-deployment/prod/vaec-celery-task-definition.json
@@ -199,6 +199,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/database/uri_read"
+        },
+        {
           "name": "SECRET_KEY",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/secret-key"
         },

--- a/cd/application-deployment/prod/vaec-db-downgrade-task-definition.json
+++ b/cd/application-deployment/prod/vaec-db-downgrade-task-definition.json
@@ -50,6 +50,10 @@
                     "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/database/uri"
                 },
                 {
+                    "name": "SQLALCHEMY_DATABASE_URI_READ",
+                    "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/database/uri_read"
+                },
+                {
                   "name": "SECRET_KEY",
                   "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/secret-key"
                 }

--- a/cd/application-deployment/prod/vaec-db-migrations-task-definition.json
+++ b/cd/application-deployment/prod/vaec-db-migrations-task-definition.json
@@ -50,6 +50,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/database/uri_read"
+        },
+        {
           "name": "SECRET_KEY",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/secret-key"
         }

--- a/cd/application-deployment/staging/vaec-api-task-definition.json
+++ b/cd/application-deployment/staging/vaec-api-task-definition.json
@@ -237,6 +237,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/database/uri_read"
+        },
+        {
           "name": "ADMIN_CLIENT_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/admin-client-secret"
         },

--- a/cd/application-deployment/staging/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/staging/vaec-celery-beat-task-definition.json
@@ -203,6 +203,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/database/uri_read"
+        },
+        {
           "name": "SECRET_KEY",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/secret-key"
         },

--- a/cd/application-deployment/staging/vaec-celery-task-definition.json
+++ b/cd/application-deployment/staging/vaec-celery-task-definition.json
@@ -215,6 +215,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/database/uri_read"
+        },
+        {
           "name": "SECRET_KEY",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/secret-key"
         },

--- a/cd/application-deployment/staging/vaec-db-downgrade-task-definition.json
+++ b/cd/application-deployment/staging/vaec-db-downgrade-task-definition.json
@@ -46,6 +46,10 @@
                     "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/database/uri"
                 },
                 {
+                    "name": "SQLALCHEMY_DATABASE_URI_READ",
+                    "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/database/uri_read"
+                },
+                {
                   "name": "SECRET_KEY",
                   "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/secret-key"
                 }

--- a/cd/application-deployment/staging/vaec-db-migrations-task-definition.json
+++ b/cd/application-deployment/staging/vaec-db-migrations-task-definition.json
@@ -46,6 +46,10 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/database/uri"
         },
         {
+          "name": "SQLALCHEMY_DATABASE_URI_READ",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/database/uri_read"
+        },
+        {
           "name": "SECRET_KEY",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/secret-key"
         }

--- a/ci/.docker-env.example
+++ b/ci/.docker-env.example
@@ -2,6 +2,7 @@ TWILIO_ACCOUNT_SID=add value
 TWILIO_AUTH_TOKEN=add value
 
 SQLALCHEMY_DATABASE_URI=postgresql://postgres:LocalPassword@db:5432/notification_api
+SQLALCHEMY_DATABASE_URI_READ=postgresql://postgres:LocalPassword@db:5432/notification_api
 NOTIFY_ENVIRONMENT=development
 FLASK_APP=application.py
 
@@ -45,4 +46,4 @@ GITHUB_CLIENT_ID=fake-id
 GITHUB_CLIENT_SECRET=fake-secret
 
 REDIS_ENABLED='True'
-REDIS_URL=redis://localhost:6379/0
+REDIS_URL=redis://redis:6379/0

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,119 @@
+# Testing Write and Read instance
+
+## Fake Replication Setup
+NOTE: This setup is enough to test basic route functions with Read & Write instances. Scroll down if you need fully functional / real time replication between read and write instances.
+#### 1. Setup Docker-Compose
+Update local environment in your `.docker-env`. You should have Read & Write URIs pointing to different instances.
+```
+SQLALCHEMY_DATABASE_URI=postgresql://postgres:LocalPassword@db:5432/notification_api
+SQLALCHEMY_DATABASE_URI_READ=postgresql://postgres:LocalPassword@db-read:5432/notification_api
+```
+Start containers
+```
+docker-compose -f ci/docker-compose-local-readwrite.yml up -d
+```
+
+#### 2. Create snapshot of the write database instance
+```
+pg_dump -U postgres -W -F t notification_api > /var/db-data/writedb.dump
+```
+
+#### 3. Copy snapshot of the write database instance into read instance's mounted volume on your system
+```
+cp ci/db-data/writedb.dump ci/db-data-read/writedb.dump
+```
+
+#### 4. Restore data from write instance on read instance
+```
+pg_restore -U postgres -W -d notification_api /var/db-data-read/writedb.dump
+```
+
+#### 5. Stop containers & remove data when done testing
+```
+docker-compose -f ci/docker-compose-local-readwrite.yml down -v
+rm -fr db-data*
+```
+
+## Real Replication Setup
+Note: use if you need to test real time synchronization
+1. run docker compose file listed below
+2. take back up from an instance that has volume mounted
+```
+pg_basebackup -h write-db -D /var/lib/postgresql/data_sync -U replicator -P -R -X stream
+```
+1. stop only **read-db**
+2. replace contents of **data-read** directory with contents of **data-sync**
+3. start **read-db**
+###### setup-replica.sh
+```
+#!/bin/bash
+set -e
+
+cat >> ${PGDATA}/postgresql.conf <<EOF
+primary_conninfo = 'host=write-db port=5432 user=replicator password=replicatorpassword'
+EOF
+
+touch ${PGDATA}/standby.signal
+
+pg_ctl reload
+```
+##### setup-replication.sh
+```
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "dev" --dbname "dev1035" <<-EOSQL
+    CREATE USER replicator WITH REPLICATION ENCRYPTED PASSWORD 'replicatorpassword';
+    GRANT ALL PRIVILEGES ON DATABASE dev1035 TO replicator;
+EOSQL
+
+cat >> ${PGDATA}/postgresql.conf <<EOF
+wal_level = replica
+archive_mode = on
+archive_command = 'cd .'
+max_wal_senders = 8
+wal_keep_size = 8
+hot_standby = on
+EOF
+
+echo "host    replication     replicator       0.0.0.0/0          md5" >> ${PGDATA}/pg_hba.conf
+
+pg_ctl reload
+```
+
+##### docker-compose.yml
+```
+services:
+  write-db:
+    image: postgres:13  # adjust to the version you need
+    container_name: write-db
+    environment:
+      POSTGRES_USER: <username>
+      POSTGRES_PASSWORD: <password>
+      POSTGRES_DB: notification_api
+    volumes:
+      - ./pgdata-write:/var/lib/postgresql/data
+      - ./pgdata-sync:/var/lib/postgresql/data_sync
+      - ./setup-replication.sh:/docker-entrypoint-initdb.d/setup-replication.sh
+    ports:
+      - "5432:5432"
+    command: ["postgres", "-c", "log_statement=all"]
+
+  read-db:
+    image: postgres:13  # adjust to the version you need
+    container_name: read-db
+    depends_on:
+      - write-db
+    environment:
+      POSTGRES_USER: <username>
+      POSTGRES_PASSWORD: <password>
+      POSTGRES_DB: notification_api
+    volumes:
+      - ./pgdata-read:/var/lib/postgresql/data
+      - ./setup-replica.sh:/docker-entrypoint-initdb.d/setup-replica.sh
+    ports:
+      - "5433:5432"
+    links:
+      - write-db
+    command: ["postgres", "-c", "log_statement=all"]
+```

--- a/ci/docker-compose-local-readwrite.yml
+++ b/ci/docker-compose-local-readwrite.yml
@@ -23,6 +23,19 @@ services:
     environment:
       - POSTGRES_PASSWORD=LocalPassword
       - POSTGRES_DB=notification_api
+    volumes:
+      - ./db-data:/var/db-data
+
+  db-read:
+    image: postgres:15
+    restart: unless-stopped
+    ports:
+      - 5433:5432
+    environment:
+      - POSTGRES_PASSWORD=LocalPassword
+      - POSTGRES_DB=notification_api
+    volumes:
+      - ./db-data-read:/var/db-data-read
 
   migrations:
     image: notification_api

--- a/ci/docker-compose-test.yml
+++ b/ci/docker-compose-test.yml
@@ -22,6 +22,7 @@ services:
       - NOTIFY_ENVIRONMENT=test
       - RETRY_SQS_URL=RETRY_SQS_URL
       - SQLALCHEMY_DATABASE_URI=postgresql://postgres:LocalPassword@db:5432/test_notification_api
+      - SQLALCHEMY_DATABASE_URI_READ=postgresql://postgres:LocalPassword@db:5432/test_notification_api
       - TIMEOUT=10
       - VA_PROFILE_DOMAIN=int.vaprofile.va.gov
       - VETEXT_API_AUTH_SSM_PATH=test

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - TWILIO_ACCOUNT_SID=
       - TWILIO_AUTH_TOKEN=
       - SQLALCHEMY_DATABASE_URI=postgresql://postgres:LocalPassword@db:5432/notification_api
+      - SQLALCHEMY_DATABASE_URI_READ=postgresql://postgres:LocalPassword@db:5432/notification_api
       - NOTIFY_ENVIRONMENT=development
       - FLASK_APP=application.py
     depends_on:
@@ -30,6 +31,7 @@ services:
       - TWILIO_ACCOUNT_SID=
       - TWILIO_AUTH_TOKEN=
       - SQLALCHEMY_DATABASE_URI=postgresql://postgres:LocalPassword@db:5432/notification_api
+      - SQLALCHEMY_DATABASE_URI_READ=postgresql://postgres:LocalPassword@db:5432/notification_api
       - NOTIFY_ENVIRONMENT=development
       - FLASK_APP=application.py
     depends_on:

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,9 +9,9 @@ The docker-compose command used to run the full test suite sets environment vari
 ## Setup
 
 1. Stop all running containers associated with Notification-api.
-2. Start the Postgres (ci_db_1) container, and any other containers required by the functionality under test: `docker start ci_db_1`.  All migrations should already be applied.
-3. Start a test container shell by running `docker run --rm -it -v "<absolute path to notification-api>:/app" --env-file tests/env_vars ci_test bash`.
-4. Add the test container started in the previous step to the default network: `docker network connect ci_default <test container name or ID>`.
+2. Start the Postgres (ci_db_1) container, and any other containers required by the functionality under test: `docker start ci-db-1`.  All migrations should already be applied.
+3. Start a test container shell by running `docker run --rm -it -v "<absolute path to notification-api>:/app" --env-file tests/env_vars --name ci-test ci-test bash`.
+4. Add the test container started in the previous step to the default network: `docker network connect ci_default ci-test`.
 5. In the test container shell, run `pytest -h` to see the syntax for running tests.  Without flags, you can run `pytest [file or directory]...`.
 
 ## Running Individual Tests

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1,5 +1,6 @@
 import json
 import os
+from app.service.service_data import ServiceDataApiKey
 import pytest
 import pytz
 import requests_mock
@@ -579,6 +580,23 @@ def sample_api_key(notify_db,
     api_key = ApiKey(**data)
     save_model_api_key(api_key)
     return api_key
+
+
+@pytest.fixture(scope='function')
+def sample_service_data_api_key(service=None, key_type=KEY_TYPE_NORMAL, name=None):
+    if service is None:
+        service = create_service(check_if_service_exists=True)
+
+    data = {
+        'service': service,
+        'name': name or uuid.uuid4(),
+        'created_by': service.created_by,
+        'key_type': key_type
+    }
+    api_key = ApiKey(**data)
+    save_model_api_key(api_key)
+
+    return ServiceDataApiKey(api_key)
 
 
 @pytest.fixture(scope='function')

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -12,7 +12,6 @@ from app.notifications.receive_notifications import (
     format_mmg_datetime,
     create_inbound_sms_object,
     strip_leading_forty_four,
-    has_inbound_sms_permissions,
     unescape_string, fetch_potential_service, NoSuitableServiceForInboundSms,
 )
 
@@ -100,7 +99,7 @@ def test_receive_notification_returns_received_to_mmg(client, mocker, sample_ser
 ])
 def test_check_permissions_for_inbound_sms(notify_db, notify_db_session, permissions, expected_response):
     service = create_service(service_permissions=permissions)
-    assert has_inbound_sms_permissions(service.permissions) is expected_response
+    assert service.has_permissions([INBOUND_SMS_TYPE, SMS_TYPE]) is expected_response
 
 
 @pytest.mark.skip(reason="Endpoint disabled and slated for removal")
@@ -722,9 +721,13 @@ class TestFetchPotentialService:
             fetch_potential_service('some-inbound-number', 'some-provider-name')
 
     def test_should_raise_if_service_doesnt_have_permission(self, notify_api, mocker):
+        # make mocked service execute original code
+        # just mocking service won't let us execute .has_permissions
+        # method properly
+        mock_service_instance = Service(permissions=[])
         mocker.patch(
             'app.notifications.receive_notifications.dao_fetch_service_by_inbound_number',
-            return_value=mocker.Mock(Service, permissions=[])
+            return_value=mock_service_instance
         )
 
         with pytest.raises(NoSuitableServiceForInboundSms):

--- a/tests/app/test_cloudfoundry_config.py
+++ b/tests/app/test_cloudfoundry_config.py
@@ -36,6 +36,7 @@ def test_extract_cloudfoundry_config_populates_other_vars():
     extract_cloudfoundry_config()
 
     assert os.environ['SQLALCHEMY_DATABASE_URI'] == 'postgres uri'
+    assert os.environ['SQLALCHEMY_DATABASE_URI_READ'] == 'postgres uri'
     assert os.environ['NOTIFY_ENVIRONMENT'] == '🚀🌌'
     assert os.environ['NOTIFY_LOG_PATH'] == '/home/vcap/logs/app.log'
 

--- a/tests/env_vars
+++ b/tests/env_vars
@@ -1,6 +1,7 @@
 # https://docs.docker.com/compose/env-file/
 
 SQLALCHEMY_DATABASE_URI=postgresql://postgres:LocalPassword@db:5432/test_notification_api
+SQLALCHEMY_DATABASE_URI_READ=postgresql://postgres:LocalPassword@db:5432/test_notification_api
 NOTIFY_ENVIRONMENT=test
 AWS_ACCESS_KEY_ID=test
 AWS_PINPOINT_APP_ID=AWS_PINPOINT_APP_ID


### PR DESCRIPTION
To reduces the load on write instance of database cluster, we need to configure and use a separate PostgreSQL engine for some of the reads.

Because we are now writing and reading from two different engines, we need a way to pass data around in an object similar to what we had before and which preserves dot notation. Thus AuthenticatedServiceInfo class is introduced in this PR.

#1344 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

 - [x] Locally with unit tests
 - [x] Locally with multiple databases
 - [x] In Dev
 - [x] Deployed to Dev and Perf

## Checklist

- [x] Appropriate labels added to this pull request (i.e. "enhancement", "dependencies", etc.)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
