### PR TITLE
#1419 Halt Celery processing to send a notification if VA Profile times outand trigger a retry

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -245,8 +245,6 @@ fileignoreconfig:
       checksum: efce5afc3015a7bdcae7e027da762acf1fefe782b30a5a92855b253cad6c3050
     - filename: requirements.txt
       checksum: 0cf734d45d6941fdc317a23c6490ed4ce92194bc02adecb52e5edff5bb5442f8
-    - filename: app/va/va_profile/va_profile_client.py
-      checksum: 2942cb80f53433d4c129c2fbd43ba7b28f252d2daf30ad2c93bf8255d3d1e179
     - filename: ci/.docker-env.example
       checksum: 7bc7fefe2e93aab23fae65dc41683255bdabd0a07af9e0154c046592567d914c
     - filename: cd/application-deployment/prod/vaec-celery-beat-task-definition.json
@@ -262,7 +260,7 @@ fileignoreconfig:
     - filename: cd/application-deployment/perf/vaec-celery-beat-task-definition.json
       checksum: fb096cd80adb5cc7916a504aac7b9657d1b5318f27479edc9a8e6b69ed3c4e9c
     - filename: app/va/va_profile/va_profile_client.py
-      checksum: 92ae208ffa16b46c91e959911b811d8fc82d274434dffc6e784f2c85682729f7
+      checksum: be53471b99e1e1e579f680f9076365170d5ca6951e32dd9f0153c2769198e8cd
     - filename: tests/app/oauth/test_rest.py
       checksum: 33abe86bb9eb4f135c7df41d7bc990258e9e368120f2088f199135462a342734
     - filename: tests/app/notifications/test_rest.py

--- a/app/celery/contact_information_tasks.py
+++ b/app/celery/contact_information_tasks.py
@@ -1,6 +1,4 @@
 from flask import current_app
-from notifications_utils.statsd_decorators import statsd
-
 from app import notify_celery, va_profile_client
 from app.celery.common import can_retry, handle_max_retries_exceeded
 from app.celery.exceptions import AutoRetryException
@@ -10,6 +8,8 @@ from app.dao.notifications_dao import get_notification_by_id, dao_update_notific
 from app.models import NOTIFICATION_PERMANENT_FAILURE, EMAIL_TYPE, SMS_TYPE
 from app.exceptions import NotificationTechnicalFailureException, NotificationPermanentFailureException
 from app.va.va_profile.exceptions import VAProfileIDNotFoundException
+from notifications_utils.statsd_decorators import statsd
+from requests import Timeout
 
 
 @notify_celery.task(bind=True, name="lookup-contact-info-tasks",
@@ -34,7 +34,7 @@ def lookup_contact_info(self, notification_id):
                 f"The task lookup_contact_info failed for notification {notification_id}. "
                 f"{notification.notification_type} is not supported")
 
-    except VAProfileRetryableException as e:
+    except (Timeout, VAProfileRetryableException) as e:
         if can_retry(self.request.retries, self.max_retries, notification_id):
             current_app.logger.warning("Unable to get contact info for notification id: %s, retrying", notification_id)
             raise AutoRetryException('Found VAProfileRetryableException, autoretrying...', e, e.args)

--- a/app/celery/contact_information_tasks.py
+++ b/app/celery/contact_information_tasks.py
@@ -37,7 +37,7 @@ def lookup_contact_info(self, notification_id):
     except (Timeout, VAProfileRetryableException) as e:
         if can_retry(self.request.retries, self.max_retries, notification_id):
             current_app.logger.warning("Unable to get contact info for notification id: %s, retrying", notification_id)
-            raise AutoRetryException('Found {type(e).__name__}, autoretrying...', e, e.args)
+            raise AutoRetryException(f'Found {type(e).__name__}, autoretrying...', e, e.args)
         else:
             msg = handle_max_retries_exceeded(notification_id, 'lookup_contact_info')
             raise NotificationTechnicalFailureException(msg)

--- a/app/celery/contact_information_tasks.py
+++ b/app/celery/contact_information_tasks.py
@@ -37,7 +37,7 @@ def lookup_contact_info(self, notification_id):
     except (Timeout, VAProfileRetryableException) as e:
         if can_retry(self.request.retries, self.max_retries, notification_id):
             current_app.logger.warning("Unable to get contact info for notification id: %s, retrying", notification_id)
-            raise AutoRetryException('Found VAProfileRetryableException, autoretrying...', e, e.args)
+            raise AutoRetryException('Found {type(e).__name__}, autoretrying...', e, e.args)
         else:
             msg = handle_max_retries_exceeded(notification_id, 'lookup_contact_info')
             raise NotificationTechnicalFailureException(msg)

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -31,6 +31,10 @@ def deliver_sms(self, notification_id, sms_sender_id=None):
             # Distributed computing race condition
             current_app.logger.warning("Notification not found for: %s, retrying", notification_id)
             raise AutoRetryException
+        if not notification.to:
+            raise RuntimeError(
+                f'The "to" field was not set for notification {notification_id}.  This is a programming error.'
+            )
         send_to_providers.send_sms_to_provider(notification, sms_sender_id)
         current_app.logger.info("Successfully sent sms for notification id: %s", notification_id)
     except InvalidProviderException as e:
@@ -78,6 +82,10 @@ def deliver_sms_with_rate_limiting(self, notification_id, sms_sender_id=None):
         if not notification:
             current_app.logger.warning("Notification not found for: %s, retrying", notification_id)
             raise AutoRetryException
+        if not notification.to:
+            raise RuntimeError(
+                f'The "to" field was not set for notification {notification_id}.  This is a programming error.'
+            )
         sms_sender = dao_get_service_sms_sender_by_service_id_and_number(notification.service_id,
                                                                          notification.reply_to_text)
         check_sms_sender_over_rate_limit(notification.service_id, sms_sender.id)
@@ -139,6 +147,10 @@ def deliver_email(self, notification_id: str, sms_sender_id=None):
         if not notification:
             current_app.logger.warning("Notification not found for: %s, retrying", notification_id)
             raise AutoRetryException
+        if not notification.to:
+            raise RuntimeError(
+                f'The "to" field was not set for notification {notification_id}.  This is a programming error.'
+            )
         send_to_providers.send_email_to_provider(notification)
         current_app.logger.info("Successfully sent email for notification id: %s", notification_id)
     except InvalidEmailError as e:

--- a/app/va/va_profile/va_profile_client.py
+++ b/app/va/va_profile/va_profile_client.py
@@ -44,6 +44,7 @@ class VAProfileClient:
     def get_email(self, va_profile_id) -> str:
         """
         Return the e-mail address for a given Profile ID, or raise NoContactInfoException.
+        Upstream code should catch and appropriately handle the requests.Timeout exception.
         """
 
         if is_fhir_format(va_profile_id):
@@ -55,14 +56,28 @@ class VAProfileClient:
         )
         response = self._make_request(url, va_profile_id, self.EMAIL_BIO_TYPE)
 
-        most_recently_created_bio = self._get_most_recently_created_email_bio(response, va_profile_id)
-        email = most_recently_created_bio['emailAddressText']
-        self.statsd_client.incr("clients.va-profile.get-email.success")
-        return email
+        try:
+            sorted_bios = sorted(
+                response['bios'],
+                key=lambda bio: iso8601.parse_date(bio['createDate']),
+                reverse=True
+            )
+            if sorted_bios:
+                if sorted_bios[0].get("emailAddressText"):
+                    # The e-mail address attribute is present and not the empty string.
+                    self.statsd_client.incr("clients.va-profile.get-email.success")
+                # This is intentionally allowed to raise KeyError so the problem is logged below.
+                return sorted_bios[0]["emailAddressText"]
+        except KeyError as e:
+            self.logger.error("Received a garbled response from VA Profile for ID %s.", va_profile_id)
+            self.logger.exception(e)
+
+        self._raise_no_contact_info_exception(self.EMAIL_BIO_TYPE, va_profile_id, response.get(self.TX_AUDIT_ID))
 
     def get_telephone(self, va_profile_id) -> str:
         """
         Return the phone number for a given Profile ID, or raise NoContactInfoException.
+        Upstream code should catch and appropriately handle the requests.Timeout exception.
         """
 
         if is_fhir_format(va_profile_id):
@@ -74,12 +89,26 @@ class VAProfileClient:
         )
         response = self._make_request(url, va_profile_id, self.PHONE_BIO_TYPE)
 
-        most_recently_created_bio = self._get_highest_order_phone_bio(response, va_profile_id)
-        phone_number = f"+{most_recently_created_bio['countryCode']}" \
-                       f"{most_recently_created_bio['areaCode']}" \
-                       f"{most_recently_created_bio['phoneNumber']}"
-        self.statsd_client.incr("clients.va-profile.get-telephone.success")
-        return phone_number
+        try:
+            # First sort by phone type and then by create date.  Since reverse order is used,
+            # potential MOBILE bios will end up before HOME.
+            sorted_bios = sorted(
+                (bio for bio in response['bios'] if bio['phoneType'] in PhoneNumberType.valid_type_values()),
+                key=lambda bio: (bio['phoneType'], iso8601.parse_date(bio['createDate'])),
+                reverse=True
+            )
+            if sorted_bios:
+                if sorted_bios[0].get("countryCode") and sorted_bios[0].get("areaCode") and \
+                        sorted_bios[0].get("phoneNumber"):
+                    # The required attributes are present and not empty strings.
+                    self.statsd_client.incr("clients.va-profile.get-email.success")
+                # This is intentionally allowed to raise KeyError so the problem is logged below.
+                return '+' + sorted_bios[0]["countryCode"] + sorted_bios[0]["areaCode"] + sorted_bios[0]["phoneNumber"]
+        except KeyError as e:
+            self.logger.error("Received a garbled response from VA Profile for ID %s.", va_profile_id)
+            self.logger.exception(e)
+
+        self._raise_no_contact_info_exception(self.PHONE_BIO_TYPE, va_profile_id, response.get(self.TX_AUDIT_ID))
 
     def get_is_communication_allowed(
             self, recipient_identifier, communication_item_id: str, notification_id: str, notification_type: str
@@ -195,32 +224,6 @@ class VAProfileClient:
         finally:
             elapsed_time = monotonic() - start_time
             self.statsd_client.timing("clients.va-profile.request-time", elapsed_time)
-
-    def _get_most_recently_created_email_bio(self, response, va_profile_id):
-        sorted_bios = None
-        if 'bios' in response:
-            sorted_bios = sorted(
-                response['bios'],
-                key=lambda bio: iso8601.parse_date(bio['createDate']),
-                reverse=True
-            )
-        if sorted_bios:
-            return sorted_bios[0]
-        self._raise_no_contact_info_exception(self.EMAIL_BIO_TYPE, va_profile_id, response.get(self.TX_AUDIT_ID))
-
-    def _get_highest_order_phone_bio(self, response, va_profile_id):
-        # First sort by phone type and then by create date
-        # since reverse order is used, potential MOBILE bios will end up before HOME
-        sorted_bios = None
-        if 'bios' in response:
-            sorted_bios = sorted(
-                (bio for bio in response['bios'] if bio['phoneType'] in PhoneNumberType.valid_type_values()),
-                key=lambda bio: (bio['phoneType'], iso8601.parse_date(bio['createDate'])),
-                reverse=True
-            )
-        if sorted_bios:
-            return sorted_bios[0]
-        self._raise_no_contact_info_exception(self.PHONE_BIO_TYPE, va_profile_id, response.get(self.TX_AUDIT_ID))
 
     def _raise_no_contact_info_exception(self, bio_type: str, va_profile_id: str, tx_audit_id: str):
         self.statsd_client.incr(f"clients.va-profile.get-{bio_type}.no-{bio_type}")

--- a/app/va/va_profile/va_profile_client.py
+++ b/app/va/va_profile/va_profile_client.py
@@ -72,6 +72,7 @@ class VAProfileClient:
             self.logger.error("Received a garbled response from VA Profile for ID %s.", va_profile_id)
             self.logger.exception(e)
 
+        self.statsd_client.incr("clients.va-profile.get-email.failure")
         self._raise_no_contact_info_exception(self.EMAIL_BIO_TYPE, va_profile_id, response.get(self.TX_AUDIT_ID))
 
     def get_telephone(self, va_profile_id) -> str:
@@ -101,13 +102,14 @@ class VAProfileClient:
                 if sorted_bios[0].get("countryCode") and sorted_bios[0].get("areaCode") and \
                         sorted_bios[0].get("phoneNumber"):
                     # The required attributes are present and not empty strings.
-                    self.statsd_client.incr("clients.va-profile.get-email.success")
+                    self.statsd_client.incr("clients.va-profile.get-telephone.success")
                 # This is intentionally allowed to raise KeyError so the problem is logged below.
                 return '+' + sorted_bios[0]["countryCode"] + sorted_bios[0]["areaCode"] + sorted_bios[0]["phoneNumber"]
         except KeyError as e:
             self.logger.error("Received a garbled response from VA Profile for ID %s.", va_profile_id)
             self.logger.exception(e)
 
+        self.statsd_client.incr("clients.va-profile.get-telephone.failure")
         self._raise_no_contact_info_exception(self.PHONE_BIO_TYPE, va_profile_id, response.get(self.TX_AUDIT_ID))
 
     def get_is_communication_allowed(

--- a/app/va/va_profile/va_profile_client.py
+++ b/app/va/va_profile/va_profile_client.py
@@ -41,7 +41,11 @@ class VAProfileClient:
         self.ssl_key_path = ssl_key_path
         self.statsd_client = statsd_client
 
-    def get_email(self, va_profile_id):
+    def get_email(self, va_profile_id) -> str:
+        """
+        Return the e-mail address for a given Profile ID, or raise NoContactInfoException.
+        """
+
         if is_fhir_format(va_profile_id):
             va_profile_id = transform_from_fhir_format(va_profile_id)
 
@@ -56,7 +60,11 @@ class VAProfileClient:
         self.statsd_client.incr("clients.va-profile.get-email.success")
         return email
 
-    def get_telephone(self, va_profile_id):
+    def get_telephone(self, va_profile_id) -> str:
+        """
+        Return the phone number for a given Profile ID, or raise NoContactInfoException.
+        """
+
         if is_fhir_format(va_profile_id):
             va_profile_id = transform_from_fhir_format(va_profile_id)
 
@@ -165,6 +173,10 @@ class VAProfileClient:
             exception.failure_reason = failure_message
 
             raise exception from e
+
+        except requests.Timeout:
+            self.logger.error("The request to VA Profile timed out for VA Profile ID %s.", va_profile_id)
+            raise
 
         else:
             response_json = response.json()


### PR DESCRIPTION
# Description

These changes address the presence of an abundance of instances of `'NoneType' object has no attribute 'replace'` in the logs and a subsequent spike in the size of the "send email" queue.  The problem seems to occur when making POST request to send a notification using a recipient ID, which results in a query to VA Profile.  The response from Profile is used to set the "to" string attribute of the Notification instance.  If the request to Profile times out, "to" remains defaulted to None, and that causes the AttributeError downstream.

These changes log the timeout exception in the Profile client, where it occurs, and handles the exception in the relevant Celery task that uses the Profile client.  I treated a timeout as a retryable exception, which means it should remain in the Celery queue until it completes or hits the retry limit.

@k-macmillan created [PR 1420](https://github.com/department-of-veterans-affairs/notification-api/pull/1420) to catch AttributeError at the downstream point.  This PR addresses the root cause.

#1419

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Add a new unit test
- [x] All tests pass
- [x] [deployed](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/5880030504)
- [x] [regressions tests pass](https://github.com/department-of-veterans-affairs/notification-api-qa/actions/runs/5880189497)
- [x] In Datadog, the Dev "send email" queue doesn't appear to be spiking upwards
- [x] No recent instances (last 4 hours) of "object has no attribute" in the logs

## Checklist

- [x] Appropriate labels added to this pull request (i.e. "enhancement", "dependencies", etc.)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes