### PR TITLE
Hotfix AutoRetry For Rate Limiting SMS Deliveries

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -72,7 +72,10 @@ def deliver_sms(self, notification_id, sms_sender_id=None):
 
 
 # Including sms_sender_id is necessary in case it's passed in when being called
-@notify_celery.task(bind=True, name='deliver_sms_with_rate_limiting', max_retries=None)
+@notify_celery.task(bind=True, name='deliver_sms_with_rate_limiting',
+                    throws=(AutoRetryException, ),
+                    autoretry_for=(AutoRetryException, ),
+                    max_retries=2886, retry_backoff=10, retry_backoff_max=60)
 @statsd(namespace='tasks')
 def deliver_sms_with_rate_limiting(self, notification_id, sms_sender_id=None):
     from app.notifications.validators import check_sms_sender_over_rate_limit

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -91,7 +91,7 @@ def deliver_sms_with_rate_limiting(self, notification_id, sms_sender_id=None):
             )
         sms_sender = dao_get_service_sms_sender_by_service_id_and_number(notification.service_id,
                                                                          notification.reply_to_text)
-        check_sms_sender_over_rate_limit(notification.service_id, sms_sender.id)
+        check_sms_sender_over_rate_limit(notification.service_id, sms_sender)
         send_to_providers.send_sms_to_provider(notification, sms_sender_id)
         current_app.logger.info('Successfully sent sms with rate limiting for notification id: %s', notification_id)
     except InvalidProviderException as e:

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -56,7 +56,7 @@ def deliver_sms(self, notification_id, sms_sender_id=None):
         )
         notification = notifications_dao.get_notification_by_id(notification_id)
         check_and_queue_callback_task(notification)
-    except (NullValueForNonConditionalPlaceholderException, AttributeError, RuntimeError, KeyError) as e:
+    except (NullValueForNonConditionalPlaceholderException, AttributeError, RuntimeError) as e:
         handle_non_retryable(notification_id, 'deliver_sms')
         raise NotificationTechnicalFailureException(f'Found {type(e).__name__}, NOT retrying...', e, e.args)
     except Exception as e:

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -58,15 +58,15 @@ def check_service_over_daily_message_limit(key_type, service):
             raise TooManyRequestsError(service.message_limit)
 
 
-def check_sms_sender_over_rate_limit(service_id, sms_sender_id):
+def check_sms_sender_over_rate_limit(service_id, sms_sender):
     if (
         not is_feature_enabled(FeatureFlag.SMS_SENDER_RATE_LIMIT_ENABLED)
-        or sms_sender_id is None
+        or sms_sender is None
     ):
         current_app.logger.info('Skipping sms sender rate limit check')
         return
 
-    sms_sender = dao_get_service_sms_sender_by_id(service_id, sms_sender_id)
+    sms_sender = dao_get_service_sms_sender_by_id(service_id, sms_sender.id)
     if current_app.config['REDIS_ENABLED']:
         current_app.logger.info('Checking sms sender rate limit')
         cache_key = sms_sender.sms_sender

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -203,6 +203,8 @@ def test_deliver_sms_with_rate_limiting_should_retry_if_rate_limit_exceeded(samp
 
 def test_deliver_sms_with_rate_limiting_should_retry_generic_exceptions(sample_notification, mocker):
     mocker.patch('app.celery.provider_tasks.send_to_providers.send_sms_to_provider', side_effect=Exception)
+    mocker.patch.dict(os.environ, {'NOTIFICATION_FAILURE_REASON_ENABLED': 'True'})
+
     with pytest.raises(AutoRetryException) as exc_info:
         deliver_sms_with_rate_limiting(sample_notification.id)
 

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -202,7 +202,7 @@ def test_deliver_sms_with_rate_limiting_should_retry_if_rate_limit_exceeded(samp
 
 
 def test_deliver_sms_with_rate_limiting_should_retry_generic_exceptions(sample_notification, mocker):
-    mocker.patch('app.delivery.send_to_providers.send_sms_to_provider', side_effect=Exception)
+    mocker.patch('app.celery.provider_tasks.send_to_providers.send_sms_to_provider', side_effect=Exception)
     with pytest.raises(AutoRetryException) as exc_info:
         deliver_sms_with_rate_limiting(sample_notification.id)
 
@@ -210,7 +210,7 @@ def test_deliver_sms_with_rate_limiting_should_retry_generic_exceptions(sample_n
 
 
 def test_deliver_sms_with_rate_limiting_max_retries_exceeded(sample_notification, mocker):
-    mocker.patch('app.delivery.send_to_providers.send_sms_to_provider', side_effect=Exception)
+    mocker.patch('app.celery.provider_tasks.send_to_providers.send_sms_to_provider', side_effect=Exception)
     mocker.patch('app.celery.provider_tasks.can_retry', return_value=False)
 
     with pytest.raises(NotificationTechnicalFailureException) as exc_info:

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -3,7 +3,6 @@ import uuid
 from collections import namedtuple
 
 import pytest
-from unittest.mock import patch
 from notifications_utils.recipients import InvalidEmailError
 
 

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -212,6 +212,7 @@ def test_deliver_sms_with_rate_limiting_should_retry_generic_exceptions(sample_n
 def test_deliver_sms_with_rate_limiting_max_retries_exceeded(sample_notification, mocker):
     mocker.patch('app.celery.provider_tasks.send_to_providers.send_sms_to_provider', side_effect=Exception)
     mocker.patch('app.celery.provider_tasks.can_retry', return_value=False)
+    mocker.patch.dict(os.environ, {'NOTIFICATION_FAILURE_REASON_ENABLED': 'True'})
 
     with pytest.raises(NotificationTechnicalFailureException) as exc_info:
         deliver_sms_with_rate_limiting(sample_notification.id)

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -202,6 +202,7 @@ def test_deliver_sms_with_rate_limiting_should_retry_if_rate_limit_exceeded(samp
 
 
 def test_deliver_sms_with_rate_limiting_should_retry_generic_exceptions(sample_notification, mocker):
+    mocker.patch('app.celery.provider_tasks.check_sms_sender_over_rate_limit')
     mocker.patch('app.celery.provider_tasks.send_to_providers.send_sms_to_provider', side_effect=Exception)
     with pytest.raises(AutoRetryException) as exc_info:
         deliver_sms_with_rate_limiting(sample_notification.id)
@@ -210,6 +211,7 @@ def test_deliver_sms_with_rate_limiting_should_retry_generic_exceptions(sample_n
 
 
 def test_deliver_sms_with_rate_limiting_max_retries_exceeded(sample_notification, mocker):
+    mocker.patch('app.celery.provider_tasks.check_sms_sender_over_rate_limit')
     mocker.patch('app.celery.provider_tasks.send_to_providers.send_sms_to_provider', side_effect=Exception)
     mocker.patch('app.celery.provider_tasks.can_retry', return_value=False)
 

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -3,6 +3,7 @@ import uuid
 from collections import namedtuple
 
 import pytest
+from unittest.mock import patch
 from notifications_utils.recipients import InvalidEmailError
 
 
@@ -202,7 +203,6 @@ def test_deliver_sms_with_rate_limiting_should_retry_if_rate_limit_exceeded(samp
 
 
 def test_deliver_sms_with_rate_limiting_should_retry_generic_exceptions(sample_notification, mocker):
-    mocker.patch('app.celery.provider_tasks.check_sms_sender_over_rate_limit')
     mocker.patch('app.celery.provider_tasks.send_to_providers.send_sms_to_provider', side_effect=Exception)
     with pytest.raises(AutoRetryException) as exc_info:
         deliver_sms_with_rate_limiting(sample_notification.id)
@@ -211,7 +211,6 @@ def test_deliver_sms_with_rate_limiting_should_retry_generic_exceptions(sample_n
 
 
 def test_deliver_sms_with_rate_limiting_max_retries_exceeded(sample_notification, mocker):
-    mocker.patch('app.celery.provider_tasks.check_sms_sender_over_rate_limit')
     mocker.patch('app.celery.provider_tasks.send_to_providers.send_sms_to_provider', side_effect=Exception)
     mocker.patch('app.celery.provider_tasks.can_retry', return_value=False)
 

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -202,20 +202,20 @@ def test_deliver_sms_with_rate_limiting_should_retry_if_rate_limit_exceeded(samp
 
 
 def test_deliver_sms_with_rate_limiting_should_retry_generic_exceptions(sample_notification, mocker):
-        mocker.patch('app.delivery.send_to_providers.send_sms_to_provider', side_effect=Exception)
-        with pytest.raises(AutoRetryException) as exc_info:
-            deliver_sms_with_rate_limiting(sample_notification.id)
+    mocker.patch('app.delivery.send_to_providers.send_sms_to_provider', side_effect=Exception)
+    with pytest.raises(AutoRetryException) as exc_info:
+        deliver_sms_with_rate_limiting(sample_notification.id)
 
-        assert exc_info.type is AutoRetryException
+    assert exc_info.type is AutoRetryException
 
 
 def test_deliver_sms_with_rate_limiting_max_retries_exceeded(sample_notification, mocker):
-        mocker.patch('app.delivery.send_to_providers.send_sms_to_provider', side_effect=Exception)
-        mocker.patch('app.celery.provider_tasks.can_retry', return_value=False)
+    mocker.patch('app.delivery.send_to_providers.send_sms_to_provider', side_effect=Exception)
+    mocker.patch('app.celery.provider_tasks.can_retry', return_value=False)
 
-        with pytest.raises(NotificationTechnicalFailureException) as exc_info:
-            deliver_sms_with_rate_limiting(sample_notification.id)
+    with pytest.raises(NotificationTechnicalFailureException) as exc_info:
+        deliver_sms_with_rate_limiting(sample_notification.id)
 
-        assert exc_info.type is NotificationTechnicalFailureException
-        assert sample_notification.status == 'technical-failure'
-        assert sample_notification.status_reason == RETRIES_EXCEEDED
+    assert exc_info.type is NotificationTechnicalFailureException
+    assert sample_notification.status == 'technical-failure'
+    assert sample_notification.status_reason == RETRIES_EXCEEDED

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -510,7 +510,7 @@ class TestSmsSenderRateLimit:
             sample_service.restricted = True
 
             with pytest.raises(RateLimitError) as e:
-                check_sms_sender_over_rate_limit(sample_service, sms_sender.id)
+                check_sms_sender_over_rate_limit(sample_service, sms_sender)
 
             should_throttle.assert_called_once_with(
                 sms_sender.sms_sender, sample_service.rate_limit, 60
@@ -540,7 +540,7 @@ class TestSmsSenderRateLimit:
 
             sample_service.restricted = True
 
-            check_sms_sender_over_rate_limit(sample_service, sms_sender.id)
+            check_sms_sender_over_rate_limit(sample_service, sms_sender)
             should_throttle.assert_called_once_with(
                 str(sms_sender.sms_sender), 10, 60
             )


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
It was missed that `autoretry_for` was not added to sms with rate limiting.

This PR adds it to `deliver_sms_with_rate_limiting` and gives it up to a 2 second initial delay.
https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.retry_backoff

As far as we can tell this has not impacted any services
![image](https://github.com/department-of-veterans-affairs/notification-api/assets/16893311/12b21744-2344-4b60-8afb-a5eff0e3440e)


This tells me that the unit tests were not initially sufficient for retries, otherwise it should have failed (retry tests for all other changes required large overhauls). 

This code (pre-autoretry_for) never had any unit test coverage:
![image](https://github.com/department-of-veterans-affairs/notification-api/assets/16893311/ebf67cb5-97d0-408d-b34f-23febaaef7a2)

So when the logic was changed to what it is now, it didn't fail unit tests because there were none to fail. The existing rate limiting retry logic was left in-place because it used an equation to calculate retry time (`retry_time = sms_sender.rate_limit_interval / sms_sender.rate_limit`) instead of our new exponential backoff. It did not fit the new use-case. but the generic exception block _does_ fit our use case. 

It is unfortunate it was missed but it seems to have had no bearing on Production. Only one service had the possibility of being affected:
![image](https://github.com/department-of-veterans-affairs/notification-api/assets/16893311/b4642f41-f14b-48d9-bf98-aaad8ffd33ef)

So this fix only applies to exceptional case where the retry was not expected and we were relying on our generic catch-all and retry. Under normal rate limiting this would have retried without issue. 

Had to update a variable to not reference object attributes. `dao_get_service_sms_sender_by_service_id_and_number` allows for a `None` to be returned, so the next line that checked `check_sms_sender_over_rate_limit` by sending `sms_sender.id` would throw an `AttributeError` if the `dao` method came back with `None`. Granted, it never should in production, but in testing it can (and did).

#N/A



## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Fixes an edge case that had not resulted in a bug yet
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
[Deployed](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/5930237988), all unit tests pass. Regression suite passes.
![image](https://github.com/department-of-veterans-affairs/notification-api/assets/16893311/81275c4d-9516-40ae-bc8f-204457f5139f)
## Checklist

- [x] Appropriate labels added to this pull request (i.e. "enhancement", "dependencies", etc.)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
