### PR TITLE
626 Twistlock Re-added

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,9 @@ jobs:
           push: true
           tags: ${{ steps.login-ecr-vaec.outputs.registry }}/notification_api:${{ inputs.ref }}_${{ inputs.environment }}
 
-      # This is temporarily removed due to EC2 issues that resulted in a switch to AWS Inspector Enhanced Scanner.  
-      # Twistlock will be fully removed from actions and the infrastructure in #1398
-      #- name: Dispatch Twistlock Workflow
-        #env:
-          #GH_TOKEN: ${{ github.token }}
-        #run: |
-          #gh workflow run -r master -F image-tag=${{ inputs.ref }}_${{ inputs.environment }} twistlock.yml
+       Twistlock will be fully removed from actions and the infrastructure in #1398
+      - name: Dispatch Twistlock Workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run -r master -F image-tag=${{ inputs.ref }}_${{ inputs.environment }} twistlock.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,6 @@ jobs:
           push: true
           tags: ${{ steps.login-ecr-vaec.outputs.registry }}/notification_api:${{ inputs.ref }}_${{ inputs.environment }}
 
-       Twistlock will be fully removed from actions and the infrastructure in #1398
       - name: Dispatch Twistlock Workflow
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,5 @@
 name: api build and push
 on:
-  workflow_dispatch:
-    inputs:
-      environment:
-        required: true
-        default: "dev"
-        type: string
-      ref:
-        required: true
-        type: string
   workflow_call:
     inputs:
       environment:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,14 @@
 name: api build and push
 on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        required: true
+        default: "dev"
+        type: string
+      ref:
+        required: true
+        type: string
   workflow_call:
     inputs:
       environment:


### PR DESCRIPTION
# Description

This PR addresses the stability issues with the Twistlock EC2 instance, which frequently faced issues during scans. We've improved the configuration of the `utility-twistlock-scanner` EC2 instance to ensure it remains stable and reliably scans our container images on every deploy.

Specifically this is simply to re-add twistlock back into our dev deploy workflow

Addresses the notification-api aspect of [#626](https://app.zenhub.com/workspaces/va-notify-620d21369d810a00146ed9c8/issues/gh/department-of-veterans-affairs/vanotify-infra/626)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Twistlock has stayed standing for multiple days and multiple tests (beyond 5).

## Checklist

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional Information

Relevant resources:
- [twistlock-init.cfg](https://github.com/department-of-veterans-affairs/vanotify-infra/blob/master/cd/utility-infrastructure/twistlock-init.cfg)
- [twistlock.tf](https://github.com/department-of-veterans-affairs/vanotify-infra/blob/master/cd/utility-infrastructure/twistlock.tf)
- [twistlock.yml](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/workflows/twistlock.yml)
- [EC2 Best Practices](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-best-practices.html)
- [EC2 Instance Types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html)
