### PR TITLE
#1360 POST /v3/notifications/ revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ install-safety:
 check-dependencies: install-safety ## Scan dependencies for security vulnerabilities
 	# Ignored issues not described here are documented in requirements-app.txt.
 	# 59956 will be resolved by upgrading certifi to >=2023.07.22.
-	safety check -r requirements.txt --full-report -i 51668 -i 59234 -i 59956
+	# 60223, 60224, and 60225 will be resolved during the next routine upgrade to cryptography>=41.0.3.
+	safety check -r requirements.txt --full-report -i 51668 -i 59234 -i 59956 -i 60223 -i 60224 -i 60225
 
 .PHONY:
 	help \

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -40,14 +40,18 @@ class AuthError(Exception):
 
     def to_dict_v3(self):
         """
-        All V3 routes use this format for the HTTP 401 response.
+        All v3 routes use this format for 401 and 403 responses.
         """
+
+        error_message = self.short_message
+        if error_message.lower().startswith("invalid token:"):
+            error_message = "Invalid token"
 
         return {
             "errors": [
                 {
                     "error": "AuthError",
-                    "message": self.short_message
+                    "message": error_message
                 }
             ]
         }

--- a/app/v3/__init__.py
+++ b/app/v3/__init__.py
@@ -37,7 +37,7 @@ def bad_request(error):
 
 
 @v3_blueprint.errorhandler(ValidationError)
-def bad_request(error):
+def schema_validation_error(error):
     """
     This is for schema validation errors, which should result in a 400 response.
     """

--- a/app/v3/__init__.py
+++ b/app/v3/__init__.py
@@ -42,11 +42,17 @@ def schema_validation_error(error):
     This is for schema validation errors, which should result in a 400 response.
     """
 
+    if "is not valid under any of the given schemas" in error.message:
+        # This is probably a failure of an "anyOf" clause, and the default error message is not helpful.
+        error_message = error.schema["anyOfValidationMessage"]
+    else:
+        error_message = error.message
+
     return {
         "errors": [
             {
                 "error": "ValidationError",
-                "message": error.message,
+                "message": error_message,
             }
         ]
     }, 400

--- a/app/v3/__init__.py
+++ b/app/v3/__init__.py
@@ -1,6 +1,7 @@
 from app.authentication.auth import AuthError
 from flask import Blueprint
 from jsonschema import ValidationError
+from werkzeug.exceptions import BadRequest
 
 v3_blueprint = Blueprint("v3", __name__, url_prefix='/v3')
 
@@ -11,11 +12,36 @@ v3_blueprint = Blueprint("v3", __name__, url_prefix='/v3')
 
 @v3_blueprint.errorhandler(AuthError)
 def auth_error(error):
+    """
+    Generally 401 and 403 errors.
+    """
+
     return error.to_dict_v3(), error.code
 
 
+@v3_blueprint.errorhandler(BadRequest)
+def bad_request(error):
+    """
+    This is for 400 responses not caused by schema validation failure.  If error.__cause__
+    is not None, the syntax "raise BadRequest from e" raised the exception.
+    """
+
+    return {
+        "errors": [
+            {
+                "error": "BadRequest",
+                "message": str(error.__cause__) if (error.__cause__ is not None) else str(error),
+            }
+        ]
+    }, 400
+
+
 @v3_blueprint.errorhandler(ValidationError)
-def validation_error(error):
+def bad_request(error):
+    """
+    This is for schema validation errors, which should result in a 400 response.
+    """
+
     return {
         "errors": [
             {

--- a/app/v3/__init__.py
+++ b/app/v3/__init__.py
@@ -23,7 +23,7 @@ def auth_error(error):
 def bad_request(error):
     """
     This is for 400 responses not caused by schema validation failure.  If error.__cause__
-    is not None, the syntax "raise BadRequest from e" raised the exception.
+    is not None, the syntax "raise BadRequest from <exception>" raised the exception.
     """
 
     return {

--- a/app/v3/__init__.py
+++ b/app/v3/__init__.py
@@ -42,7 +42,7 @@ def schema_validation_error(error):
     This is for schema validation errors, which should result in a 400 response.
     """
 
-    if "is not valid under any of the given schemas" in error.message:
+    if "is not valid under any of the given schemas" in error.message and "anyOfValidationMessage" in error.schema:
         # This is probably a failure of an "anyOf" clause, and the default error message is not helpful.
         error_message = error.schema["anyOfValidationMessage"]
     else:

--- a/app/v3/notifications/notification_schemas.py
+++ b/app/v3/notifications/notification_schemas.py
@@ -48,7 +48,10 @@ notification_v3_post_email_request_schema = {
     "anyOf": [
         {"required": ["email_address"]},
         {"required": ["recipient_identifier"]}
-    ]
+    ],
+    "validationMessage": {
+        "anyOf": "Please provide either an e-mail address or recipient identifier."
+    }
 }
 notification_v3_post_email_request_schema["properties"].update(common_properties)
 
@@ -67,6 +70,9 @@ notification_v3_post_sms_request_schema = {
     "anyOf": [
         {"required": ["phone_number"]},
         {"required": ["recipient_identifier"]}
-    ]
+    ],
+    "validationMessage": {
+        "anyOf": "Please provide either a phone number or recipient identifier."
+    }
 }
 notification_v3_post_sms_request_schema["properties"].update(common_properties)

--- a/app/v3/notifications/notification_schemas.py
+++ b/app/v3/notifications/notification_schemas.py
@@ -1,6 +1,9 @@
 """
 Define schemas to validate requests to /v3/notifications.
 https://json-schema.org/understanding-json-schema/
+
+The ValidationError handler should reference the schemas' "anyOfValidationMessage" attribute, which is not part
+of the JSON schema specification, to customize the error message.
 """
 
 from app.models import EMAIL_TYPE, SMS_TYPE
@@ -49,7 +52,8 @@ notification_v3_post_email_request_schema = {
     "anyOf": [
         {"required": ["email_address"]},
         {"required": ["recipient_identifier"]}
-    ]
+    ],
+    "anyOfValidationMessage": "You must provide an e-mail address or recipient identifier."
 }
 notification_v3_post_email_request_schema["properties"].update(common_properties)
 
@@ -68,6 +72,7 @@ notification_v3_post_sms_request_schema = {
     "anyOf": [
         {"required": ["phone_number"]},
         {"required": ["recipient_identifier"]}
-    ]
+    ],
+    "anyOfValidationMessage": "You must provide a phone number or recipient identifier."
 }
 notification_v3_post_sms_request_schema["properties"].update(common_properties)

--- a/app/v3/notifications/notification_schemas.py
+++ b/app/v3/notifications/notification_schemas.py
@@ -31,6 +31,7 @@ common_properties = {
     "personalisation": personalisation,
     "recipient_identifier": recipient_identifier_schema,
     "reference": {"type": "string"},
+    "scheduled_for": {"type": "string", "format": "date-time"},
     "template_id": {"type": "string", "format": "uuid"}
 }
 
@@ -48,10 +49,7 @@ notification_v3_post_email_request_schema = {
     "anyOf": [
         {"required": ["email_address"]},
         {"required": ["recipient_identifier"]}
-    ],
-    "validationMessage": {
-        "anyOf": "Please provide either an e-mail address or recipient identifier."
-    }
+    ]
 }
 notification_v3_post_email_request_schema["properties"].update(common_properties)
 
@@ -70,9 +68,6 @@ notification_v3_post_sms_request_schema = {
     "anyOf": [
         {"required": ["phone_number"]},
         {"required": ["recipient_identifier"]}
-    ],
-    "validationMessage": {
-        "anyOf": "Please provide either a phone number or recipient identifier."
-    }
+    ]
 }
 notification_v3_post_sms_request_schema["properties"].update(common_properties)

--- a/app/v3/notifications/notification_schemas.py
+++ b/app/v3/notifications/notification_schemas.py
@@ -24,48 +24,49 @@ recipient_identifier_schema = {
 }
 
 
-notification_v3_post_request_schema = {
+# All notification types include these properties.  They should be added to notification-type-specific schemas.
+common_properties = {
+    "billing_code": {"type": "string", "maxLength": 256},
+    "client_reference": {"type": "string"},
+    "personalisation": personalisation,
+    "recipient_identifier": recipient_identifier_schema,
+    "reference": {"type": "string"},
+    "template_id": {"type": "string", "format": "uuid"}
+}
+
+
+notification_v3_post_email_request_schema = {
     "$schema": "http://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
-        "billing_code": {"type": "string", "maxLength": 256},
-        "client_reference": {"type": "string"},
         "email_address": {"type": "string", "format": "email"},
         "email_reply_to_id": {"type": "string", "format": "uuid"},
-        "notification_type": {"type": "string", "enum": [EMAIL_TYPE, SMS_TYPE]},
-        "personalisation": personalisation,
-        # Note that there is no "phone_number" string format, contrary to the v2 schema definition.
-        "phone_number": {"type": "string"},
-        "recipient_identifier": recipient_identifier_schema,
-        "reference": {"type": "string"},
-        "sms_sender_id": {"type": "string", "format": "uuid"},
-        "template_id": {"type": "string", "format": "uuid"}
+        "notification_type": {"const": EMAIL_TYPE},
     },
     "additionalProperties": False,
     "required": ["notification_type", "template_id"],
     "anyOf": [
         {"required": ["email_address"]},
+        {"required": ["recipient_identifier"]}
+    ]
+}
+notification_v3_post_email_request_schema["properties"].update(common_properties)
+
+
+notification_v3_post_sms_request_schema = {
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "notification_type": {"const": SMS_TYPE},
+        # Note that there is no "phone_number" string format, contrary to the v2 schema definition.
+        "phone_number": {"type": "string"},
+        "sms_sender_id": {"type": "string", "format": "uuid"},
+    },
+    "additionalProperties": False,
+    "required": ["notification_type", "template_id"],
+    "anyOf": [
         {"required": ["phone_number"]},
         {"required": ["recipient_identifier"]}
-    ],
-    "not": {
-        "anyOf": [
-            # "phone_number" and "sms_sender_id" must not be present for e-mail notifications.
-            {
-                "properties": {"notification_type": {"const": EMAIL_TYPE}},
-                "anyOf": [
-                    {"required": ["phone_number"]},
-                    {"required": ["sms_sender_id"]}
-                ]
-            },
-            # "email_address" and "email_reply_to_id" must not be present for SMS notifications.
-            {
-                "properties": {"notification_type": {"const": SMS_TYPE}},
-                "anyOf": [
-                    {"required": ["email_address"]},
-                    {"required": ["email_reply_to_id"]}
-                ]
-            }
-        ]
-    }
+    ]
 }
+notification_v3_post_sms_request_schema["properties"].update(common_properties)

--- a/app/v3/notifications/rest.py
+++ b/app/v3/notifications/rest.py
@@ -69,7 +69,7 @@ def v3_send_notification(request_data: dict) -> str:
 
     if "phone_number" in request_data:
         # This might raise phonenumbers.phonenumberutil.NumberParseException.
-        phone_number = phonenumbers.parse(request_data["phone_number"]) 
+        phone_number = phonenumbers.parse(request_data["phone_number"])
 
         # This is a possible phone number, but is it in an assigned exchange (valid area code, etc.)?
         if not phonenumbers.is_valid_number(phone_number):

--- a/app/v3/notifications/rest.py
+++ b/app/v3/notifications/rest.py
@@ -71,7 +71,7 @@ def v3_send_notification(request_data: dict) -> str:
         # This might raise phonenumbers.phonenumberutil.NumberParseException.
         phone_number = phonenumbers.parse(request_data["phone_number"]) 
 
-        # This is a possible phone number, but is it in an assigned exchange (valid area code)?
+        # This is a possible phone number, but is it in an assigned exchange (valid area code, etc.)?
         if not phonenumbers.is_valid_number(phone_number):
             raise ValueError(f"{request_data['phone_number']} is not a valid phone number.")
 

--- a/app/v3/notifications/rest.py
+++ b/app/v3/notifications/rest.py
@@ -6,7 +6,7 @@ from app.v3.notifications.notification_schemas import (
     notification_v3_post_email_request_schema,
     notification_v3_post_sms_request_schema,
 )
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from flask import Blueprint, request
 from jsonschema import FormatChecker
 from jsonschema.validators import Draft202012Validator

--- a/app/v3/notifications/rest.py
+++ b/app/v3/notifications/rest.py
@@ -1,16 +1,34 @@
 """ Implement v3 endpoints for the Notification model. """
 
+import phonenumbers
 from app.models import EMAIL_TYPE, SMS_TYPE
-from app.v3.notifications.notification_schemas import notification_v3_post_request_schema
+from app.v3.notifications.notification_schemas import (
+    notification_v3_post_email_request_schema,
+    notification_v3_post_sms_request_schema,
+)
 from flask import Blueprint, request
+from jsonschema import FormatChecker
 from jsonschema.validators import Draft202012Validator
 from uuid import uuid4
+from werkzeug.exceptions import BadRequest
 
 v3_notifications_blueprint = Blueprint("v3_notifications", __name__, url_prefix='/notifications')
 
-# Create an instance of Draft202012Validator to validate post request data.  Unit tests
-# should call jsonschema.validate, which also verifies that the schema is valid.
-v3_notifications_post_request_validator = Draft202012Validator(notification_v3_post_request_schema)
+#########################################################################
+# Create instances of Draft202012Validator to validate post request data.
+#########################################################################
+
+v3_notifications_post_email_request_validator = Draft202012Validator(
+    notification_v3_post_email_request_schema,
+    format_checker=FormatChecker(["email", "uuid"])
+)
+
+v3_notifications_post_sms_request_validator = Draft202012Validator(
+    notification_v3_post_sms_request_schema,
+    format_checker=FormatChecker(["uuid"])
+)
+
+#########################################################################
 
 
 @v3_notifications_blueprint.route("/email", methods=["POST"])
@@ -18,8 +36,7 @@ def v3_post_notification_email():
     request_data = request.get_json()
     request_data["notification_type"] = EMAIL_TYPE
 
-    # This might raise jsonschema.ValidationError, which should trigger an error handler in
-    # app/v3/__init__.py that returns a 400 response.
+    # This might raise an exception, which should trigger an error handler that returns a 400 response.
     return {"id": v3_send_notification(request_data)}, 202
 
 
@@ -28,20 +45,35 @@ def v3_post_notification_sms():
     request_data = request.get_json()
     request_data["notification_type"] = SMS_TYPE
 
-    # This might raise jsonschema.ValidationError, which should trigger an error handler in
-    # app/v3/__init__.py that returns a 400 response.
-    return {"id": v3_send_notification(request_data)}, 202
+    try:
+        return {"id": v3_send_notification(request_data)}, 202
+    except (phonenumbers.phonenumberutil.NumberParseException, ValueError) as e:
+        # This should trigger an error handler that returns a 400 response.
+        raise BadRequest from e
 
 
 def v3_send_notification(request_data: dict) -> str:
     """
     This function can be called directly to send notifications without having to make API requests.
     In that use case, the upstream code is responsbile for populating notification_type and for
-    catching jsonschema.ValidationError.
+    catching exceptions.
     """
 
     # This might raise jsonschema.ValidationError.
-    v3_notifications_post_request_validator.validate(request_data)
+    if request_data["notification_type"] == EMAIL_TYPE:
+        v3_notifications_post_email_request_validator.validate(request_data)
+    elif request_data["notification_type"] == SMS_TYPE:
+        v3_notifications_post_sms_request_validator.validate(request_data)
+    else:
+        raise RuntimeError("Unrecognized notification type.  This is a programming error.")
+
+    if "phone_number" in request_data:
+        # This might raise phonenumbers.phonenumberutil.NumberParseException.
+        phone_number = phonenumbers.parse(request_data["phone_number"]) 
+
+        # This is a possible phone number, but is it in an assigned exchange (valid area code)?
+        if not phonenumbers.is_valid_number(phone_number):
+            raise ValueError(f"{request_data['phone_number']} is not a valid phone number.")
 
     # This has the side effect of modifying the input in the upstream code.
     request_data["id"] = str(uuid4())

--- a/app/v3/notifications/rest.py
+++ b/app/v3/notifications/rest.py
@@ -6,6 +6,7 @@ from app.v3.notifications.notification_schemas import (
     notification_v3_post_email_request_schema,
     notification_v3_post_sms_request_schema,
 )
+from datetime import datetime, timedelta, timezone
 from flask import Blueprint, request
 from jsonschema import FormatChecker
 from jsonschema.validators import Draft202012Validator
@@ -20,12 +21,12 @@ v3_notifications_blueprint = Blueprint("v3_notifications", __name__, url_prefix=
 
 v3_notifications_post_email_request_validator = Draft202012Validator(
     notification_v3_post_email_request_schema,
-    format_checker=FormatChecker(["email", "uuid"])
+    format_checker=FormatChecker(["date-time", "email", "uuid"])
 )
 
 v3_notifications_post_sms_request_validator = Draft202012Validator(
     notification_v3_post_sms_request_schema,
-    format_checker=FormatChecker(["uuid"])
+    format_checker=FormatChecker(["date-time", "uuid"])
 )
 
 #########################################################################
@@ -36,8 +37,12 @@ def v3_post_notification_email():
     request_data = request.get_json()
     request_data["notification_type"] = EMAIL_TYPE
 
-    # This might raise an exception, which should trigger an error handler that returns a 400 response.
-    return {"id": v3_send_notification(request_data)}, 202
+    try:
+        # This might trigger an error handler for ValidationError that returns a 400 response.
+        return {"id": v3_send_notification(request_data)}, 202
+    except ValueError as e:
+        # This should trigger an error handler for BadRequest that returns a 400 response.
+        raise BadRequest from e
 
 
 @v3_notifications_blueprint.route("/sms", methods=["POST"])
@@ -46,9 +51,10 @@ def v3_post_notification_sms():
     request_data["notification_type"] = SMS_TYPE
 
     try:
+        # This might trigger an error handler for ValidationError that returns a 400 response.
         return {"id": v3_send_notification(request_data)}, 202
     except (phonenumbers.phonenumberutil.NumberParseException, ValueError) as e:
-        # This should trigger an error handler that returns a 400 response.
+        # This should trigger an error handler for BadRequest that returns a 400 response.
         raise BadRequest from e
 
 
@@ -66,6 +72,18 @@ def v3_send_notification(request_data: dict) -> str:
         v3_notifications_post_sms_request_validator.validate(request_data)
     else:
         raise RuntimeError("Unrecognized notification type.  This is a programming error.")
+
+    if "scheduled_for" in request_data:
+        # The scheduled time must not be in the past or more than a calendar day in the future.
+        # The time should be in ISO 8601 format with timezone data, as required by the validator.
+        scheduled_for = datetime.fromisoformat(request_data["scheduled_for"])
+
+        right_now = datetime.now(timezone.utc)
+        if scheduled_for < right_now:
+            raise ValueError("The scheduled time cannot be in the past.")
+
+        if (scheduled_for - right_now).days > 1:
+            raise ValueError("The scheduled time cannot be more than one calendar day in the future.")
 
     if "phone_number" in request_data:
         # This might raise phonenumbers.phonenumberutil.NumberParseException.

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -1353,7 +1353,7 @@ paths:
                   personalisation:
                     full_name: John Smith
                     claim_id: '123456'
-                  scheduled_for: string
+                  scheduled_for: "2023-09-06T19:55:23.592973+00:00"
                   billing_code: string
                   email_reply_to_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
                   email: "test@notification.com"
@@ -1365,7 +1365,7 @@ paths:
                   personalisation:
                     full_name: John Smith
                     claim_id: '123456'
-                  scheduled_for: string
+                  scheduled_for: "2023-09-06T19:55:23.592973+00:00"
                   billing_code: string
                   email_reply_to_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
                   recipient_identifier:
@@ -1379,7 +1379,7 @@ paths:
                   personalisation:
                     full_name: John Smith
                     claim_id: '123456'
-                  scheduled_for: string
+                  scheduled_for: "2023-09-06T19:55:23.592973+00:00"
                   billing_code: string
                   email_reply_to_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
                   email: "test@notification.com"
@@ -1415,7 +1415,7 @@ paths:
                   personalisation:
                     full_name: John Smith
                     claim_id: '123456'
-                  scheduled_for: string
+                  scheduled_for: "2023-09-06T19:55:23.592973+00:00"
                   billing_code: string
                   sms_sender_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
                   phone_number: "+19876543210"
@@ -1427,7 +1427,7 @@ paths:
                   personalisation:
                     full_name: John Smith
                     claim_id: '123456'
-                  scheduled_for: string
+                  scheduled_for: "2023-09-06T19:55:23.592973+00:00"
                   billing_code: string
                   sms_sender_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6                  
                   recipient_identifier:
@@ -1441,7 +1441,7 @@ paths:
                   personalisation:
                     full_name: John Smith
                     claim_id: '123456'
-                  scheduled_for: string
+                  scheduled_for: "2023-09-06T19:55:23.592973+00:00"
                   billing_code: string
                   sms_sender_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6                  
                   phone_number: "+19876543210"
@@ -2453,13 +2453,16 @@ components:
         client_reference:
           type: string
         email_reply_to_id:
-          description: For e-mail notifications
           type: string
           format: uuid
         personalisation:
           $ref: "#/components/schemas/Personalisation"
         reference:
           type: string
+        scheduled_for:
+          description: An ISO 8601 formatted date-time string with timezone info
+          type: string
+          format: date-time
         template_id:
           $ref: "#/components/schemas/Id"
       additionalProperties: false
@@ -2487,8 +2490,11 @@ components:
           $ref: "#/components/schemas/Personalisation"
         reference:
           type: string
+        scheduled_for:
+          description: An ISO 8601 formatted date-time string with timezone info
+          type: string
+          format: date-time
         sms_sender_id:
-          description: For SMS notifications
           type: string
           format: uuid
         template_id:

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -1348,6 +1348,7 @@ paths:
               email:
                 value:
                   reference: string
+                  client_reference: string
                   template_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
                   personalisation:
                     full_name: John Smith
@@ -1359,6 +1360,7 @@ paths:
               recipient_identifier:
                 value:
                   reference: string
+                  client_reference: string
                   template_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
                   personalisation:
                     full_name: John Smith
@@ -1372,6 +1374,7 @@ paths:
               both:
                 value:
                   reference: string
+                  client_reference: string
                   template_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
                   personalisation:
                     full_name: John Smith
@@ -1386,15 +1389,7 @@ paths:
         required: true
       responses:
         "202":
-          description: Accepted
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                    format: uuid
+          $ref: "#/components/responses/AcceptedV3"
         "400":
           $ref: "#/components/responses/BadRequestV3"
         "401":
@@ -1415,6 +1410,7 @@ paths:
               phone_number:
                 value:
                   reference: string
+                  client_reference: string
                   template_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
                   personalisation:
                     full_name: John Smith
@@ -1426,6 +1422,7 @@ paths:
               recipient_identifier:
                 value:
                   reference: string
+                  client_reference: string
                   template_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
                   personalisation:
                     full_name: John Smith
@@ -1439,6 +1436,7 @@ paths:
               both:
                 value:
                   reference: string
+                  client_reference: string
                   template_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
                   personalisation:
                     full_name: John Smith
@@ -1453,15 +1451,7 @@ paths:
         required: true
       responses:
         "202":
-          description: Accepted
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                    format: uuid
+          $ref: "#/components/responses/AcceptedV3"
         "400":
           $ref: "#/components/responses/BadRequestV3"
         "401":
@@ -1613,6 +1603,14 @@ components:
       description: CommunicationItem identifier
       example: e925b547-8195-4ed2-83c5-0633a74d780a
   responses:
+    AcceptedV3:
+      description: Accepted
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/V3AcceptedResponse"
+          example:
+            id: 9ffb5212-e621-45df-820d-97ee65d392ab
     BadRequest:
       description: Bad Request
       content:
@@ -1630,7 +1628,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/V3Response400"
+            $ref: "#/components/schemas/V3ErrorResponse"
           example:
             errors:
               - error: ValidationError
@@ -1651,7 +1649,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/V3Response401"
+            $ref: "#/components/schemas/V3ErrorResponse"
           example:
             errors:
               - error: AuthError
@@ -1661,7 +1659,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/V3Response403"
+            $ref: "#/components/schemas/V3ErrorResponse"
           example:
             errors:
               - error: AuthError
@@ -1765,8 +1763,8 @@ components:
                 type: string
               message:
                 type: string
-    V3Response400:
-      description: 400 response for all V3 routes
+    V3ErrorResponse:
+      description: 4xx and 5xx response for all V3 routes
       type: object
       properties:
         errors:
@@ -1782,42 +1780,17 @@ components:
             required:
               - error
               - message
-    V3Response401:
-      description: 401 response for all V3 routes
+      required:
+        - errors
+    V3AcceptedResponse:
+      description: 202 Accepted
       type: object
       properties:
-        errors:
-          type: array
-          items:
-            type: object
-            properties:
-              error:
-                type: string
-                const: AuthError
-              message:
-                type: string
-                const: "Unauthortized, authentication token must be provided"
-            required:
-              - error
-              - message
-    V3Response403:
-      description: 403 response for all V3 routes
-      type: object
-      properties:
-        errors:
-          type: array
-          items:
-            type: object
-            properties:
-              error:
-                type: string
-                const: AuthError
-              message:
-                type: string
-                const: Invalid token
-            required:
-              - error
-              - message
+        id:
+          type: string
+          format: uuid
+      required:
+        - id
     ErrorMessage:
       type: object
       properties:

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -1398,7 +1398,9 @@ paths:
         "400":
           $ref: "#/components/responses/BadRequestV3"
         "401":
-          $ref: "#/components/responses/UnauthorizedV3"
+          $ref: "#/components/responses/Unauthorized_401_V3"
+        "403":
+          $ref: "#/components/responses/Unauthorized_403_V3"
   /v3/notifications/sms:
     post:
       summary: Send a SMS notification
@@ -1463,7 +1465,9 @@ paths:
         "400":
           $ref: "#/components/responses/BadRequestV3"
         "401":
-          $ref: "#/components/responses/UnauthorizedV3"
+          $ref: "#/components/responses/Unauthorized_401_V3"
+        "403":
+          $ref: "#/components/responses/Unauthorized_403_V3"
   /inbound-number:
     get:
       summary: Retrieve an inbound number
@@ -1630,8 +1634,7 @@ components:
           example:
             errors:
               - error: ValidationError
-                message: "sms_sender_id e925b547-8195-4ed2-83c5-0633a74d780a does not exist in database
-                                  for service id 9ffb5212-e621-45df-820d-97ee65d392ab"
+                message: "template_id is not a valid uuid"
     Unauthorized:
       description: No Bearer authentication provided
       content:
@@ -1643,8 +1646,8 @@ components:
             message:
               token:
                 - 'Unauthorized, authentication token must be provided'
-    UnauthorizedV3:
-      description: No Bearer authentication provided
+    Unauthorized_401_V3:
+      description: Not authenticated
       content:
         application/json:
           schema:
@@ -1653,6 +1656,16 @@ components:
             errors:
               - error: AuthError
                 message: "Unauthorized, authentication token must be provided"
+    Unauthorized_403_V3:
+      description: Not authorized
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/V3Response403"
+          example:
+            errors:
+              - error: AuthError
+                message: Invalid token
     AdminAuthError:
       description: Authentication Error for Admin endpoints
       content:
@@ -1784,6 +1797,24 @@ components:
               message:
                 type: string
                 const: "Unauthortized, authentication token must be provided"
+            required:
+              - error
+              - message
+    V3Response403:
+      description: 403 response for all V3 routes
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              error:
+                type: string
+                const: AuthError
+              message:
+                type: string
+                const: Invalid token
             required:
               - error
               - message

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -47,6 +47,11 @@ marshmallow ~= 2.20.5
 marshmallow-sqlalchemy ~= 0.22.3
 nanoid >= 2.0.0
 notifications-python-client >= 8.0.1
+
+# Sending an SMS message with v3 endpoints uses this package to test for a valid phone number.  The package
+# is also a dependency of notification-utils.
+phonenumbers ~= 8.12.57
+
 psycopg2-binary >= 2.9.6
 pwnedpasswords >= 2.0.0
 PyJWT >= 2.8.0
@@ -68,3 +73,7 @@ SQLAlchemy ~= 1.4.49
 twilio >= 8.5.0
 Unidecode >= 1.3.6
 validatesns >= 0.1.1
+
+# Flask depends on this package.  It's listed here as a top level dependency--intentionally with no version--because
+# it's directly imported in v3 error handling code to reference the exception BadRequest.
+Werkzeug

--- a/tests/app/v3/notifications/test_notification_schemas.py
+++ b/tests/app/v3/notifications/test_notification_schemas.py
@@ -24,17 +24,32 @@ def test_notification_v3_post_request_schemas():
     v3_notifications_post_sms_request_validator.check_schema(notification_v3_post_sms_request_schema)
 
 
-def test_v3_notifications_post_request_validators_require_notification_type():
+def test_v3_notifications_post_email_request_validator_requires_notification_type():
     post_data = {
+        "notification_type": EMAIL_TYPE,
         "email_address": "test@va.gov",
         "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
     }
 
+    # This should not raise ValidationError.
+    v3_notifications_post_email_request_validator.validate(post_data)
+
+    del post_data["notification_type"]
     with pytest.raises(ValidationError):
         v3_notifications_post_email_request_validator.validate(post_data)
 
-    post_data["phone_number"] = "+12701234567"
 
+def test_v3_notifications_post_sms_request_validator_requires_notification_type():
+    post_data = {
+        "notification_type": SMS_TYPE,
+        "phone_number": "+12701234567",
+        "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+    }
+
+    # This should not raise ValidationError.
+    v3_notifications_post_sms_request_validator.validate(post_data)
+
+    del post_data["notification_type"]
     with pytest.raises(ValidationError):
         v3_notifications_post_sms_request_validator.validate(post_data)
 
@@ -119,6 +134,7 @@ def test_v3_notifications_post_request_validators_require_notification_type():
                     },
                 },
                 "reference": "reference",
+                "scheduled_for": "2023-09-06T19:55:23.592973+00:00",
             },
             True,
         ),
@@ -149,6 +165,14 @@ def test_v3_notifications_post_request_validators_require_notification_type():
             },
             True,
         ),
+        (
+            {
+                "email_address": "test@va.gov",
+                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+                "scheduled_for": "not a date-time",
+            },
+            False,
+        ),
     ),
     ids=(
         "send with e-mail address",
@@ -162,6 +186,7 @@ def test_v3_notifications_post_request_validators_require_notification_type():
         "all optional fields including file personalisation",
         "non-file personalisation",
         "file and non-file personalisation",
+        "scheduled_for not a date-time",
     )
 )
 def test_v3_notifications_post_email_request_validator(post_data: dict, should_validate: bool):
@@ -258,6 +283,7 @@ def test_v3_notifications_post_email_request_validator(post_data: dict, should_v
                     },
                 },
                 "reference": "reference",
+                "scheduled_for": "2023-09-06T19:55:23.592973+00:00",
             },
             True,
         ),
@@ -288,6 +314,14 @@ def test_v3_notifications_post_email_request_validator(post_data: dict, should_v
             },
             True,
         ),
+        (
+            {
+                "phone_number": "+12701234567",
+                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+                "scheduled_for": "not a date-time",
+            },
+            False,
+        ),
     ),
     ids=(
         "send with phone number",
@@ -301,6 +335,7 @@ def test_v3_notifications_post_email_request_validator(post_data: dict, should_v
         "all optional fields including file personalisation",
         "non-file personalisation",
         "file and non-file personalisation",
+        "scheduled_for not a date-time",
     )
 )
 def test_v3_notifications_post_sms_request_validator(post_data: dict, should_validate: bool):

--- a/tests/app/v3/notifications/test_notification_schemas.py
+++ b/tests/app/v3/notifications/test_notification_schemas.py
@@ -2,8 +2,41 @@
 
 import pytest
 from app.models import EMAIL_TYPE, SMS_TYPE
-from app.v3.notifications.notification_schemas import notification_v3_post_request_schema
-from jsonschema import FormatChecker, validate, ValidationError
+from app.v3.notifications.notification_schemas import (
+    notification_v3_post_email_request_schema,
+    notification_v3_post_sms_request_schema,
+)
+from app.v3.notifications.rest import (
+    v3_notifications_post_email_request_validator,
+    v3_notifications_post_sms_request_validator,
+)
+from jsonschema import ValidationError
+
+
+def test_notification_v3_post_request_schemas():
+    """
+    Test that the schemas declared in app/v3/notifications/notification_schemas.py are valid
+    with the validators declared in app/v3/notifications/rest.py.
+    """
+
+    # These checks should not raise SchemaError.
+    v3_notifications_post_email_request_validator.check_schema(notification_v3_post_email_request_schema)
+    v3_notifications_post_sms_request_validator.check_schema(notification_v3_post_sms_request_schema)
+
+
+def test_v3_notifications_post_request_validators_require_notification_type():
+    post_data = {
+        "email_address": "test@va.gov",
+        "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+    }
+
+    with pytest.raises(ValidationError):
+        v3_notifications_post_email_request_validator.validate(post_data)
+
+    post_data["phone_number"] = "+12701234567"
+
+    with pytest.raises(ValidationError):
+        v3_notifications_post_sms_request_validator.validate(post_data)
 
 
 @pytest.mark.parametrize(
@@ -11,16 +44,6 @@ from jsonschema import FormatChecker, validate, ValidationError
     (
         (
             {
-                "notification_type": SMS_TYPE,
-                "phone_number": "+12701234567",
-                "sms_sender_id": "4f365dd4-332e-454d-94ff-e393463602db",
-                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
-            },
-            True,
-        ),
-        (
-            {
-                "notification_type": EMAIL_TYPE,
                 "email_address": "test@va.gov",
                 "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
             },
@@ -28,50 +51,6 @@ from jsonschema import FormatChecker, validate, ValidationError
         ),
         (
             {
-                "notification_type": SMS_TYPE,
-                "email_address": "test@va.gov",
-                "sms_sender_id": "4f365dd4-332e-454d-94ff-e393463602db",
-                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
-            },
-            False,
-        ),
-        (
-            {
-                "notification_type": EMAIL_TYPE,
-                "phone_number": "+12701234567",
-                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
-            },
-            False,
-        ),
-        (
-            {
-                "notification_type": SMS_TYPE,
-                "phone_number": "+12701234567",
-                "email_reply_to_id": "4f365dd4-332e-454d-94ff-e393463602db",
-                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
-            },
-            False,
-        ),
-        (
-            {
-                "notification_type": EMAIL_TYPE,
-                "email_address": "test@va.gov",
-                "sms_sender_id": "4f365dd4-332e-454d-94ff-e393463602db",
-                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
-            },
-            False,
-        ),
-        (
-            {
-                "notification_type": SMS_TYPE,
-                "phone_number": "+12701234567",
-                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
-            },
-            True,
-        ),
-        (
-            {
-                "notification_type": EMAIL_TYPE,
                 "email_address": "not an e-mail address",
                 "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
             },
@@ -79,7 +58,12 @@ from jsonschema import FormatChecker, validate, ValidationError
         ),
         (
             {
-                "notification_type": EMAIL_TYPE,
+                "email_address": "test@va.gov",
+            },
+            False,
+        ),
+        (
+            {
                 "email_address": "test@va.gov",
                 "template_id": "not a UUID4",
             },
@@ -87,19 +71,6 @@ from jsonschema import FormatChecker, validate, ValidationError
         ),
         (
             {
-                "notification_type": SMS_TYPE,
-                "recipient_identifier": {
-                    "id_type": "VAPROFILEID",
-                    "id_value": "some value",
-                },
-                "sms_sender_id": "4f365dd4-332e-454d-94ff-e393463602db",
-                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
-            },
-            True,
-        ),
-        (
-            {
-                "notification_type": EMAIL_TYPE,
                 "recipient_identifier": {
                     "id_type": "EDIPI",
                     "id_value": "some value",
@@ -110,7 +81,6 @@ from jsonschema import FormatChecker, validate, ValidationError
         ),
         (
             {
-                "notification_type": EMAIL_TYPE,
                 "email_address": "test@va.gov",
                 "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
                 "something": 42,
@@ -119,14 +89,12 @@ from jsonschema import FormatChecker, validate, ValidationError
         ),
         (
             {
-                "notification_type": EMAIL_TYPE,
                 "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
             },
             False,
         ),
         (
             {
-                "notification_type": EMAIL_TYPE,
                 "email_address": "test@va.gov",
                 "recipient_identifier": {
                     "id_type": "EDIPI",
@@ -138,33 +106,6 @@ from jsonschema import FormatChecker, validate, ValidationError
         ),
         (
             {
-                "notification_type": SMS_TYPE,
-                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
-            },
-            False,
-        ),
-        (
-            {
-                "notification_type": SMS_TYPE,
-                "phone_number": "+12701234567",
-                "recipient_identifier": {
-                    "id_type": "EDIPI",
-                    "id_value": "some value",
-                },
-                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
-            },
-            True,
-        ),
-        (
-            {
-                "notification_type": "some other type",
-                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
-            },
-            False,
-        ),
-        (
-            {
-                "notification_type": EMAIL_TYPE,
                 "email_address": "test@va.gov",
                 "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
                 "billing_code": "billing code",
@@ -183,7 +124,6 @@ from jsonschema import FormatChecker, validate, ValidationError
         ),
         (
             {
-                "notification_type": EMAIL_TYPE,
                 "email_address": "test@va.gov",
                 "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
                 "personalisation": {
@@ -195,7 +135,6 @@ from jsonschema import FormatChecker, validate, ValidationError
         ),
         (
             {
-                "notification_type": EMAIL_TYPE,
                 "email_address": "test@va.gov",
                 "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
                 "personalisation": {
@@ -212,33 +151,168 @@ from jsonschema import FormatChecker, validate, ValidationError
         ),
     ),
     ids=(
-        "SMS with phone number",
-        "e-mail with e-mail address",
-        "SMS with e-mail address",
-        "e-mail with phone number",
-        "SMS with email_reply_to_id address",
-        "e-mail with sms_sender_id",
-        "SMS without sms_sender_id",
+        "send with e-mail address",
         "bad e-mail address",
-        "bad UUID4",
-        "SMS with recipient ID",
-        "e-mail with recipient ID",
+        "no template_id",
+        "template_id is not a valid uuid",
+        "send with recipient ID",
         "additional properties not allowed",
         'neither "email_address" nor recipient ID',
-        '"email_address" and recipient ID',
-        'neither "phone_number" nor recipient ID',
-        '"phone_number" and recipient ID',
-        "unrecognized notification type",
+        'send with "email_address" and recipient ID',
         "all optional fields including file personalisation",
         "non-file personalisation",
         "file and non-file personalisation",
     )
 )
-def test_notification_v3_post_request_schema(post_data: dict, should_validate: bool):
-    format_checker = FormatChecker(["email", "uuid"])
+def test_v3_notifications_post_email_request_validator(post_data: dict, should_validate: bool):
+    """
+    Test schema validation using the validator declared in app/v3/notifications/rest.py.
+    """
+
+    post_data["notification_type"] = EMAIL_TYPE
 
     if should_validate:
-        validate(post_data, notification_v3_post_request_schema, format_checker=format_checker)
+        v3_notifications_post_email_request_validator.validate(post_data)
     else:
         with pytest.raises(ValidationError):
-            validate(post_data, notification_v3_post_request_schema, format_checker=format_checker)
+            v3_notifications_post_email_request_validator.validate(post_data)
+
+
+@pytest.mark.parametrize(
+    "post_data, should_validate",
+    (
+        (
+            {
+                "phone_number": "+12701234567",
+                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+            },
+            True,
+        ),
+        (
+            {
+                "phone_number": 42,
+                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+            },
+            False,
+        ),
+        (
+            {
+                "phone_number": "+12701234567",
+            },
+            False,
+        ),
+        (
+            {
+                "phone_number": "+12701234567",
+                "template_id": "not a UUID4",
+            },
+            False,
+        ),
+        (
+            {
+                "recipient_identifier": {
+                    "id_type": "EDIPI",
+                    "id_value": "some value",
+                },
+                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+            },
+            True,
+        ),
+        (
+            {
+                "phone_number": "+12701234567",
+                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+                "something": 42,
+            },
+            False,
+        ),
+        (
+            {
+                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+            },
+            False,
+        ),
+        (
+            {
+                "phone_number": "+12701234567",
+                "recipient_identifier": {
+                    "id_type": "EDIPI",
+                    "id_value": "some value",
+                },
+                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+            },
+            True,
+        ),
+        (
+            {
+                "phone_number": "+12701234567",
+                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+                "billing_code": "billing code",
+                "client_reference": "client reference",
+                "sms_sender_id": "4f365dd4-332e-454d-94ff-e393463602db",
+                "personalisation": {
+                    "test_file": {
+                        "file": "string",
+                        "filename": "file name",
+                        "sending_method": "link",
+                    },
+                },
+                "reference": "reference",
+            },
+            True,
+        ),
+        (
+            {
+                "phone_number": "+12701234567",
+                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+                "personalisation": {
+                    "test1": "This is not a file.",
+                    "test2": "ditto",
+                },
+            },
+            True,
+        ),
+        (
+            {
+                "phone_number": "+12701234567",
+                "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+                "personalisation": {
+                    "test1": "This is not a file.",
+                    "test2": "ditto",
+                    "test_file": {
+                        "file": "string",
+                        "filename": "file name",
+                        "sending_method": "link",
+                    },
+                },
+            },
+            True,
+        ),
+    ),
+    ids=(
+        "send with phone number",
+        "phone number isn't a string",
+        "no template_id",
+        "template_id is not a valid uuid",
+        "send with recipient ID",
+        "additional properties not allowed",
+        'neither "phone_number" nor recipient ID',
+        '"phone_number" and recipient ID',
+        "all optional fields including file personalisation",
+        "non-file personalisation",
+        "file and non-file personalisation",
+    )
+)
+def test_v3_notifications_post_sms_request_validator(post_data: dict, should_validate: bool):
+    """
+    Test schema validation using the validator declared in app/v3/notifications/rest.py.
+    Note that JSON schema only validates that phone numbers are strings.
+    """
+
+    post_data["notification_type"] = SMS_TYPE
+
+    if should_validate:
+        v3_notifications_post_sms_request_validator.validate(post_data)
+    else:
+        with pytest.raises(ValidationError):
+            v3_notifications_post_sms_request_validator.validate(post_data)

--- a/tests/app/v3/notifications/test_rest.py
+++ b/tests/app/v3/notifications/test_rest.py
@@ -3,7 +3,8 @@
 import pytest
 from app.models import EMAIL_TYPE, SMS_TYPE
 from app.v3.notifications.rest import v3_send_notification
-from flask import url_for
+from datetime import datetime, timedelta, timezone
+from flask import Response, url_for
 from json import dumps
 from jsonschema import ValidationError
 from tests import create_authorization_header
@@ -77,7 +78,8 @@ def test_post_v3_notifications(notify_db_session, client, sample_service, reques
     Also test POSTing with bad request data to verify a 400 response.  This test does not exhaustively test
     request data combinations because tests/app/v3/notifications/test_notification_schemas.py handles that.
 
-    Also test the utility function to send notifications directly (not via an API call).
+    Also test the utility function, v3_send_notification, to send notifications directly (not via an API call).
+    The route handlers call this function.
 
     Tests for authentication are in tests/app/test_route_authentication.py.
     """
@@ -96,7 +98,7 @@ def test_post_v3_notifications(notify_db_session, client, sample_service, reques
         assert isinstance(UUID(response.get_json().get("id")), UUID)
         assert isinstance(UUID(v3_send_notification(request_data)), UUID)
     elif expected_status_code == 400:
-        assert "errors" in response.get_json()
+        assert response.get_json()["errors"][0]["error"] == "ValidationError"
         with pytest.raises(ValidationError):
             v3_send_notification(request_data)
 
@@ -133,13 +135,7 @@ def test_post_v3_notifications_phone_number_not_possible(notify_db_session, clie
         data=dumps(request_data),
         headers=(("Content-Type", "application/json"), auth_header)
     )
-    assert response.status_code == 400
-
-    response_json = response.get_json()
-    assert response_json["errors"][0]["error"] == "BadRequest"
-
-    # The error message varies.  The details don't matter for testing purposes.
-    assert "message" in response_json["errors"][0]
+    bad_request_helper(response)
 
 
 def test_post_v3_notifications_phone_number_not_valid(notify_db_session, client, sample_service):
@@ -165,3 +161,75 @@ def test_post_v3_notifications_phone_number_not_valid(notify_db_session, client,
     response_json = response.get_json()
     assert response_json["errors"][0]["error"] == "BadRequest"
     assert response_json["errors"][0]["message"].endswith("is not a valid phone number.")
+
+
+def test_post_v3_notifications_scheduled_for(notify_db_session, client, sample_service):
+    """
+    The scheduled time must not be in the past or more than a calendar day in the future.
+    """
+
+    auth_header = create_authorization_header(service_id=sample_service.id, key_type="team")
+    scheduled_for = datetime.now(timezone.utc) + timedelta(hours=2)
+    email_request_data = {
+        "notification_type": EMAIL_TYPE,
+        "email_address": "test@va.gov",
+        "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+        "scheduled_for": scheduled_for.isoformat(),
+    }
+    sms_request_data = {
+        "notification_type": SMS_TYPE,
+        "phone_number": "+18006982411",
+        "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+        "scheduled_for": scheduled_for.isoformat(),
+    }
+
+    #######################################################################
+    # Test scheduled_for is acceptable.
+    #######################################################################
+
+    response = client.post(
+        path=url_for(f"v3.v3_notifications.v3_post_notification_email"),
+        data=dumps(email_request_data),
+        headers=(("Content-Type", "application/json"), auth_header)
+    )
+    assert response.status_code == 202, response.get_json()
+
+    response = client.post(
+        path=url_for(f"v3.v3_notifications.v3_post_notification_sms"),
+        data=dumps(sms_request_data),
+        headers=(("Content-Type", "application/json"), auth_header)
+    )
+    assert response.status_code == 202, response.get_json()
+
+    #######################################################################
+    # Test scheduled_for too far in the future and in the past.
+    #######################################################################
+
+    for bad_scheduled_for in (scheduled_for + timedelta(days=2), scheduled_for - timedelta(days=5)):
+        email_request_data["scheduled_for"] = bad_scheduled_for.isoformat()
+        response = client.post(
+            path=url_for(f"v3.v3_notifications.v3_post_notification_email"),
+            data=dumps(email_request_data),
+            headers=(("Content-Type", "application/json"), auth_header)
+        )
+        bad_request_helper(response)
+
+        sms_request_data["scheduled_for"] = bad_scheduled_for.isoformat()
+        response = client.post(
+            path=url_for(f"v3.v3_notifications.v3_post_notification_sms"),
+            data=dumps(sms_request_data),
+            headers=(("Content-Type", "application/json"), auth_header)
+        )
+        bad_request_helper(response)
+
+
+def bad_request_helper(response: Response):
+    """
+    Perform assertions for a BadRequest response for which the specific
+    error message isn't important.
+    """
+
+    assert response.status_code == 400
+    response_json = response.get_json()
+    assert response_json["errors"][0]["error"] == "BadRequest"
+    assert "message" in response_json["errors"][0]

--- a/tests/app/v3/notifications/test_rest.py
+++ b/tests/app/v3/notifications/test_rest.py
@@ -246,8 +246,8 @@ def test_post_v3_notifications_custom_validation_error_messages(
     notify_db_session, client, sample_service, notification_type, error_message
 ):
     """
-    Send a request that has neither an e-mail address nor a recipient identifier.  The response should have
-    a custom validation error message because the default message is not helpful.
+    Send a request that has neither direct contact information nor a recipient identifier.  The response
+    should have a custom validation error message because the default message is not helpful.
     """
 
     auth_header = create_authorization_header(service_id=sample_service.id, key_type="team")


### PR DESCRIPTION
# Description

This is a revision to address QA findings after I merged [PR 1430](https://github.com/department-of-veterans-affairs/notification-api/pull/1430).  These changes:
- Address schema validation failures
- Utilize the Python "phonenumbers" package to test for "possible" and "valid" phone numbers.  (See "Example Usage" [here](https://pypi.org/project/phonenumbers/).)
- Restore the "scheduled_for" field, and validate that the value is neither in the past nor more than one calendar day in the future.  This is easy to change later if necessary.  It isn't entirely obvious from the v2 implementation what the permissible range is supposed to be, and none of our customers are using this functionality now.
- Customizes the validation error response body for requests that provide neither (phone number OR e-mail address) nor a recipient ID.
- Update unit tests and Swagger
- Split the v3 schema into 2 schemas--one for e-mail; one for SMS.  This requires that I declare 2 Draft202012Validator instances in rest.py, rather than 1, but the effect is much more useful validation error messages.
- Add 2 existing subdependencies as top-level dependencies.  See the new comments in requirements-app.txt.

The reason unit tests all passed for the last PR even though the realized behavior had problems is that I assumed from [this documentation](https://python-jsonschema.readthedocs.io/en/latest/api/jsonschema/validators/#jsonschema.validators.Draft202012Validator.FORMAT_CHECKER) that "email" and "uuid" string format constraints are in effect by default with instances of Draft202012Validator.  That was incorrect, and I didn't catch it because I was using jsonschema.validate in the tests instead of the Draft202012Validator I instantiate in rest.py.  I did this because jsonschema.validate also verifies that a schema is correct.  Now my tests use the same Draft202012Validator instances that rest.py uses, and I added a new unit test specifically to verify the schemas.

issue #1360

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Looked at openapi.yml changes in Swagger Editor
- Verified the custom validation error messages in Postman by making requests to Dev
- [deployed](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/6103242407) (user-flows fails, as expected)
- Wrote new tests, and revised existing tests
- [Regression tests pass](https://github.com/department-of-veterans-affairs/notification-api-qa/actions/runs/6103535265) using the notification-api-qa 130-v3-post-notifications branch

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an appropriate title: #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/release.yaml) to the PR.
- [ ] I did not remove any parts of the template, such as checkboxes even if they are not used --> I removed some from "Type of change" because the template for that section still says I should.  Is this an error? @ldraney 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation --> Swagger
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have ensured the latest master is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket is now moved into the DEV test column
