### PR TITLE
Add p2p_enabled field to services table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -377,6 +377,8 @@ class Service(db.Model, Versioned):
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey('organisation.id'), index=True, nullable=True)
     organisation = db.relationship('Organisation', backref='services')
 
+    p2p_enabled = db.Column(db.Boolean, nullable=True, default=False)
+
     email_branding = db.relationship(
         'EmailBranding',
         secondary=service_email_branding,

--- a/migrations/versions/0362_add_service_field.py
+++ b/migrations/versions/0362_add_service_field.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0362_add_service_field
+Revises: 0361_remove_letter_branding
+Create Date: 2023-09-08 11:01:59.093025
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0362_add_service_field'
+down_revision = '0361_remove_letter_branding'
+
+
+def upgrade():
+    op.add_column('services', sa.Column('p2p_enabled', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('services', 'p2p_enabled')

--- a/migrations/versions/0362_add_service_field.py
+++ b/migrations/versions/0362_add_service_field.py
@@ -7,7 +7,6 @@ Create Date: 2023-09-08 11:01:59.093025
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 revision = '0362_add_service_field'
 down_revision = '0361_remove_letter_branding'

--- a/migrations/versions/0362_add_service_field.py
+++ b/migrations/versions/0362_add_service_field.py
@@ -14,7 +14,9 @@ down_revision = '0361_remove_letter_branding'
 
 def upgrade():
     op.add_column('services', sa.Column('p2p_enabled', sa.Boolean(), nullable=True))
+    op.add_column('services_history', sa.Column('p2p_enabled', sa.Boolean(), nullable=True))
 
 
 def downgrade():
     op.drop_column('services', 'p2p_enabled')
+    op.drop_column('services_history', 'p2p_enabled')


### PR DESCRIPTION
# Description

Adds new field to the `services` table.
- `p2p_enabled` optional boolean field

This new field will allow the portal to track and update P2P status on a service by service basis. Thanks to @MarchandMD for pairing on this with me.

issue [1118](https://app.zenhub.com/workspaces/forms-strike-team-620c2914e703390013c4b414/issues/gh/department-of-veterans-affairs/vanotify-team/1118)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested locally and was able to upgrade and downgrade without any issues.
- [x] Deployed to [migration to dev](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/6125549273) and successfully [rolled back](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/6125684117/job/16628156123).


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
