### PR TITLE
Add Reply-to Inbox Table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -448,6 +448,14 @@ class Service(db.Model, Versioned):
         }
 
 
+class ReplyToInbox(db.Model):
+    __tablename__ = "reply_to_inbox"
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    inbox = db.Column(db.String, nullable=False)
+    service = db.relationship(Service)
+    service_id = db.Column(UUID(as_uuid=True), db.ForeignKey('services.id'), nullable=False, index=True, unique=False)
+
+
 class AnnualBilling(db.Model):
     __tablename__ = "annual_billing"
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=False)

--- a/app/models.py
+++ b/app/models.py
@@ -454,6 +454,8 @@ class ReplyToInbox(db.Model):
     inbox = db.Column(db.String, nullable=False)
     service = db.relationship(Service)
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey('services.id'), nullable=False, index=True, unique=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 
 
 class AnnualBilling(db.Model):

--- a/migrations/versions/0363_add_reply_to_inbox.py
+++ b/migrations/versions/0363_add_reply_to_inbox.py
@@ -1,0 +1,30 @@
+"""
+
+Revision ID: 0362_add_service_field
+Revises: 0361_remove_letter_branding
+Create Date: 2023-09-20 19:58:37.246845
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0363_add_reply_to_inbox'
+down_revision = '0362_add_service_field'
+
+
+def upgrade():
+    op.create_table('reply_to_inbox',
+    sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column('inbox', sa.String(length=255), nullable=False),
+    sa.Column('service_id', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column('created_at', sa.DateTime(), nullable=True),
+    sa.Column('updated_at', sa.DateTime(), nullable=True),
+    sa.PrimaryKeyConstraint('id'),
+    sa.UniqueConstraint('service_id', 'inbox', name='uix_service_to_reply_to_inbox')
+    )
+    op.create_index(op.f('ix_reply_to_inbox_service_id'), 'reply_to_inbox', ['service_id'], unique=False)
+
+def downgrade():
+    op.drop_index('ix_reply_to_inbox_service_id', table_name='reply_to_inbox')
+    op.drop_table('reply_to_inbox')

--- a/migrations/versions/0363_add_reply_to_inbox.py
+++ b/migrations/versions/0363_add_reply_to_inbox.py
@@ -1,7 +1,7 @@
 """
 
-Revision ID: 0362_add_service_field
-Revises: 0361_remove_letter_branding
+Revision ID: 0363_add_reply_to_inbox
+Revises: 0362_add_service_field
 Create Date: 2023-09-20 19:58:37.246845
 
 """
@@ -16,15 +16,16 @@ down_revision = '0362_add_service_field'
 def upgrade():
     op.create_table('reply_to_inbox',
     sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
-    sa.Column('inbox', sa.String(length=255), nullable=False),
+    sa.Column('inbox', sa.String(), nullable=False),
     sa.Column('service_id', postgresql.UUID(as_uuid=True), nullable=False),
     sa.Column('created_at', sa.DateTime(), nullable=True),
     sa.Column('updated_at', sa.DateTime(), nullable=True),
-    sa.PrimaryKeyConstraint('id'),
-    sa.UniqueConstraint('service_id', 'inbox', name='uix_service_to_reply_to_inbox')
+    sa.ForeignKeyConstraint(['service_id'], ['services.id']),
+    sa.PrimaryKeyConstraint('id')
     )
     op.create_index(op.f('ix_reply_to_inbox_service_id'), 'reply_to_inbox', ['service_id'], unique=False)
 
+
 def downgrade():
-    op.drop_index('ix_reply_to_inbox_service_id', table_name='reply_to_inbox')
+    op.drop_index(op.f('ix_reply_to_inbox_service_id'), table_name='reply_to_inbox')
     op.drop_table('reply_to_inbox')


### PR DESCRIPTION
# Description

Add `reply_to_inbox` database table for tracking Reply-to Inboxes related to each service.

[issue](https://app.zenhub.com/workspaces/forms-strike-team-620c2914e703390013c4b414/issues/gh/department-of-veterans-affairs/notification-portal/1362)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?
- Tested locally and was able to upgrade and downgrade without any issues.
- Deployed to [migration to dev](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/6276595747) and successfully [rolled back](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/6276798370).

