### PR TITLE
#1361 v3 basic send logic (part 1)

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -334,4 +334,4 @@ fileignoreconfig:
     - filename: app/schema_validation/__init__.py
       checksum: a2ee4584781782e5154ae0641f85777bc263d6f1e6f9fe1cfd370fff0a869418
     - filename: app/celery/v3/notification_tasks.py
-      checksum: 6aa4c0e7d5347d42dfa1fcc1af1dcd44f1c7fc1b6313617af917d3d8f6c8b194
+      checksum: f24411a73bb9d2114434b1cb5c5edbdade6520797698a20be37c74bdc4b26252

--- a/.talismanrc
+++ b/.talismanrc
@@ -333,3 +333,5 @@ fileignoreconfig:
       checksum: 1c963f08a88caf7de46e27f89fdc7af37b38a61bb62b10498bfca26bc29d792e
     - filename: app/schema_validation/__init__.py
       checksum: a2ee4584781782e5154ae0641f85777bc263d6f1e6f9fe1cfd370fff0a869418
+    - filename: app/celery/v3/notification_tasks.py
+      checksum: 6aa4c0e7d5347d42dfa1fcc1af1dcd44f1c7fc1b6313617af917d3d8f6c8b194

--- a/.talismanrc
+++ b/.talismanrc
@@ -274,7 +274,7 @@ fileignoreconfig:
     - filename: app/__init__.py
       checksum: 6b99603dd19ba02921639b7da0b04d15908622de4238f443795e2982d311acaa
     - filename: app/config.py
-      checksum: e4e35170dd17728f2fcdfa0d40177dcaeffe020293f5fe28f253a27688845476
+      checksum: dd2df4bbed5a0c18271a242e50b2a98ceb34838b48487f755c2665e2d72b51a0
     - filename: tests/app/celery/test_reporting_tasks.py
       checksum: 9caffea8b2253d9b86c512aeff16e03487501a9b84a98737593a79dc4d8ee14d
     - filename: scripts/trigger_task.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -333,5 +333,9 @@ fileignoreconfig:
       checksum: 1c963f08a88caf7de46e27f89fdc7af37b38a61bb62b10498bfca26bc29d792e
     - filename: app/schema_validation/__init__.py
       checksum: a2ee4584781782e5154ae0641f85777bc263d6f1e6f9fe1cfd370fff0a869418
+    - filename: app/v3/notifications/rest.py
+      checksum: 7b12a5909efcd0e34c97661bee128cebd2968c186ce455699fcc668a4470244f
     - filename: app/celery/v3/notification_tasks.py
-      checksum: f24411a73bb9d2114434b1cb5c5edbdade6520797698a20be37c74bdc4b26252
+      checksum: 68a0f794fd010f7c2916de4e1af28aabba4e6465a8020f8f3b9f5f2e4d1bfa1a
+    - filename: tests/app/v3/notifications/test_rest.py
+      checksum: f970efab73ad52e3e203fe0805925929033a72d9975ec1deb077331e9409f06f

--- a/app/celery/v3/notification_tasks.py
+++ b/app/celery/v3/notification_tasks.py
@@ -1,0 +1,16 @@
+# TODO - Should I continue using this?  It has side-effects.
+from app import notify_celery
+from app.models import Service
+
+
+@notify_celery.task
+def v3_process_notification(request_data: dict, service: Service):
+    """
+    This is the first task used to process request data send to POST /v3/notification/(email|sms).  It performs
+    additional, non-schema verifications that require database queries:
+    
+    1. The specified template exists is for the specified type of notification.
+    2. ...etc...
+    """
+
+    raise RuntimeError("Not implemented")

--- a/app/celery/v3/notification_tasks.py
+++ b/app/celery/v3/notification_tasks.py
@@ -182,8 +182,10 @@ def v3_send_sms_notification(notification: Notification, sender_phone_number: st
     # TODO - test "client is None"
     client = clients.get_sms_client("pinpoint")
 
-    db.session.add(notification)
+    # Persist the notification so related model instances are available to downstream code, which would raise
+    # exceptions otherwise.
     notification.status = NOTIFICATION_CREATED
+    db.session.add(notification)
     db.session.commit()
 
     # This might raise AwsPinpointException.
@@ -196,6 +198,6 @@ def v3_send_sms_notification(notification: Notification, sender_phone_number: st
         sender_phone_number
     )
 
-    notification.status = NOTIFICATION_SENT
-    notification.client_reference = aws_reference
+    # notification.status = NOTIFICATION_SENT
+    notification.reference = aws_reference
     db.session.commit()

--- a/app/celery/v3/notification_tasks.py
+++ b/app/celery/v3/notification_tasks.py
@@ -139,6 +139,7 @@ def v3_send_email_notification(notification: Notification, template: Template):
     # Persist the notification so related model instances are available to downstream code.
     notification.status = NOTIFICATION_CREATED
     db.session.add(notification)
+    db.session.add(template)
     db.session.commit()
 
     # query = select(Template).where(

--- a/app/celery/v3/notification_tasks.py
+++ b/app/celery/v3/notification_tasks.py
@@ -114,11 +114,21 @@ def v3_process_notification(request_data: dict, service_id: str, api_key_id: str
         )
 
 
+# TODO - retry conditions
 @notify_celery.task(serializer="pickle")
 def v3_send_email_notification_with_ses(notification: Notification):
-    print("MADE IT HERE E-MAIL SES")
+    # TODO
+    notification.status = NOTIFICATION_TECHNICAL_FAILURE
+    notification.status_reason = "Sending e-mail with SES is not yet implemented."
+    db.session.add(notification)
+    db.session.commit()
 
 
+# TODO - retry conditions
 @notify_celery.task(serializer="pickle")
 def v3_send_sms_notification_with_pinpoint(notification: Notification):
-    print("MADE IT HERE SMS PINPOINT")
+    # TODO
+    notification.status = NOTIFICATION_TECHNICAL_FAILURE
+    notification.status_reason = "Sending SMS with Pinpoint is not yet implemented."
+    db.session.add(notification)
+    db.session.commit()

--- a/app/celery/v3/notification_tasks.py
+++ b/app/celery/v3/notification_tasks.py
@@ -1,16 +1,35 @@
-# TODO - Should I continue using this?  It has side-effects.
+# TODO - Should I continue using notify_celery?  It has side-effects.
 from app import notify_celery
-from app.models import Service
+# from app.models import NOTIFICATION_PERMANENT_FAILURE
 
 
 @notify_celery.task
-def v3_process_notification(request_data: dict, service: Service):
+def v3_process_notification(request_data: dict):
     """
     This is the first task used to process request data send to POST /v3/notification/(email|sms).  It performs
     additional, non-schema verifications that require database queries:
-    
+
     1. The specified template exists is for the specified type of notification.
     2. ...etc...
     """
 
+    # TODO - Query to get the template
+
+    # Ensure the template type matches the given notification type.
+    # TODO
+
+    # Create the notification content using the template and personalization data.
+    # TODO
+
+    # Determine the provider.
+    # Launch a new task to make an API call to the provider.
     raise RuntimeError("Not implemented")
+
+
+def persist_notification(request_data: dict, service_id: str, status: str, status_reason: str):
+    """
+    Create a Notification instance, and persist it in the database.
+    """
+
+    raise RuntimeError("Not implemented")
+    # TODO - query

--- a/app/celery/v3/notification_tasks.py
+++ b/app/celery/v3/notification_tasks.py
@@ -1,5 +1,5 @@
 # TODO - Should I continue using notify_celery?  It has side-effects.
-from app import db, notify_celery
+from app import clients, db, notify_celery
 from app.dao.dao_utils import get_reader_session
 from app.models import (
     EMAIL_TYPE,
@@ -9,9 +9,12 @@ from app.models import (
     SMS_TYPE,
     Template,
 )
+# from app.service.utils import compute_source_email_address
 from celery.utils.log import get_task_logger
 from datetime import datetime
 from flask import current_app
+# from notifications_utils.template import HTMLEmailTemplate, PlainTextEmailTemplate
+# from notifications_utils.recipients import validate_and_format_email_address
 from sqlalchemy import select
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 
@@ -107,11 +110,47 @@ def v3_process_notification(request_data: dict, service_id: str, api_key_id: str
 # TODO - retry conditions
 @notify_celery.task(serializer="pickle")
 def v3_send_email_notification(notification: Notification):
-    # TODO - Determine the provider.  For now, assume SES.
     notification.status = NOTIFICATION_TECHNICAL_FAILURE
     notification.status_reason = "Sending e-mail is not yet implemented."
     db.session.add(notification)
     db.session.commit()
+
+    # TODO - Determine the provider.  For now, assume SES.
+#    client = clients.get_email_client('ses')  # Hardcoded
+#    with get_reader_session() as r_session:
+#        stmt = select(Template).where(Template.id == notification.template_id,
+#                                      Template.version == notification.template_version)
+#        template_dict = r_session.execute(stmt).mappings().all()[0]
+
+#    personlization_data = notification.personalisation.copy()
+
+#    html_email = HTMLEmailTemplate(
+#        template_dict,
+#        values=personlization_data,
+#        **get_html_email_options(notification, client)
+#    )
+
+#    plain_text_email = PlainTextEmailTemplate(
+#        template_dict,
+#        values=personlization_data
+#    )
+
+#    reference = client.send_email(
+#        source=compute_source_email_address(notification.service, client),
+#        to_addresses=validate_and_format_email_address(notification.to),
+#        subject=plain_text_email.subject,
+#        body=str(plain_text_email),
+#        html_body=str(html_email),
+#        reply_to_address=validate_and_format_email_address(notification.get('reply_to_text')),
+#        attachments=[]
+#    )
+#    notification.reference = reference
+#    notification.sent_at = datetime.utcnow()
+#    notification.sent_by = client.get_name()
+#    notification.status = NOTIFICATION_SENDING
+#    db.session.add(notification)
+#    db.session.commit()
+#    current_app.logger.info("Saved provider reference: %s for notification id: %s", reference, notification.id)
 
 
 # TODO - retry conditions

--- a/app/celery/v3/notification_tasks.py
+++ b/app/celery/v3/notification_tasks.py
@@ -181,7 +181,10 @@ def v3_send_sms_notification(notification: Notification, sender_phone_number: st
     # TODO - Determine the provider.  For now, assume Pinpoint.
     # TODO - test "client is None"
     client = clients.get_sms_client("pinpoint")
+
     db.session.add(notification)
+    notification.status = NOTIFICATION_CREATED
+    db.session.commit()
 
     # This might raise AwsPinpointException.
     # TODO - Conditional retry based on exception details.

--- a/app/celery/v3/notification_tasks.py
+++ b/app/celery/v3/notification_tasks.py
@@ -1,35 +1,84 @@
 # TODO - Should I continue using notify_celery?  It has side-effects.
-from app import notify_celery
-# from app.models import NOTIFICATION_PERMANENT_FAILURE
+from app import db, notify_celery
+from app.dao.dao_utils import get_reader_session
+from app.models import EMAIL_TYPE, KEY_TYPE_NORMAL, Notification, NOTIFICATION_PERMANENT_FAILURE, SMS_TYPE, Template
+from app.service.service_data import ServiceData
+from datetime import datetime
+from flask import current_app
+from sqlalchemy import select
+from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 
 
 @notify_celery.task
-def v3_process_notification(request_data: dict):
+def v3_process_notification(request_data: dict, service_data: ServiceData):
     """
     This is the first task used to process request data send to POST /v3/notification/(email|sms).  It performs
     additional, non-schema verifications that require database queries:
 
-    1. The specified template exists is for the specified type of notification.
-    2. ...etc...
+    1. The specified template exists and is for the specified type of notification.
+    2. The given service owns the specified template.
+    x. ...etc...
     """
 
-    # TODO - Query to get the template
+    notification = Notification(
+        id=request_data["id"],
+        to=request_data.get("email_address" if request_data["notification_type"] == EMAIL_TYPE else "phone_number"),
+        service_id=service_data.id,
+        template_id=request_data["template_id"],
+        template_version=0,
+        # TODO - v2 uses the imported value "api_user" for the api_key.
+        # Does the list service_data.api_keys ever have more than one element?
+        api_key_id=service_data.api_keys[0].id if service_data.api_keys else None,
+        key_type=service_data.api_keys[0].key_type if service_data.api_keys else KEY_TYPE_NORMAL,
+        notification_type=request_data["notification_type"],
+        created_at=datetime.utcnow(),
+        status=NOTIFICATION_PERMANENT_FAILURE,
+        client_reference=request_data.get("client_reference"),
+        reference=request_data.get("reference"),
+        personalisation=request_data.get("personalisation"),
+        sms_sender_id=request_data.get("sms_sender_id"),
+        billing_code=request_data.get("billing_code")
+    )
 
-    # Ensure the template type matches the given notification type.
-    # TODO
+    # TODO - Catch db connection errors and retry?
+    query = select(Template).where(Template.id == request_data["template_id"])
+    with get_reader_session() as reader_session:
+        try:
+            template = reader_session.execute(query).one().Template
+        except (MultipleResultsFound, NoResultFound):
+            notification.status_reason = "The template does not exist."
+            # TODO - This isn't an option right now because Notification.template_id is non-nullable and
+            # must reference a valid template.
+            # db.session.add(notification)
+            # db.session.commit()
+            # TODO - Delete logging when the above issue is remedied.
+            current_app.logger.error(
+                "Notification %s specified nonexistent template %s.", notification.id, notification.template_id
+            )
+            return
+
+    notification.template_version = template.version
+    if notification.notification_type == SMS_TYPE and notification.sms_sender_id is None:
+        # Get the template or service default sms_sender_id.
+        # TODO
+        pass
+
+    if service_data.id != template.service_id:
+        notification.status_reason = "The service does not own the template."
+        db.session.add(notification)
+        db.session.commit()
+        return
+
+    if request_data["notification_type"] != template.template_type:
+        notification.status_reason = "The template type does not match the notification type."
+        db.session.add(notification)
+        db.session.commit()
+        return
 
     # Create the notification content using the template and personalization data.
     # TODO
 
     # Determine the provider.
     # Launch a new task to make an API call to the provider.
-    raise RuntimeError("Not implemented")
-
-
-def persist_notification(request_data: dict, service_id: str, status: str, status_reason: str):
-    """
-    Create a Notification instance, and persist it in the database.
-    """
-
-    raise RuntimeError("Not implemented")
-    # TODO - query
+    print("MADE IT HERE 4")  # TODO
+    raise NotImplementedError

--- a/app/config.py
+++ b/app/config.py
@@ -340,41 +340,13 @@ class Config(object):
                 'schedule': crontab(hour=4, minute=0),
                 'options': {'queue': QueueNames.PERIODIC},
             },
-            # 'remove_letter_jobs': {
-            # 'task': 'remove_letter_jobs',
-            # 'schedule': crontab(hour=4, minute=20),
-            #  since we mark jobs as archived
-            # 'options': {'queue': QueueNames.PERIODIC},
-            # },
-            # 'check-templated-letter-state': {
-            # 'task': 'check-templated-letter-state',
-            # 'schedule': crontab(day_of_week='mon-fri', hour=9, minute=0),
-            # 'options': {'queue': QueueNames.PERIODIC}
-            # },
-            # 'check-precompiled-letter-state': {
-            # 'task': 'check-precompiled-letter-state',
-            # 'schedule': crontab(day_of_week='mon-fri', hour='9,15', minute=0),
-            # 'options': {'queue': QueueNames.PERIODIC}
-            # },
-            # 'raise-alert-if-letter-notifications-still-sending': {
-            # 'task': 'raise-alert-if-letter-notifications-still-sending',
-            # 'schedule': crontab(hour=16, minute=30),
-            # 'options': {'queue': QueueNames.PERIODIC}
-            # },
-            # The collate-letter-pdf does assume it is called in an hour that BST does not make a
-            # difference to the truncate date which translates to the filename to process
-            # 'collate-letter-pdfs-for-day': {
-            # 'task': 'collate-letter-pdfs-for-day',
-            # 'schedule': crontab(hour=17, minute=50),
-            # 'options': {'queue': QueueNames.PERIODIC}
-            # },
-            # 'raise-alert-if-no-letter-ack-file': {
-            # 'task': 'raise-alert-if-no-letter-ack-file',
-            # 'schedule': crontab(hour=23, minute=00),
-            # 'options': {'queue': QueueNames.PERIODIC}
-            # },
         },
-        'task_queues': []
+        "task_queues": [Queue(queue, Exchange("default"), routing_key=queue) for queue in QueueNames.all_queues()],
+        "task_routes": {
+            "app.celery.v3.notification_tasks.v3_process_notification": {"queue": QueueNames.NOTIFY},
+            "app.celery.v3.notification_tasks.v3_send_email_notification": {"queue": QueueNames.SEND_EMAIL},
+            "app.celery.v3.notification_tasks.v3_send_sms_notification": {"queue": QueueNames.SEND_SMS},
+        },
     }
 
     # When a service is created, this gets saved as default sms_sender
@@ -486,7 +458,6 @@ class Config(object):
     ATTACHMENTS_BUCKET = os.getenv('ATTACHMENTS_BUCKET', 'dev-notifications-va-gov-attachments')
     MAX_CONTENT_LENGTH = 1024 * 1024  # = 1024 KB
 
-
 ######################
 # Config overrides ###
 ######################
@@ -523,11 +494,6 @@ class Development(Config):
 
     ANTIVIRUS_ENABLED = os.getenv('ANTIVIRUS_ENABLED') == '1'
 
-    for queue in QueueNames.all_queues():
-        Config.CELERY_SETTINGS['task_queues'].append(
-            Queue(queue, Exchange('default'), routing_key=queue)
-        )
-
 
 class Test(Development):
     # When a service is created, this gets saved as default sms_sender
@@ -559,11 +525,6 @@ class Test(Development):
     }
 
     ANTIVIRUS_ENABLED = True
-
-    for queue in QueueNames.all_queues():
-        Config.CELERY_SETTINGS['task_queues'].append(
-            Queue(queue, Exchange('default'), routing_key=queue)
-        )
 
     API_HOST_NAME = "http://localhost:6011"
 

--- a/app/config.py
+++ b/app/config.py
@@ -249,7 +249,7 @@ class Config(object):
         'worker_enable_remote_control': False,
         'enable_utc': True,
         'timezone': os.getenv("TIMEZONE", "America/New_York"),
-        'accept_content': ['json'],
+        'accept_content': ['json', 'pickle'],
         'task_serializer': 'json',
         'imports': (
             'app.celery.tasks',

--- a/app/config.py
+++ b/app/config.py
@@ -258,7 +258,8 @@ class Config(object):
             'app.celery.nightly_tasks',
             'app.celery.process_pinpoint_receipt_tasks',
             'app.celery.process_pinpoint_inbound_sms',
-            'app.celery.process_delivery_status_result_tasks'
+            'app.celery.process_delivery_status_result_tasks',
+            'app.celery.v3.notification_tasks',
         ),
         'beat_schedule': {
             # app/celery/scheduled_tasks.py

--- a/app/models.py
+++ b/app/models.py
@@ -1351,10 +1351,14 @@ class Notification(db.Model):
         default='created',
         key='status'  # http://docs.sqlalchemy.org/en/latest/core/metadata.html#sqlalchemy.schema.Column
     )
-    reference = db.Column(db.String, nullable=True, index=True)
-    client_reference = db.Column(db.String, index=True, nullable=True)
-    _personalisation = db.Column(db.String, nullable=True)
 
+    # This is an ID from a provider, such as SES (e-mail) or Pinpoint (SMS).
+    reference = db.Column(db.String, nullable=True, index=True)
+
+    # This is an ID optionally provided in POST data by a VA service (a.k.a. the client).
+    client_reference = db.Column(db.String, index=True, nullable=True)
+
+    _personalisation = db.Column(db.String, nullable=True)
     scheduled_notification = db.relationship('ScheduledNotification', uselist=False)
 
     international = db.Column(db.Boolean, nullable=False, default=False)

--- a/app/models.py
+++ b/app/models.py
@@ -1357,8 +1357,6 @@ class Notification(db.Model):
 
     scheduled_notification = db.relationship('ScheduledNotification', uselist=False)
 
-    client_reference = db.Column(db.String, index=True, nullable=True)
-
     international = db.Column(db.Boolean, nullable=False, default=False)
     phone_prefix = db.Column(db.String, nullable=True)
     rate_multiplier = db.Column(db.Float(asdecimal=False), nullable=True)

--- a/app/v3/__init__.py
+++ b/app/v3/__init__.py
@@ -56,3 +56,15 @@ def schema_validation_error(error):
             }
         ]
     }, 400
+
+
+@v3_blueprint.errorhandler(NotImplementedError)
+def not_implemented_error(error):
+    return {
+        "errors": [
+            {
+                "error": "NotImplementedError",
+                "message": str(error),
+            }
+        ]
+    }, 501

--- a/app/v3/notifications/rest.py
+++ b/app/v3/notifications/rest.py
@@ -112,5 +112,5 @@ def v3_send_notification(request_data: dict, service_data: ServiceData) -> str:
     request_data["id"] = str(uuid4())
 
     # Initiate a Celery task to process the validated request data.  This does not block.
-    v3_process_notification.delay(request_data)
+    v3_process_notification.delay(request_data, service_data)
     return request_data["id"]

--- a/app/v3/notifications/rest.py
+++ b/app/v3/notifications/rest.py
@@ -2,7 +2,6 @@
 
 import phonenumbers
 from app import authenticated_service
-from app.config import QueueNames
 from app.authentication.auth import AuthError
 from app.celery.v3.notification_tasks import v3_process_notification
 from app.models import EMAIL_TYPE, KEY_TYPE_NORMAL, SMS_TYPE
@@ -82,10 +81,8 @@ def v3_send_notification(request_data: dict, service_data: ServiceData) -> str:
     # This might raise jsonschema.ValidationError.
     if request_data["notification_type"] == EMAIL_TYPE:
         v3_notifications_post_email_request_validator.validate(request_data)
-        celery_queue = QueueNames.SEND_EMAIL
     elif request_data["notification_type"] == SMS_TYPE:
         v3_notifications_post_sms_request_validator.validate(request_data)
-        celery_queue = QueueNames.SEND_SMS
     else:
         raise RuntimeError("Unrecognized notification type.  This is a programming error.")
 

--- a/app/v3/notifications/rest.py
+++ b/app/v3/notifications/rest.py
@@ -4,7 +4,7 @@ import phonenumbers
 from app import authenticated_service
 from app.authentication.auth import AuthError
 from app.celery.v3.notification_tasks import v3_process_notification
-from app.models import EMAIL_TYPE, SMS_TYPE
+from app.models import EMAIL_TYPE, KEY_TYPE_NORMAL, SMS_TYPE
 from app.service.service_data import ServiceData
 from app.v3.notifications.notification_schemas import (
     notification_v3_post_email_request_schema,
@@ -112,5 +112,13 @@ def v3_send_notification(request_data: dict, service_data: ServiceData) -> str:
     request_data["id"] = str(uuid4())
 
     # Initiate a Celery task to process the validated request data.  This does not block.
-    v3_process_notification.delay(request_data, service_data)
+    # TODO - v2 uses the imported value "api_user" for the api_key.
+    # Does the list service_data.api_keys ever have more than one element?
+    print("MADE IT HERE 1")  # TODO
+    v3_process_notification.delay(
+        request_data,
+        service_data.id,
+        service_data.api_keys[0].id if service_data.api_keys else None,
+        service_data.api_keys[0].key_type if service_data.api_keys else KEY_TYPE_NORMAL,
+    )
     return request_data["id"]

--- a/app/v3/notifications/rest.py
+++ b/app/v3/notifications/rest.py
@@ -117,14 +117,10 @@ def v3_send_notification(request_data: dict, service_data: ServiceData) -> str:
     # Initiate a Celery task to process the validated request data.  This does not block.
     # TODO - v2 uses the imported value "api_user" for the api_key.
     # Does the list service_data.api_keys ever have more than one element?
-    v3_process_notification.apply_async(
-        (
-            request_data,
-            service_data.id,
-            service_data.api_keys[0].id if service_data.api_keys else None,
-            service_data.api_keys[0].key_type if service_data.api_keys else KEY_TYPE_NORMAL,
-        ),
-        queue=celery_queue,
-        routing_key=celery_queue
+    v3_process_notification.delay(
+        request_data,
+        service_data.id,
+        service_data.api_keys[0].id if service_data.api_keys else None,
+        service_data.api_keys[0].key_type if service_data.api_keys else KEY_TYPE_NORMAL,
     )
     return request_data["id"]

--- a/tests/app/celery/v3/test_notification_tasks.py
+++ b/tests/app/celery/v3/test_notification_tasks.py
@@ -1,6 +1,80 @@
-# import pytest
-# from app.celery.v3.notification_tasks import v3_process_notification
+import pytest
+from app.celery.v3.notification_tasks import v3_process_notification
+from app.models import EMAIL_TYPE, Notification, NOTIFICATION_PERMANENT_FAILURE, SMS_TYPE
+from app.service.service_data import ServiceData
+from sqlalchemy import select
+from uuid import uuid4
 
 
-def test_v3_process_notification_permission_check(sample_service_data):
-    pass
+# TODO - Make the Notification.template_id field nullable?  Have a default template?
+@pytest.mark.xfail(reason="A Notification with an invalid template ID cannot be persisted.")
+def test_v3_process_notification_no_template(notify_db_session, sample_service):
+    """
+    Call the task with request data referencing a nonexistent template.
+    """
+
+    request_data = {
+        "id": str(uuid4()),
+        "notification_type": EMAIL_TYPE,
+        "email_address": "test@va.gov",
+        "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
+    }
+
+    v3_process_notification(request_data, ServiceData(sample_service))
+
+    query = select(Notification).where(Notification.id == request_data["id"])
+    notification = notify_db_session.session.execute(query).one().Notification
+    assert notification.status == NOTIFICATION_PERMANENT_FAILURE
+    assert notification.status_reason == "The template does not exist."
+
+
+@pytest.mark.xfail(reason="This test needs a template not owned by sample_service.", run=False)
+def test_v3_process_notification_template_owner_mismatch(
+    notify_db_session, sample_service, sample_template, sample_template_without_email_permission
+):
+    """
+    Call the task with request data for a template the service doesn't own.
+    """
+
+    assert sample_template.template_type == SMS_TYPE
+    assert sample_template.service_id == sample_service.id
+
+    assert sample_template_without_email_permission.template_type == EMAIL_TYPE
+    assert sample_template_without_email_permission.service_id != sample_service.id
+    assert False
+
+    request_data = {
+        "id": str(uuid4()),
+        "notification_type": SMS_TYPE,
+        "phone_number": "+18006982411",
+        "template_id": sample_template.id,
+    }
+
+    v3_process_notification(request_data, ServiceData(sample_service))
+
+    query = select(Notification).where(Notification.id == request_data["id"])
+    notification = notify_db_session.session.execute(query).one().Notification
+    assert notification.status == NOTIFICATION_PERMANENT_FAILURE
+    assert notification.status_reason == "The service does not own the template."
+
+
+def test_v3_process_notification_template_type_mismatch(notify_db_session, sample_service, sample_template):
+    """
+    Call the task with request data for an e-mail notification, but specify and SMS template.
+    """
+
+    assert sample_template.template_type == SMS_TYPE
+
+    request_data = {
+        "id": str(uuid4()),
+        "notification_type": EMAIL_TYPE,
+        "email_address": "test@va.gov",
+        "template_id": sample_template.id,
+    }
+
+    v3_process_notification(request_data, ServiceData(sample_service))
+
+    query = select(Notification).where(Notification.id == request_data["id"])
+    notification = notify_db_session.session.execute(query).one().Notification
+    assert notification.status == NOTIFICATION_PERMANENT_FAILURE
+    assert notification.status_reason == "The template type does not match the notification type."

--- a/tests/app/celery/v3/test_notification_tasks.py
+++ b/tests/app/celery/v3/test_notification_tasks.py
@@ -58,7 +58,6 @@ def test_v3_process_notification_template_owner_mismatch(
 
     assert sample_template_without_email_permission.template_type == EMAIL_TYPE
     assert sample_template_without_email_permission.service_id != sample_service.id
-    assert False
 
     request_data = {
         "id": str(uuid4()),

--- a/tests/app/celery/v3/test_notification_tasks.py
+++ b/tests/app/celery/v3/test_notification_tasks.py
@@ -1,0 +1,6 @@
+# import pytest
+# from app.celery.v3.notification_tasks import v3_process_notification
+
+
+def test_v3_process_notification_permission_check(sample_service_data):
+    pass

--- a/tests/app/celery/v3/test_notification_tasks.py
+++ b/tests/app/celery/v3/test_notification_tasks.py
@@ -1,9 +1,24 @@
 import pytest
-from app.celery.v3.notification_tasks import v3_process_notification
-from app.models import EMAIL_TYPE, KEY_TYPE_TEST, Notification, NOTIFICATION_PERMANENT_FAILURE, SMS_TYPE
+from app.celery.v3.notification_tasks import (
+    v3_process_notification,
+    # v3_send_email_notification,
+    v3_send_sms_notification,
+)
+from app.models import (
+    EMAIL_TYPE,
+    KEY_TYPE_TEST,
+    Notification,
+    NOTIFICATION_PERMANENT_FAILURE,
+    NOTIFICATION_SENT,
+    SMS_TYPE,
+)
 from sqlalchemy import select
 from uuid import uuid4
 
+
+############################################################################################
+# Test non-schema validations.
+############################################################################################
 
 # TODO - Make the Notification.template_id field nullable?  Have a default template?
 @pytest.mark.xfail(reason="A Notification with an invalid template ID cannot be persisted.")
@@ -19,12 +34,7 @@ def test_v3_process_notification_no_template(notify_db_session, sample_service):
         "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
     }
 
-    v3_process_notification(
-        request_data,
-        sample_service.id,
-        None,
-        KEY_TYPE_TEST
-    )
+    v3_process_notification(request_data, sample_service.id, None, KEY_TYPE_TEST)
 
     query = select(Notification).where(Notification.id == request_data["id"])
     notification = notify_db_session.session.execute(query).one().Notification
@@ -54,12 +64,7 @@ def test_v3_process_notification_template_owner_mismatch(
         "template_id": sample_template.id,
     }
 
-    v3_process_notification(
-        request_data,
-        sample_service.id,
-        None,
-        KEY_TYPE_TEST
-    )
+    v3_process_notification(request_data, sample_service.id, None, KEY_TYPE_TEST)
 
     query = select(Notification).where(Notification.id == request_data["id"])
     notification = notify_db_session.session.execute(query).one().Notification
@@ -67,9 +72,9 @@ def test_v3_process_notification_template_owner_mismatch(
     assert notification.status_reason == "The service does not own the template."
 
 
-def test_v3_process_notification_template_type_mismatch(notify_db_session, sample_service, sample_template):
+def test_v3_process_notification_template_type_mismatch_1(notify_db_session, sample_service, sample_template):
     """
-    Call the task with request data for an e-mail notification, but specify and SMS template.
+    Call the task with request data for an e-mail notification, but specify an SMS template.
     """
 
     assert sample_template.template_type == SMS_TYPE
@@ -81,14 +86,114 @@ def test_v3_process_notification_template_type_mismatch(notify_db_session, sampl
         "template_id": sample_template.id,
     }
 
-    v3_process_notification(
-        request_data,
-        sample_service.id,
-        None,
-        KEY_TYPE_TEST
-    )
+    v3_process_notification(request_data, sample_service.id, None, KEY_TYPE_TEST)
 
     query = select(Notification).where(Notification.id == request_data["id"])
     notification = notify_db_session.session.execute(query).one().Notification
     assert notification.status == NOTIFICATION_PERMANENT_FAILURE
     assert notification.status_reason == "The template type does not match the notification type."
+
+
+def test_v3_process_notification_template_type_mismatch_2(notify_db_session, sample_service, sample_email_template):
+    """
+    Call the task with request data for an SMS notification, but specify an e-mail template.
+    """
+
+    assert sample_email_template.template_type == EMAIL_TYPE
+
+    request_data = {
+        "id": str(uuid4()),
+        "notification_type": SMS_TYPE,
+        "phone_number": "+18006982411",
+        "template_id": sample_email_template.id,
+    }
+
+    v3_process_notification(request_data, sample_service.id, None, KEY_TYPE_TEST)
+
+    query = select(Notification).where(Notification.id == request_data["id"])
+    notification = notify_db_session.session.execute(query).one().Notification
+    assert notification.status == NOTIFICATION_PERMANENT_FAILURE
+    assert notification.status_reason == "The template type does not match the notification type."
+
+
+############################################################################################
+# Test sending e-mail notifications.
+############################################################################################
+
+@pytest.mark.xfail(reason="Not implemented.", run=False)
+def test_v3_process_notification_valid_email(notify_db_session, sample_service):
+    """
+    Given data for a valid e-mail notification, the task v3_process_notification should pass a Notification
+    instance to the task v3_send_email_notification.
+    """
+
+    pass
+
+
+@pytest.mark.xfail(reason="Not implemented.", run=False)
+def test_v3_send_email_notification():
+    pass
+
+
+############################################################################################
+# Test sending SMS notifications.
+############################################################################################
+
+def test_v3_process_notification_valid_sms_with_sender_id(
+    notify_db_session, mocker, sample_service, sample_template, sample_sms_sender
+):
+    """
+    Given data for a valid SMS notification that includes an sms_sender_id, the task v3_process_notification
+    should pass a Notification instance to the task v3_send_sms_notification.
+    """
+
+    assert sample_template.template_type == SMS_TYPE
+
+    request_data = {
+        "id": str(uuid4()),
+        "notification_type": SMS_TYPE,
+        "phone_number": "+18006982411",
+        "template_id": sample_template.id,
+        "sms_sender_id": sample_sms_sender.id,
+    }
+
+    v3_send_sms_notification_mock = mocker.patch("app.celery.v3.notification_tasks.v3_send_sms_notification.delay")
+    v3_process_notification(request_data, sample_service.id, None, KEY_TYPE_TEST)
+    v3_send_sms_notification_mock.assert_called_once_with(
+        mocker.ANY,
+        sample_sms_sender.sms_sender
+    )
+
+
+@pytest.mark.xfail(reason="Not implemented.", run=False)
+def test_v3_process_notification_valid_sms_without_sender_id(
+    notify_db_session, mocker, sample_service, sample_template, sample_sms_sender
+):
+    """
+    Given data for a valid SMS notification that does not include an sms_sender_id, the task v3_process_notification
+    should pass a Notification instance to the task v3_send_sms_notification.
+    """
+
+    pass
+
+
+def test_v3_send_sms_notification(notify_db_session, mocker, sample_notification, sample_sms_sender):
+    assert sample_notification.notification_type == SMS_TYPE
+
+    client_mock = mocker.Mock()
+    client_mock.send_sms = mocker.Mock(return_value="client reference")
+    mocker.patch("app.celery.v3.notification_tasks.clients.get_sms_client", return_value=client_mock)
+
+    v3_send_sms_notification(sample_notification, sample_sms_sender.sms_sender)
+    client_mock.send_sms.assert_called_once_with(
+        sample_notification.to,
+        sample_notification.content,
+        sample_notification.reference,
+        True,
+        sample_sms_sender.sms_sender
+    )
+
+    query = select(Notification).where(Notification.id == sample_notification.id)
+    notification = notify_db_session.session.execute(query).one().Notification
+    assert notification.status == NOTIFICATION_SENT
+    assert notification.client_reference == "client reference"

--- a/tests/app/celery/v3/test_notification_tasks.py
+++ b/tests/app/celery/v3/test_notification_tasks.py
@@ -1,7 +1,6 @@
 import pytest
 from app.celery.v3.notification_tasks import v3_process_notification
-from app.models import EMAIL_TYPE, Notification, NOTIFICATION_PERMANENT_FAILURE, SMS_TYPE
-from app.service.service_data import ServiceData
+from app.models import EMAIL_TYPE, KEY_TYPE_TEST, Notification, NOTIFICATION_PERMANENT_FAILURE, SMS_TYPE
 from sqlalchemy import select
 from uuid import uuid4
 
@@ -20,7 +19,12 @@ def test_v3_process_notification_no_template(notify_db_session, sample_service):
         "template_id": "4f365dd4-332e-454d-94ff-e393463602db",
     }
 
-    v3_process_notification(request_data, ServiceData(sample_service))
+    v3_process_notification(
+        request_data,
+        sample_service.id,
+        None,
+        KEY_TYPE_TEST
+    )
 
     query = select(Notification).where(Notification.id == request_data["id"])
     notification = notify_db_session.session.execute(query).one().Notification
@@ -50,7 +54,12 @@ def test_v3_process_notification_template_owner_mismatch(
         "template_id": sample_template.id,
     }
 
-    v3_process_notification(request_data, ServiceData(sample_service))
+    v3_process_notification(
+        request_data,
+        sample_service.id,
+        None,
+        KEY_TYPE_TEST
+    )
 
     query = select(Notification).where(Notification.id == request_data["id"])
     notification = notify_db_session.session.execute(query).one().Notification
@@ -72,7 +81,12 @@ def test_v3_process_notification_template_type_mismatch(notify_db_session, sampl
         "template_id": sample_template.id,
     }
 
-    v3_process_notification(request_data, ServiceData(sample_service))
+    v3_process_notification(
+        request_data,
+        sample_service.id,
+        None,
+        KEY_TYPE_TEST
+    )
 
     query = select(Notification).where(Notification.id == request_data["id"])
     notification = notify_db_session.session.execute(query).one().Notification

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -54,6 +54,7 @@ from app.models import (
     TemplateHistory,
     UserServiceRoles,
 )
+from app.service.service_data import ServiceData
 from datetime import datetime, timedelta
 from flask import current_app, url_for
 from random import randrange
@@ -345,9 +346,7 @@ def sample_notification_model_with_organization(
     return notification
 
 
-@pytest.fixture(scope='function')
-def sample_service(
-        notify_db,
+def sample_service_helper(
         notify_db_session,
         service_name="Sample service",
         user=None,
@@ -387,6 +386,21 @@ def sample_service(
     return service
 
 
+@pytest.fixture(scope='function')
+def sample_service(notify_db_session):
+    return sample_service_helper(notify_db_session)
+
+
+@pytest.fixture(scope="function")
+def sample_service_email_permission(notify_db_session):
+    return sample_service_helper(notify_db_session, permissions=[EMAIL_TYPE])
+
+
+@pytest.fixture(scope="function")
+def sample_service_sms_permission(notify_db_session):
+    return sample_service_helper(notify_db_session, permissions=[SMS_TYPE])
+
+
 @pytest.fixture(scope='function', name='sample_service_full_permissions')
 def _sample_service_full_permissions(notify_db_session):
     service = create_service(
@@ -402,6 +416,11 @@ def _sample_service_full_permissions(notify_db_session):
 def _sample_service_custom_letter_contact_block(sample_service):
     create_letter_contact(sample_service, contact_block='((contact block))')
     return sample_service
+
+
+@pytest.fixture(scope="function")
+def sample_service_data(sample_service):
+    return ServiceData(sample_service)
 
 
 @pytest.fixture(scope='function')

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -226,7 +226,7 @@ def create_service_model(
         crown=True,
         organisation=None,
         smtp_user=None
-):
+) -> Service:
     service = Service(
         name=service_name,
         message_limit=message_limit,
@@ -300,7 +300,7 @@ def sample_notification_model_with_organization(
         normalised_to=None,
         postage=None,
         sms_sender_id=None
-):
+) -> Notification:
     created_at = datetime.utcnow()
 
     if service is None:

--- a/tests/app/v3/notifications/test_rest.py
+++ b/tests/app/v3/notifications/test_rest.py
@@ -1,6 +1,7 @@
 """ Test endpoints for the v3 notifications. """
 
 import pytest
+from app.authentication.auth import AuthError
 from app.models import EMAIL_TYPE, SMS_TYPE
 from app.service.service_data import ServiceData
 from app.v3.notifications.rest import v3_send_notification
@@ -111,9 +112,7 @@ def test_post_v3_notifications(notify_db_session, client, mocker, sample_service
     if expected_status_code == 202:
         assert isinstance(UUID(response_json["id"]), UUID)
         request_data["id"] = response_json["id"]
-        celery_mock.assert_called_once_with(request_data, mocker.ANY)
-        assert isinstance(celery_mock.call_args.args[1], ServiceData)
-        assert celery_mock.call_args.args[1].id == sample_service.id
+        celery_mock.assert_called_once_with(request_data)
 
         # For the same request data, calling v3_send_notification directly, rather than through a route
         # handler, should also succeed.
@@ -121,9 +120,7 @@ def test_post_v3_notifications(notify_db_session, client, mocker, sample_service
         del request_data["id"]
         request_data["id"] = v3_send_notification(request_data, service_data)
         assert isinstance(UUID(request_data["id"]), UUID)
-        celery_mock.assert_called_once_with(request_data, service_data)
-        assert isinstance(celery_mock.call_args.args[1], ServiceData)
-        assert celery_mock.call_args.args[1].id == sample_service.id
+        celery_mock.assert_called_once_with(request_data)
     elif expected_status_code == 400:
         assert response_json["errors"][0]["error"] == "ValidationError"
 
@@ -133,6 +130,64 @@ def test_post_v3_notifications(notify_db_session, client, mocker, sample_service
             v3_send_notification(request_data, service_data)
 
         celery_mock.assert_not_called()
+
+
+def test_post_v3_notifications_email_denied(notify_db_session, client, mocker, sample_service_sms_permission):
+    """
+    Test trying to send e-mail with a service that does not have permission to send e-mail.
+    The implementation should test permission before validating the request data.
+    """
+
+    assert not sample_service_sms_permission.has_permissions(EMAIL_TYPE)
+
+    celery_mock = mocker.patch("app.v3.notifications.rest.v3_process_notification.delay")
+    auth_header = create_authorization_header(service_id=sample_service_sms_permission.id, key_type="team")
+    response = client.post(
+        path=url_for(f"v3.v3_notifications.v3_post_notification_email"),
+        data=dumps({}),
+        headers=(("Content-Type", "application/json"), auth_header)
+    )
+    assert response.status_code == 403
+    response_json = response.get_json()
+    assert response_json["errors"][0]["error"] == "AuthError"
+    assert response_json["errors"][0]["message"] == \
+        "The service does not have permission to send this type of notification."
+    celery_mock.assert_not_called()
+
+    # For the same request data, calling v3_send_notification directly, rather than through a route
+    # handler, should also raise AuthError.
+    with pytest.raises(AuthError):
+        v3_send_notification({"notification_type": EMAIL_TYPE}, ServiceData(sample_service_sms_permission))
+    celery_mock.assert_not_called()
+
+
+def test_post_v3_notifications_sms_denied(notify_db_session, client, mocker, sample_service_email_permission):
+    """
+    Test trying to send a SMS notification with a service that does not have permission to send SMS.
+    The implementation should test permission before validating the request data.
+    """
+
+    assert not sample_service_email_permission.has_permissions(SMS_TYPE)
+
+    celery_mock = mocker.patch("app.v3.notifications.rest.v3_process_notification.delay")
+    auth_header = create_authorization_header(service_id=sample_service_email_permission.id, key_type="team")
+    response = client.post(
+        path=url_for(f"v3.v3_notifications.v3_post_notification_sms"),
+        data=dumps({}),
+        headers=(("Content-Type", "application/json"), auth_header)
+    )
+    assert response.status_code == 403
+    response_json = response.get_json()
+    assert response_json["errors"][0]["error"] == "AuthError"
+    assert response_json["errors"][0]["message"] == \
+        "The service does not have permission to send this type of notification."
+    celery_mock.assert_not_called()
+
+    # For the same request data, calling v3_send_notification directly, rather than through a route
+    # handler, should also raise AuthError.
+    with pytest.raises(AuthError):
+        v3_send_notification({"notification_type": SMS_TYPE}, ServiceData(sample_service_email_permission))
+    celery_mock.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -158,7 +213,7 @@ def test_post_v3_notifications(notify_db_session, client, mocker, sample_service
 )
 def test_post_v3_notifications_phone_number_not_possible(notify_db_session, client, sample_service, request_data):
     """
-    Test a phone number strings that cannot be parsed.
+    Test phone number strings that cannot be parsed.
     """
 
     auth_header = create_authorization_header(service_id=sample_service.id, key_type="team")
@@ -226,13 +281,20 @@ def test_post_v3_notifications_scheduled_for(notify_db_session, client, mocker, 
         headers=(("Content-Type", "application/json"), auth_header)
     )
     response_json = response.get_json()
-    assert response.status_code == 202, response_json
-    email_request_data["id"] = response_json["id"]
-    celery_mock.assert_called_once_with(email_request_data, mocker.ANY)
-    assert isinstance(celery_mock.call_args.args[1], ServiceData)
-    assert celery_mock.call_args.args[1].id == sample_service.id
-    celery_mock.reset_mock()
-    del email_request_data["id"]
+
+    # TODO - Delete when scheduled sending is implemented.
+    assert response.status_code == 501, response_json
+    assert response_json["errors"][0]["message"] == "Scheduled sending is not implemented."
+    celery_mock.assert_not_called()
+
+    # TODO - Uncomment when scheduled sending is implemented.
+    # assert response.status_code == 202, response_json
+    # email_request_data["id"] = response_json["id"]
+    # celery_mock.assert_called_once_with(email_request_data)
+    # assert isinstance(celery_mock.call_args.args[1], ServiceData)
+    # assert celery_mock.call_args.args[1].id == sample_service.id
+    # celery_mock.reset_mock()
+    # del email_request_data["id"]
 
     response = client.post(
         path=url_for("v3.v3_notifications.v3_post_notification_sms"),
@@ -240,13 +302,20 @@ def test_post_v3_notifications_scheduled_for(notify_db_session, client, mocker, 
         headers=(("Content-Type", "application/json"), auth_header)
     )
     response_json = response.get_json()
-    assert response.status_code == 202, response_json
-    sms_request_data["id"] = response_json["id"]
-    celery_mock.assert_called_once_with(sms_request_data, mocker.ANY)
-    assert isinstance(celery_mock.call_args.args[1], ServiceData)
-    assert celery_mock.call_args.args[1].id == sample_service.id
-    celery_mock.reset_mock()
-    del sms_request_data["id"]
+
+    # TODO - Delete when scheduled sending is implemented.
+    assert response.status_code == 501, response_json
+    assert response_json["errors"][0]["message"] == "Scheduled sending is not implemented."
+    celery_mock.assert_not_called()
+
+    # TODO - Uncomment when scheduled sending is implemented.
+    # assert response.status_code == 202, response_json
+    # sms_request_data["id"] = response_json["id"]
+    # celery_mock.assert_called_once_with(sms_request_data)
+    # assert isinstance(celery_mock.call_args.args[1], ServiceData)
+    # assert celery_mock.call_args.args[1].id == sample_service.id
+    # celery_mock.reset_mock()
+    # del sms_request_data["id"]
 
     #######################################################################
     # Test scheduled_for too far in the future and in the past.

--- a/tests/app/v3/notifications/test_rest.py
+++ b/tests/app/v3/notifications/test_rest.py
@@ -2,7 +2,6 @@
 
 import pytest
 from app.authentication.auth import AuthError
-from app.config import QueueNames
 from app.models import EMAIL_TYPE, KEY_TYPE_TEAM, SMS_TYPE
 from app.service.service_data import ServiceData
 from app.v3.notifications.rest import v3_send_notification
@@ -113,8 +112,6 @@ def test_post_v3_notifications(notify_db_session, client, mocker, sample_service
     if expected_status_code == 202:
         assert isinstance(UUID(response_json["id"]), UUID)
         request_data["id"] = response_json["id"]
-        expected_celery_queue = QueueNames.SEND_EMAIL if \
-            (request_data["notification_type"] == EMAIL_TYPE) else QueueNames.SEND_SMS
         celery_mock.assert_called_once_with(
             request_data, sample_service.id, sample_service.api_keys[0].id, KEY_TYPE_TEAM
         )

--- a/tests/app/v3/notifications/test_rest.py
+++ b/tests/app/v3/notifications/test_rest.py
@@ -112,7 +112,9 @@ def test_post_v3_notifications(notify_db_session, client, mocker, sample_service
     if expected_status_code == 202:
         assert isinstance(UUID(response_json["id"]), UUID)
         request_data["id"] = response_json["id"]
-        celery_mock.assert_called_once_with(request_data)
+        celery_mock.assert_called_once_with(request_data, mocker.ANY)
+        assert isinstance(celery_mock.call_args.args[1], ServiceData)
+        assert celery_mock.call_args.args[1].id == sample_service.id
 
         # For the same request data, calling v3_send_notification directly, rather than through a route
         # handler, should also succeed.
@@ -120,7 +122,9 @@ def test_post_v3_notifications(notify_db_session, client, mocker, sample_service
         del request_data["id"]
         request_data["id"] = v3_send_notification(request_data, service_data)
         assert isinstance(UUID(request_data["id"]), UUID)
-        celery_mock.assert_called_once_with(request_data)
+        celery_mock.assert_called_once_with(request_data, mocker.ANY)
+        assert isinstance(celery_mock.call_args.args[1], ServiceData)
+        assert celery_mock.call_args.args[1].id == sample_service.id
     elif expected_status_code == 400:
         assert response_json["errors"][0]["error"] == "ValidationError"
 
@@ -290,7 +294,7 @@ def test_post_v3_notifications_scheduled_for(notify_db_session, client, mocker, 
     # TODO - Uncomment when scheduled sending is implemented.
     # assert response.status_code == 202, response_json
     # email_request_data["id"] = response_json["id"]
-    # celery_mock.assert_called_once_with(email_request_data)
+    # celery_mock.assert_called_once_with(email_request_data, mocker.ANY)
     # assert isinstance(celery_mock.call_args.args[1], ServiceData)
     # assert celery_mock.call_args.args[1].id == sample_service.id
     # celery_mock.reset_mock()
@@ -311,7 +315,7 @@ def test_post_v3_notifications_scheduled_for(notify_db_session, client, mocker, 
     # TODO - Uncomment when scheduled sending is implemented.
     # assert response.status_code == 202, response_json
     # sms_request_data["id"] = response_json["id"]
-    # celery_mock.assert_called_once_with(sms_request_data)
+    # celery_mock.assert_called_once_with(sms_request_data, mocker.ANY)
     # assert isinstance(celery_mock.call_args.args[1], ServiceData)
     # assert celery_mock.call_args.args[1].id == sample_service.id
     # celery_mock.reset_mock()


### PR DESCRIPTION
# Description

These changes for v3 notification logic:
- Implement a 501 (not implemented) response if a user includes "scheduled_for" in the request data
- Include Celery tasks to send notifications with Pinpoint (SMS) and SES (e-mail)
- Include unit tests for the above

The changes are nowhere near feature complete, and this PR does not complete #1361.  I will author a new PR with additional changes that add error handling, which is necessary, among other reasons, to retry failed tasks when appropriate.

Many other tickets are necessary before v3 achieves anything resembling feature completeness or parity with v2.  There are a lot of TODOs in the code, and creating tickets for all of them now is not feasible.  Please trust that I'm working on all of it.

issue #1361

## Type of change

Please check the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?

In addition to new unit tests, I have successfully sent myself SMS and e-mail notifications using Postman.  Please see the ticket comments for specific Dev notification IDs you can GET, or try Postman yourself.  (Make sure you have imported the latest Postman collection.)

For SMS, you must provide a valid sms_sender_id right now.  You won't see personalizations either; just the raw template.

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an appropriate title: #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have ensured the latest master is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket is now moved into the DEV test column
