### PR TITLE
Hotfix to Return 201 on PUSH Timeout

### DIFF
--- a/app/va/vetext/client.py
+++ b/app/va/vetext/client.py
@@ -48,6 +48,11 @@ class VETextClient:
             )
             self.logger.info("VEText response: %s", response.json() if response.ok else response.status_code)
             response.raise_for_status()
+        except requests.exceptions.ReadTimeout:
+            # Discussion with VEText: read timeouts are still processed, so are marking this as good
+            self.logger.warning('ReadTimeout exceptions are still processed, returning 201')
+            # Logging as error.read_timeout so we can easily track it
+            self.statsd.incr(f"{self.STATSD_KEY}.error.read_timeout")
         except requests.HTTPError as e:
             self.logger.exception(e)
             self.statsd.incr(f"{self.STATSD_KEY}.error.{e.response.status_code}")

--- a/tests/app/v2/notifications/test_push_notifications.py
+++ b/tests/app/v2/notifications/test_push_notifications.py
@@ -5,6 +5,7 @@ from app.models import PUSH_TYPE
 from app.mobile_app import MobileAppType, DEAFULT_MOBILE_APP_TYPE
 from app.va.vetext import VETextClient, VETextBadRequestException, VETextNonRetryableException, VETextRetryableException
 import requests
+import requests_mock
 from tests.app.factories.feature_flag import mock_feature_flag
 from tests.app.db import (
     create_service,
@@ -139,8 +140,8 @@ class TestPushSending:
         assert response.status_code == 201
 
     def test_returns_201_after_read_timeout(self, client, service_with_push_permission, vetext_client, mocker):
-        mock_request = MockRequest()
-        mocker.patch('app.va.vetext.client.VETextClient.send_push_notification.response', mock_request.post())
+        with requests_mock.Mocker() as m:
+            m.post(f'{client.application.config["VETEXT_URL"]}/mobile/push/send', exc=requests.exceptions.ReadTimeout)
         response = post_send_notification(client, service_with_push_permission, 'push', push_request)
 
         assert response.status_code == 201

--- a/tests/app/v2/notifications/test_push_notifications.py
+++ b/tests/app/v2/notifications/test_push_notifications.py
@@ -43,12 +43,6 @@ def test_returns_not_implemented_if_feature_flag_disabled(client, mocker, servic
     assert response.status_code == 501
 
 
-class MockRequest:
-    @staticmethod
-    def post(*args, **kwargs):
-        raise requests.exceptions.ReadTimeout
-
-
 class TestValidations:
 
     def test_checks_service_permissions(self, client, notify_db_session):
@@ -139,7 +133,7 @@ class TestPushSending:
 
         assert response.status_code == 201
 
-    def test_returns_201_after_read_timeout(self, client, service_with_push_permission, vetext_client, mocker):
+    def test_returns_201_after_read_timeout(self, client, service_with_push_permission, vetext_client):
         with requests_mock.Mocker() as m:
             m.post(f'{client.application.config["VETEXT_URL"]}/mobile/push/send', exc=requests.exceptions.ReadTimeout)
         response = post_send_notification(client, service_with_push_permission, 'push', push_request)

--- a/tests/app/v2/notifications/test_push_notifications.py
+++ b/tests/app/v2/notifications/test_push_notifications.py
@@ -43,8 +43,8 @@ def test_returns_not_implemented_if_feature_flag_disabled(client, mocker, servic
 
 
 class MockRequest:
-    @classmethod
-    def post(self, args, kwargs):
+    @staticmethod
+    def post(*args, **kwargs):
         raise requests.exceptions.ReadTimeout
 
 


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
Talks with VEText let us know that if we make the connection we can consider the PUSH notification sent. This looks specifically for the read timeouts and does not raise a retryable exception if there was a read timeout. Services have been retrying these timeouts that VEText processes, which is leading to duplicate PUSH notifications.

issue N/A

## Type of change

Please check the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->
Unit tests [pass](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/6693640584/job/18185211368?pr=1519#step:8:8229). I can't force VEText to have a read timeout. [Deployment](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/6693827458) was successful.


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an appropriate title: #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have ensured the latest master is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket is now moved into the DEV test column
