### PR TITLE
#1504 - Use the default SMS sender if one is not provided

### DIFF
--- a/app/celery/v3/notification_tasks.py
+++ b/app/celery/v3/notification_tasks.py
@@ -111,14 +111,13 @@ def v3_process_notification(request_data: dict, service_id: str, api_key_id: str
                 ServiceSmsSender.is_default
             )
             with get_reader_session() as db:
-                sms_sender = None
                 try:
-                    sms_sender = db.execute(query).one()
+                    sms_sender = db.execute(query).one().ServiceSmsSender
                     v3_send_sms_notification.delay(notification, sms_sender.sms_sender)
                 except NoResultFound:
                     _msg = ("SMS sender ID was not set for the notification and no default was found.")
                     v3_persist_failed_notification(notification, NOTIFICATION_TECHNICAL_FAILURE, _msg)
-                except Exception as err: 
+                except Exception as err:
                     _msg = "Unexpected error while retrieving the SMS sender: %s" % err
                     v3_persist_failed_notification(notification, NOTIFICATION_TECHNICAL_FAILURE, _msg)
             return

--- a/app/celery/v3/notification_tasks.py
+++ b/app/celery/v3/notification_tasks.py
@@ -104,7 +104,6 @@ def v3_process_notification(request_data: dict, service_id: str, api_key_id: str
     if notification.notification_type == EMAIL_TYPE:
         v3_send_email_notification.delay(notification, template)
     elif notification.notification_type == SMS_TYPE:
-        current_app.logger.critical(f"V3: service_id: {service_id}")
         if notification.sms_sender_id is None:
             current_app.logger.critical(f"V3: sms_sender_id is not set for notification. Fetching the default one.")
             query = select(ServiceSmsSender).where(

--- a/app/celery/v3/notification_tasks.py
+++ b/app/celery/v3/notification_tasks.py
@@ -26,25 +26,24 @@ from notifications_utils.recipients import validate_and_format_email_address
 # from notifications_utils.template import HTMLEmailTemplate, PlainTextEmailTemplate
 from sqlalchemy import select
 from sqlalchemy.exc import MultipleResultsFound, NoResultFound
+from typing import Tuple, Optional
 
 logger = get_task_logger(__name__)
 
 
-def get_default_sms_sender_id(service_id: str) -> str:
+def get_default_sms_sender_id(service_id: str) -> Tuple[Optional[str], Optional[str]]:
     """
-    Retrieve the default SMS sender ID for a given service.
+    Retrieves the default SMS sender ID for a given service.
+
+    This function queries the database to find the default SMS sender associated with a specified service ID.
 
     Parameters:
-    - service_id (str): The UUID for the service whose default SMS sender ID is being retrieved.
+    service_id (str): The unique identifier for the service whose default SMS sender ID is to be retrieved.
 
     Returns:
-    - str: The ID of the default SMS sender.
-
-    Raises:
-    - RuntimeError:
-        If no default SMS sender ID is found.
-        If there is an unexpected error during the database query.
-        If the SMS sender ID is None after retrieving a sender that was marked as default.
+    Tuple[Optional[str], Optional[str]]:
+        - First element is an error message or None if no error occurs.
+        - Second element is the SMS sender ID (if found) or None (if not found or an error occurs).
     """
     query = select(ServiceSmsSender).where(
         (ServiceSmsSender.service_id == service_id) &

--- a/app/celery/v3/notification_tasks.py
+++ b/app/celery/v3/notification_tasks.py
@@ -108,15 +108,16 @@ def v3_process_notification(request_data: dict, service_id: str, api_key_id: str
         if notification.sms_sender_id is None:
             current_app.logger.critical(f"V3: sms_sender_id is not set for notification. Fetching the default one.")
             query = select(ServiceSmsSender).where(
-                (ServiceSmsSender.service_id == f"d6aa2c68-a2d9-4437-ab19-3ae8eb202888") & 
-                (ServiceSmsSender.is_default == True)
+                (ServiceSmsSender.service_id == service_id) &
+                ServiceSmsSender.is_default
             )
             with get_reader_session() as dbsession:
                 try:
                     sms_sender: ServiceSmsSender = dbsession.execute(query).one().ServiceSmsSender
                     v3_send_sms_notification.delay(notification, sms_sender.sms_sender)
                 except Exception as err:
-                    _msg = "sms_sender_id was not set for notification and we were unable to retreive the default one. Error: %s" % err
+                    _msg = "sms_sender_id was not set for notification and we were unable to retreive the default one.\
+                            Error: %s" % err
                     current_app.logger.critical(_msg)
                     v3_persist_failed_notification(notification, NOTIFICATION_TECHNICAL_FAILURE, _msg)
             return

--- a/app/celery/v3/notification_tasks.py
+++ b/app/celery/v3/notification_tasks.py
@@ -124,7 +124,7 @@ def v3_process_notification(request_data: dict, service_id: str, api_key_id: str
                     return
                 else:
                     if notification.sms_sender_id is None:
-                        _msg = "Unexpected error while retrieving the SMS sender: %s" % err
+                        _msg = "Missing sms_sender_id after retrieving the SMS sender."
                         v3_persist_failed_notification(notification, NOTIFICATION_TECHNICAL_FAILURE, _msg)
                         return
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,8 +1,12 @@
 # This is used to create Postgres stored functions via the migrations process.
 alembic_utils >= 0.8.1
 
+# 8 Nov 2023: Ignoring security vulnerabilities for aiohttp 61657 & 61661 in Makefile. Fixed in >=3.8.6
+
 Authlib >= 1.2.1
 boto3 >= 1.28.32
+# 7 Nov 2023: Ignoring security vulnerability 61601 in Makefile. This is for urllib3, fixed in >=1.26.17
+# update restricted by botocore version
 botocore >= 1.31.32
 cachelib >= 0.10.2
 celery[sqs] >= 5.3.1

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,12 +1,8 @@
 # This is used to create Postgres stored functions via the migrations process.
 alembic_utils >= 0.8.1
 
-# 8 Nov 2023: Ignoring security vulnerabilities for aiohttp 61657 & 61661 in Makefile. Fixed in >=3.8.6
-
 Authlib >= 1.2.1
 boto3 >= 1.28.32
-# 7 Nov 2023: Ignoring security vulnerability 61601 in Makefile. This is for urllib3, fixed in >=1.26.17
-# update restricted by botocore version
 botocore >= 1.31.32
 cachelib >= 0.10.2
 celery[sqs] >= 5.3.1

--- a/tests/app/celery/v3/test_notification_tasks.py
+++ b/tests/app/celery/v3/test_notification_tasks.py
@@ -203,7 +203,6 @@ def test_v3_process_notification_valid_sms_with_sender_id(
     assert isinstance(v3_send_sms_notification_mock.call_args.args[0], Notification)
 
 
-@pytest.mark.xfail(reason="Not implemented.", run=False)
 def test_v3_process_notification_valid_sms_without_sender_id(
     notify_db_session, mocker, sample_service, sample_template, sample_sms_sender
 ):
@@ -212,7 +211,22 @@ def test_v3_process_notification_valid_sms_without_sender_id(
     should pass a Notification instance to the task v3_send_sms_notification.
     """
 
-    pass
+    assert sample_template.template_type == SMS_TYPE
+
+    request_data = {
+        "id": str(uuid4()),
+        "notification_type": SMS_TYPE,
+        "phone_number": "+18006982411",
+        "template_id": sample_template.id,
+    }
+
+    v3_send_sms_notification_mock = mocker.patch("app.celery.v3.notification_tasks.v3_send_sms_notification.delay")
+    v3_process_notification(request_data, sample_service.id, None, KEY_TYPE_TEST)
+    v3_send_sms_notification_mock.assert_called_once_with(
+        mocker.ANY,
+        sample_sms_sender.sms_sender
+    )
+    assert isinstance(v3_send_sms_notification_mock.call_args.args[0], Notification)
 
 
 def test_v3_send_sms_notification(notify_db_session, mocker, sample_notification, sample_sms_sender):

--- a/tests/app/celery/v3/test_notification_tasks.py
+++ b/tests/app/celery/v3/test_notification_tasks.py
@@ -223,14 +223,14 @@ def test_v3_process_notification_valid_sms_without_sender_id(
     v3_send_sms_notification_mock = mocker.patch(
         "app.celery.v3.notification_tasks.v3_send_sms_notification.delay"
     )
-    
+
     get_default_sms_sender_id_mock = mocker.patch(
         "app.celery.v3.notification_tasks.get_default_sms_sender_id",
         return_value=sample_sms_sender.id
     )
 
     v3_process_notification(request_data, sample_service.id, None, KEY_TYPE_TEST)
-    
+
     v3_send_sms_notification_mock.assert_called_once_with(
         mocker.ANY,
         sample_sms_sender.sms_sender

--- a/tests/app/celery/v3/test_notification_tasks.py
+++ b/tests/app/celery/v3/test_notification_tasks.py
@@ -229,6 +229,33 @@ def test_v3_process_notification_valid_sms_without_sender_id(
     assert isinstance(v3_send_sms_notification_mock.call_args.args[0], Notification)
 
 
+def test_v3_process_notification_invalid_sms_with_sender_id(
+    notify_db_session, mocker, sample_service, sample_template, sample_sms_sender
+):
+    """
+    Given data for a valid SMS notification that includes an INVALID sms_sender_id, the task v3_process_notification
+    should pass a Notification instance to the task v3_send_sms_notification.
+    """
+
+    assert sample_template.template_type == SMS_TYPE
+
+    request_data = {
+        "id": str(uuid4()),
+        "notification_type": SMS_TYPE,
+        "phone_number": "+18006982411",
+        "template_id": sample_template.id,
+        "sms_sender_id": '111a1111-aaaa-1aa1-aa11-a1111aa1a1a1',
+    }
+
+    v3_send_sms_notification_mock = mocker.patch("app.celery.v3.notification_tasks.v3_send_sms_notification.delay")
+    v3_process_notification(request_data, sample_service.id, None, KEY_TYPE_TEST)
+    v3_send_sms_notification_mock.assert_called_once_with(
+        mocker.ANY,
+        sample_sms_sender.sms_sender
+    )
+    assert isinstance(v3_send_sms_notification_mock.call_args.args[0], Notification)
+
+
 def test_v3_send_sms_notification(notify_db_session, mocker, sample_notification, sample_sms_sender):
     assert sample_notification.notification_type == SMS_TYPE
 

--- a/tests/app/celery/v3/test_notification_tasks.py
+++ b/tests/app/celery/v3/test_notification_tasks.py
@@ -229,7 +229,7 @@ def test_v3_process_notification_valid_sms_without_sender_id(
     assert isinstance(v3_send_sms_notification_mock.call_args.args[0], Notification)
 
 
-def test_v3_process_notification_invalid_sms_with_sender_id(
+def test_v3_process_notification_valid_sms_with_invalid_sender_id(
     notify_db_session, mocker, sample_service, sample_template, sample_sms_sender
 ):
     """

--- a/tests/app/celery/v3/test_notification_tasks.py
+++ b/tests/app/celery/v3/test_notification_tasks.py
@@ -233,8 +233,8 @@ def test_v3_process_notification_invalid_sms_with_sender_id(
     notify_db_session, mocker, sample_service, sample_template, sample_sms_sender
 ):
     """
-    Given data for a valid SMS notification that includes an INVALID sms_sender_id, the task v3_process_notification
-    should pass a Notification instance to the task v3_send_sms_notification.
+    Given data for a valid SMS notification that includes an INVALID sms_sender_id,
+    v3_process_notification should NOT call v3_send_sms_notification after checking sms_sender_id.
     """
 
     assert sample_template.template_type == SMS_TYPE
@@ -249,11 +249,7 @@ def test_v3_process_notification_invalid_sms_with_sender_id(
 
     v3_send_sms_notification_mock = mocker.patch("app.celery.v3.notification_tasks.v3_send_sms_notification.delay")
     v3_process_notification(request_data, sample_service.id, None, KEY_TYPE_TEST)
-    v3_send_sms_notification_mock.assert_called_once_with(
-        mocker.ANY,
-        sample_sms_sender.sms_sender
-    )
-    assert isinstance(v3_send_sms_notification_mock.call_args.args[0], Notification)
+    v3_send_sms_notification_mock.assert_not_called()
 
 
 def test_v3_send_sms_notification(notify_db_session, mocker, sample_notification, sample_sms_sender):

--- a/tests/app/celery/v3/test_notification_tasks.py
+++ b/tests/app/celery/v3/test_notification_tasks.py
@@ -226,7 +226,7 @@ def test_v3_process_notification_valid_sms_without_sender_id(
 
     get_default_sms_sender_id_mock = mocker.patch(
         "app.celery.v3.notification_tasks.get_default_sms_sender_id",
-        return_value=sample_sms_sender.id
+        return_value=(None, sample_sms_sender.id)
     )
 
     v3_process_notification(request_data, sample_service.id, None, KEY_TYPE_TEST)
@@ -238,7 +238,9 @@ def test_v3_process_notification_valid_sms_without_sender_id(
 
     _notification = v3_send_sms_notification_mock.call_args.args[0]
     assert isinstance(_notification, Notification)
-    assert _notification.sms_sender_id == get_default_sms_sender_id_mock.return_value
+    _err, _sender_id = get_default_sms_sender_id_mock.return_value
+    assert _err is None
+    assert _notification.sms_sender_id == _sender_id
 
     get_default_sms_sender_id_mock.assert_called_once_with(sample_service.id)
 


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description

We want to ensure V3 has feature parity with V2. Clients can send an SMS request with or without an sms_sender_id. If they send without, then we must look up the default sender assigned to the service and send the SMS from that sender.

issue #1504

## Type of change

Please check the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?

- this was tested locally by modifying requests and records in database to simulate relevant conditions
- this was deployed to Dev and tested there by Nikolai and Cris

Latest deployment to DEV
https://github.com/department-of-veterans-affairs/notification-api/actions/runs/6806916784


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an appropriate title: #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have ensured the latest master is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket is now moved into the DEV test column
