### PR TITLE
#1499 migration to add `sessions` table

### DIFF
--- a/migrations/versions/0366_add_sessions_table.py
+++ b/migrations/versions/0366_add_sessions_table.py
@@ -22,8 +22,8 @@ def upgrade():
     sa.Column('updated_at', sa.DateTime(), nullable=True),
     )
 
-    op.create_index('unique_session_id', 'sessions', ['session_id'], unique=True)
-    op.create_index('index_session_updated_at', 'sessions', ['updated_at'])
+    op.create_index('index_sessions_on_session_id', 'sessions', ['session_id'], unique=True)
+    op.create_index('index_sessions_on_updated_at', 'sessions', ['updated_at'])
 
 def downgrade():
     op.drop_index('index_session_updated_at', table_name='sessions')

--- a/migrations/versions/0366_add_sessions_table.py
+++ b/migrations/versions/0366_add_sessions_table.py
@@ -1,0 +1,31 @@
+"""
+
+Revision ID: 6392698ad84a
+Revises: 0365_add_notification_failures
+Create Date: 2023-11-30 21:40:23.546531
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0366_add_sessions_table'
+down_revision = '0365_add_notification_failures'
+
+
+def upgrade():
+    op.create_table('sessions',
+    sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column('session_id', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column('data', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    sa.Column('created_at', sa.DateTime(), nullable=False),
+    sa.Column('updated_at', sa.DateTime(), nullable=True),
+    )
+
+    op.create_index('unique_session_id', 'sessions', ['session_id'], unique=True)
+    op.create_index('index_session_updated_at', 'sessions', ['updated_at'])
+
+def downgrade():
+    op.drop_index('index_session_updated_at', table_name='sessions')
+    op.drop_index('unique_session_id', table_name='sessions')
+    op.drop_table('sessions')


### PR DESCRIPTION
# Description

- Adds migration to add `sessions` table

We're adding this table as part of a solution for a `CookieOverflowError` introduced by new functionality on the SSUI. 

Rails flash messages are being used to pass data that exceeds the threshold for standard cookies. 

This solution moves storage of sessions to an ActiveRecord-backed database table, titled "sessions". 

issue [notification-portal issue 1499](https://github.com/department-of-veterans-affairs/notification-portal/issues/1499)

## Type of change

Please check the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  

n/a (aside from verification in dev env)


Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)

[corresponding PR for notification portal](https://github.com/department-of-veterans-affairs/notification-portal/pull/1560)


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an appropriate title: #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/release.yaml) to the PR.
- [ ] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to any documentation~~
- [x] My changes generate no new warnings
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have ensured the latest master is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket is now moved into the DEV test column
