### PR TITLE
Ensured strings were sent to the method expecting strings

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -257,7 +257,7 @@ def send_to_queue_for_recipient_info_based_on_recipient_identifier(
     deliver_task, deliver_queue = _get_delivery_task(notification)
     if id_type == IdentifierType.VA_PROFILE_ID.value:
         tasks = [
-            send_va_onsite_notification_task.s(id_value, notification.template.id, onsite_enabled)
+            send_va_onsite_notification_task.s(id_value, str(notification.template.id), onsite_enabled)
                                             .set(queue=QueueNames.SEND_ONSITE_NOTIFICATION),
             lookup_contact_info.si(notification.id).set(queue=QueueNames.LOOKUP_CONTACT_INFO),
             deliver_task.si(notification.id).set(queue=deliver_queue)
@@ -273,7 +273,7 @@ def send_to_queue_for_recipient_info_based_on_recipient_identifier(
     else:
         tasks = [
             lookup_va_profile_id.si(notification.id).set(queue=QueueNames.LOOKUP_VA_PROFILE_ID),
-            send_va_onsite_notification_task.s(notification.template.id, onsite_enabled)
+            send_va_onsite_notification_task.s(str(notification.template.id), onsite_enabled)
                                             .set(queue=QueueNames.SEND_ONSITE_NOTIFICATION),
             lookup_contact_info.si(notification.id).set(queue=QueueNames.LOOKUP_CONTACT_INFO),
             deliver_task.si(notification.id).set(queue=deliver_queue)


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description

`send_va_onsite_notification_task` expected that the template id was a string, but we were not casting it to a string, leading to serialization issues when attempting to send onsite notifications.

Occurrence in prod:
![image](https://github.com/department-of-veterans-affairs/notification-api/assets/16893311/68929c20-6777-40d7-8523-9c788028c1d9)

Body we are attempting to serialize:
![image](https://github.com/department-of-veterans-affairs/notification-api/assets/16893311/6e5b9e17-ddbe-4fd9-9459-a6522b4dd8a0)

Should not say, `UUID('<redacted>')` It should just be the redacted string.

issue #N/A

## Type of change

Please check the relevant option(s).
- [ ] Hotfix
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->
The method is called in two places in a single method. Cast the UUID to str.

## Checklist

- [ ] I have assigned myself to this PR
- [ ] PR has an appropriate title: #9999 - What the thing does
- [ ] PR has a detailed description, including links to specific documentation
- [ ] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/release.yaml) to the PR.
- [ ] I did not remove any parts of the template, such as checkboxes even if they are not used
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured the latest master is merged into my branch and all checks are green prior to review
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket is now moved into the DEV test column
