### PR TITLE
#1525 [BUGFIX] KeyError Invalid Phone Number Prefix

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -126,7 +126,11 @@ def validate_and_format_recipient(send_to, key_type, service, notification_type,
     service_can_send_to_recipient(send_to, key_type, service, allow_whitelisted_recipients)
 
     if notification_type == SMS_TYPE:
-        phone_info = get_international_phone_info(send_to)
+        try:
+            phone_info = get_international_phone_info(send_to)
+        except KeyError:
+            current_app.logger.warn("Service used invalid International Billing Rate prefix: %s", send_to)
+            raise BadRequestError(message="Invalid International Billing Prefix")
 
         if phone_info.international and not service.has_permissions(INTERNATIONAL_SMS_TYPE):
             raise BadRequestError(message="Cannot send to international mobile numbers")

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -388,6 +388,14 @@ def test_rejects_api_calls_with_no_recipient():
     assert e.value.message == "Recipient can't be empty"
 
 
+def test_rejects_invalid_international_prefix(mocker):
+    service = create_service(service_permissions=[SMS_TYPE])
+    with pytest.raises(KeyError) as e:
+        mocker.patch('app.notifications.validators.validate_and_format_recipient.service_can_send_to_recipient')
+        validate_and_format_recipient('+808888', 'test', service, SMS_TYPE)
+    assert e.value.status_code == 400
+
+
 @pytest.mark.parametrize('notification_type', ['sms', 'email', 'letter'])
 def test_check_service_email_reply_to_id_where_reply_to_id_is_none(notification_type):
     assert check_service_email_reply_to_id(None, None, notification_type) is None

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from uuid import uuid4
 
 import pytest
 from freezegun import freeze_time
@@ -389,10 +390,10 @@ def test_rejects_api_calls_with_no_recipient():
 
 
 def test_rejects_invalid_international_prefix(mocker):
-    service = create_service(service_permissions=[SMS_TYPE])
-    with pytest.raises(KeyError) as e:
-        mocker.patch('app.notifications.validators.validate_and_format_recipient.service_can_send_to_recipient')
-        validate_and_format_recipient('+808888', 'test', service, SMS_TYPE)
+    service = create_service(service_name=str(uuid4()), service_permissions=[SMS_TYPE])
+    with pytest.raises(BadRequestError) as e:
+        mocker.patch('app.notifications.validators.service_can_send_to_recipient')
+        validate_and_format_recipient('+80888888888', 'test', service, SMS_TYPE)
     assert e.value.status_code == 400
 
 


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description

Updated the appropriate code with a try/except block to catch the `KeyError` raised if an invalid country code (prefix) makes it all the way to the international lookup table.

issue #1525 

## Type of change

Please check the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->
Ran and made modifications locally until it passed. [Regression tests](https://github.com/department-of-veterans-affairs/notification-api-qa/actions/runs/7341439249) pass. Created a test API key, [deployed](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/7341332607) and validated it raised the error and returned the status code we expected:
![image](https://github.com/department-of-veterans-affairs/notification-api/assets/16893311/45d7d3ef-2fa7-469c-a1d3-852e3ae9f730)

Properly logs so we can help services:
![image](https://github.com/department-of-veterans-affairs/notification-api/assets/16893311/9e2326c8-0845-419b-912a-eacfb100e53d)



## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an appropriate title: #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/release.yaml) to the PR.
- [ ] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have ensured the latest master is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket is now moved into the DEV test column
