### PR TITLE
#1501 [v3] Removed Extra Decorator

### DIFF
--- a/app/celery/v3/notification_tasks.py
+++ b/app/celery/v3/notification_tasks.py
@@ -181,7 +181,6 @@ def v3_process_notification(  # noqa: C901
     retry_backoff_max=60,
     max_retries=2886,
 )
-@notify_celery.task(serializer='pickle')
 def v3_send_email_notification(
     notification: Notification,
     template: Template,

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -6,13 +6,15 @@ ruff >= 0.1.9
 freezegun >= 1.2.2
 
 # This is a library for mocking AWS services.
-moto >= 4.1.7
+# 5.0 has breaking changes
+moto < 5.0.0
 
 # https://pyjwt.readthedocs.io/en/stable/installation.html#cryptographic-dependencies-optional
 # When this is upgraded, also upgrade the version in the kafka (commons) repo file lambda_layer_requirements/pyjwt-layer-requirements.txt
 PyJWT[crypto] ~= 2.8.0
 
-pytest >= 7.3.1
+# 8.0 has breaking changes
+pytest < 8.0.0
 pytest-cov >= 4.0.0
 pytest-env >= 0.8.1
 pytest-mock >= 3.10.0

--- a/tests/app/communication_item/test_rest.py
+++ b/tests/app/communication_item/test_rest.py
@@ -156,8 +156,16 @@ def test_get_communication_item_not_found(notify_db_session, admin_request, comm
         ({'name': 'different name', 'va_profile_item_id': 2, 'default_send_indicator': False}, 805, 200),
     ],
 )
-def test_partially_update_communication_item(notify_db_session, admin_request, post_data, expected_status):
-    communication_item = CommunicationItem(id=uuid4(), va_profile_item_id=1, name='communication item tests')
+def test_partially_update_communication_item(
+    notify_db_session,
+    admin_request,
+    post_data,
+    starting_profile_id,
+    expected_status,
+):
+    communication_item = CommunicationItem(
+        id=uuid4(), va_profile_item_id=starting_profile_id, name='communication item tests'
+    )
     notify_db_session.session.add(communication_item)
     notify_db_session.session.commit()
     assert communication_item.default_send_indicator, 'Should be True by default.'

--- a/tests/app/communication_item/test_rest.py
+++ b/tests/app/communication_item/test_rest.py
@@ -140,20 +140,20 @@ def test_get_communication_item_not_found(notify_db_session, admin_request, comm
 
 
 @pytest.mark.parametrize(
-    'post_data,expected_status',
+    'post_data, starting_profile_id, expected_status',
     [
-        ({}, 400),
-        ({'name': 1}, 400),
-        ({'name': ''}, 400),
-        ({'name': 'communication item tests'}, 200),
-        ({'va_profile_item_id': 'not a number'}, 400),
-        ({'va_profile_item_id': -5}, 400),
-        ({'va_profile_item_id': 0}, 400),
-        ({'va_profile_item_id': 1}, 200),
-        ({'name': 'different name'}, 200),
-        ({'va_profile_item_id': 2}, 200),
-        ({'default_send_indicator': False}, 200),
-        ({'name': 'different name', 'va_profile_item_id': 2, 'default_send_indicator': False}, 200),
+        ({}, 999, 400),
+        ({'name': 1}, 999, 400),
+        ({'name': ''}, 999, 400),
+        ({'name': 'communication item tests'}, 800, 200),
+        ({'va_profile_item_id': 'not a number'}, 999, 400),
+        ({'va_profile_item_id': -5}, 999, 400),
+        ({'va_profile_item_id': 0}, 999, 400),
+        ({'va_profile_item_id': 801}, 801, 200),
+        ({'name': 'different name'}, 802, 200),
+        ({'va_profile_item_id': 2}, 803, 200),
+        ({'default_send_indicator': False}, 804, 200),
+        ({'name': 'different name', 'va_profile_item_id': 2, 'default_send_indicator': False}, 805, 200),
     ],
 )
 def test_partially_update_communication_item(notify_db_session, admin_request, post_data, expected_status):

--- a/tests/app/test_cronitor.py
+++ b/tests/app/test_cronitor.py
@@ -68,13 +68,13 @@ def test_cronitor_does_nothing_if_cronitor_not_enabled(notify_api, rmock):
     assert not rmock.called
 
 
-def test_cronitor_does_nothing_if_name_not_recognised(notify_api, rmock, caplog):
+def test_cronitor_does_nothing_if_name_not_recognised(notify_api, mocker, rmock):
+    mock_logger = mocker.patch('app.cronitor.current_app.logger.error')
+
     with set_config_values(notify_api, {'CRONITOR_ENABLED': True, 'CRONITOR_KEYS': {'not-hello': 'other'}}):
         assert successful_task() == 1
 
-    error_log = caplog.records[0]
-    assert error_log.levelname == 'ERROR'
-    assert error_log.getMessage() == 'Cronitor enabled but task_name hello not found in environment'
+    mock_logger.assert_called_with('Cronitor enabled, but task_name %s not found in environment.', 'hello')
     assert not rmock.called
 
 

--- a/tests/app/test_cronitor.py
+++ b/tests/app/test_cronitor.py
@@ -74,7 +74,7 @@ def test_cronitor_does_nothing_if_name_not_recognised(notify_api, mocker, rmock)
     with set_config_values(notify_api, {'CRONITOR_ENABLED': True, 'CRONITOR_KEYS': {'not-hello': 'other'}}):
         assert successful_task() == 1
 
-    mock_logger.assert_called_with('Cronitor enabled, but task_name %s not found in environment.', 'hello')
+    mock_logger.assert_called_with('Cronitor enabled but task_name %s not found in environment', 'hello')
     assert not rmock.called
 
 


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description

Removed extra decorator that prevented the Celery task from running.

Added some unrelated, but required, unit test fixes and locked pytest + moto to their last major versions due to breaking changes.

issue #1501 

## Type of change

Please check the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->
Deployed and tested sending an email with v3. Succeeded. 

![image](https://github.com/department-of-veterans-affairs/notification-api/assets/16893311/9ba62d3a-f0ca-48ed-a53e-3f8f7a28d1c4)

![image](https://github.com/department-of-veterans-affairs/notification-api/assets/16893311/647b8716-d5b3-49d5-816c-0a113bfe9a40)

![image](https://github.com/department-of-veterans-affairs/notification-api/assets/16893311/08faa6f0-9790-4912-82f8-626aa7e1710c)


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an appropriate title: #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/release.yaml) to the PR.
- [ ] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have ensured the latest master is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket is now moved into the DEV test column
