### PR TITLE
#1523 Add additional environment variables to Perf for push notifications

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -35,3 +35,7 @@ fileignoreconfig:
   checksum: 2a5c8291ae13fffac0f6820880d0891248f7b958ef4106a23bd8d0bf3d17e15b
 - filename: tests/app/v2/notifications/test_push_broadcast_notifications.py
   checksum: eed7b99992b43ff534736502d72a3b8f3f3cdbdd17c26be88f9dea9614321e38
+- filename: cd/application-deployment/perf/vaec-api-task-definition.json
+  checksum: b32eae40a0fb22d71ef585eaf56983ced8abfa24087f6d1d03e4a3e7b7d48cb0
+- filename: cd/application-deployment/perf/vaec-celery-task-definition.json
+  checksum: c7d10bd01c45d4f2199a0a89d6d94fa1c222d5770187051320a0a0e2a5ca5d30

--- a/app/va/vetext/client.py
+++ b/app/va/vetext/client.py
@@ -74,7 +74,6 @@ class VETextClient:
             raise VETextRetryableException from e
         except requests.HTTPError as e:
             self.logger.warning('HTTPError raised sending push notification')
-            self.logger.exception(e)
             self.statsd.incr(f'{self.STATSD_KEY}.error.{e.response.status_code}')
             if e.response.status_code in [429, 500, 502, 503, 504]:
                 self.logger.warning('Retryable exception raised with status code: %s', e.response.status_code)

--- a/app/va/vetext/client.py
+++ b/app/va/vetext/client.py
@@ -74,6 +74,7 @@ class VETextClient:
             raise VETextRetryableException from e
         except requests.HTTPError as e:
             self.logger.warning('HTTPError raised sending push notification')
+            self.logger.exception(e)
             self.statsd.incr(f'{self.STATSD_KEY}.error.{e.response.status_code}')
             if e.response.status_code in [429, 500, 502, 503, 504]:
                 self.logger.warning('Retryable exception raised with status code: %s', e.response.status_code)

--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -269,6 +269,14 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/redis/url"
         },
         {
+          "name": "VETEXT_USERNAME",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/vetext/user"
+        },
+        {
+          "name": "VETEXT_PASSWORD",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/vetext/password"
+        },
+        {
           "name": "VA_SSO_CLIENT_ID",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/iam-sso-client-id"
         },

--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -167,6 +167,14 @@
           "value": "perf-notifications-va-gov-attachments"
         },
         {
+          "name": "VA_FLAGSHIP_APP_SID",
+          "value": "A20623E2321D4053A6C34C9307C6C221"
+        },
+        {
+          "name": "VETEXT_SID",
+          "value": "C9BEC63F53CE4C1D992CE73E8D1D8D94"
+        },
+        {
           "name": "PUSH_NOTIFICATIONS_ENABLED",
           "value": "True"
         },

--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -270,11 +270,11 @@
         },
         {
           "name": "VETEXT_USERNAME",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/vetext/user"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/vetext/user"
         },
         {
           "name": "VETEXT_PASSWORD",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/vetext/password"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/vetext/password"
         },
         {
           "name": "VA_SSO_CLIENT_ID",

--- a/cd/application-deployment/perf/vaec-celery-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-task-definition.json
@@ -157,6 +157,14 @@
           "value": "perf-notifications-va-gov-attachments"
         },
         {
+          "name": "VA_FLAGSHIP_APP_SID",
+          "value": "A20623E2321D4053A6C34C9307C6C221"
+        },
+        {
+          "name": "VETEXT_SID",
+          "value": "C9BEC63F53CE4C1D992CE73E8D1D8D94"
+        },
+        {
           "name": "PUSH_NOTIFICATIONS_ENABLED",
           "value": "True"
         },

--- a/cd/application-deployment/perf/vaec-celery-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-task-definition.json
@@ -233,6 +233,14 @@
         {
           "name": "VA_ONSITE_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/onsite/notification-priv"
+        },
+        {
+          "name": "VETEXT_USERNAME",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/vetext/user"
+        },
+        {
+          "name": "VETEXT_PASSWORD",
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/vetext/password"
         }
       ],
       "command": [

--- a/cd/application-deployment/perf/vaec-celery-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-task-definition.json
@@ -236,11 +236,11 @@
         },
         {
           "name": "VETEXT_USERNAME",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/vetext/user"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/vetext/user"
         },
         {
           "name": "VETEXT_PASSWORD",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/vetext/password"
+          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/vetext/password"
         }
       ],
       "command": [


### PR DESCRIPTION
…ions

<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description

Add additional environment variables to Perf for push notifications.  Without these variables, push requests fail in Perf.  The changes are already in other environments.

I also manually added new Parameter Store parameters for Perf.  These parameters already exist for the other environments and were created manually for them as well.

issue #1523

## Type of change

Please check the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)



## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an appropriate title: #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have ensured the latest master is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket is now moved into the DEV test column --> It's already in QA.
