### PR TITLE
#1800 Delivery Status Callbacks: VA Profile lookup failures

### DIFF
--- a/app/celery/common.py
+++ b/app/celery/common.py
@@ -26,7 +26,10 @@ def handle_max_retries_exceeded(
     notification_id: str,
     method_name: str,
 ) -> str:
-    """Handles sms/email deliver requests that exceeded the retry maximum, updates Notification status"""
+    """
+    Handles sms/email deliver requests that exceeded the retry maximum.  Updates the Notification status.
+    """
+
     current_app.logger.critical('%s: Notification %s failed by exceeding retry limits', method_name, notification_id)
     message = (
         'RETRY FAILED: Max retries reached. '

--- a/app/celery/contact_information_tasks.py
+++ b/app/celery/contact_information_tasks.py
@@ -28,7 +28,7 @@ def lookup_contact_info(
     self,
     notification_id,
 ):
-    current_app.logger.info(f'Looking up contact information for notification_id:{notification_id}.')
+    current_app.logger.info('Looking up contact information for notification_id: %s.', notification_id)
 
     notification = get_notification_by_id(notification_id)
     va_profile_id = notification.recipient_identifiers[IdentifierType.VA_PROFILE_ID.value]
@@ -63,13 +63,13 @@ def lookup_contact_info(
             f"Can't proceed after querying VA Profile for contact information for {notification_id}. "
             'Stopping execution of following tasks. Notification has been updated to permanent-failure.'
         )
-        current_app.logger.warning(f'{e.__class__.__name__} - {str(e)}: ' + message)
-        self.request.chain = None
+        current_app.logger.warning('%s - %s:  %s', e.__class__.__name__, str(e), message)
 
         update_notification_status_by_id(
             notification_id, NOTIFICATION_PERMANENT_FAILURE, status_reason=e.failure_reason
         )
         check_and_queue_callback_task(notification)
+        raise NotificationPermanentFailureException(message) from e
 
     except (VAProfileIDNotFoundException, VAProfileNonRetryableException) as e:
         current_app.logger.exception(e)

--- a/app/celery/lookup_va_profile_id_task.py
+++ b/app/celery/lookup_va_profile_id_task.py
@@ -75,7 +75,6 @@ def lookup_va_profile_id(
             'Stopping execution of following tasks. Notification has been updated to permanent-failure.'
         )
         current_app.logger.warning(message)
-        self.request.chain = None
         notifications_dao.update_notification_status_by_id(
             notification_id, NOTIFICATION_PERMANENT_FAILURE, status_reason=e.failure_reason
         )
@@ -88,7 +87,6 @@ def lookup_va_profile_id(
             'Notification has been updated to technical-failure'
         )
         current_app.logger.exception(message)
-        self.request.chain = None
         status_reason = e.failure_reason if hasattr(e, 'failure_reason') else 'Unknown error from MPI'
         notifications_dao.update_notification_status_by_id(
             notification_id, NOTIFICATION_TECHNICAL_FAILURE, status_reason=status_reason

--- a/app/celery/lookup_va_profile_id_task.py
+++ b/app/celery/lookup_va_profile_id_task.py
@@ -58,6 +58,7 @@ def lookup_va_profile_id(
             raise AutoRetryException('Found MpiRetryableException, autoretrying...', e, e.args)
         else:
             msg = handle_max_retries_exceeded(notification_id, 'lookup_va_profile_id')
+            check_and_queue_callback_task(notification)
             raise NotificationTechnicalFailureException(msg)
 
     except (
@@ -87,9 +88,10 @@ def lookup_va_profile_id(
             'Notification has been updated to technical-failure'
         )
         current_app.logger.exception(message)
-
+        self.request.chain = None
         status_reason = e.failure_reason if hasattr(e, 'failure_reason') else 'Unknown error from MPI'
         notifications_dao.update_notification_status_by_id(
             notification_id, NOTIFICATION_TECHNICAL_FAILURE, status_reason=status_reason
         )
+        check_and_queue_callback_task(notification)
         raise NotificationTechnicalFailureException(message) from e

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -313,13 +313,14 @@ def check_and_queue_callback_task(
         service_id=notification.service_id, notification_status=notification.status
     )
 
-    # if a row of info is found
     if service_callback_api:
         # build dictionary for notification
         notification_data = create_delivery_status_callback_data(notification, service_callback_api, payload)
         send_delivery_status_to_service.apply_async(
             [service_callback_api.id, str(notification.id), notification_data], queue=QueueNames.CALLBACKS
         )
+    else:
+        current_app.logger.debug('No callbacks found for notification %s.', notification.id)
 
 
 def _check_and_queue_complaint_callback_task(

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -320,7 +320,9 @@ def check_and_queue_callback_task(
             [service_callback_api.id, str(notification.id), notification_data], queue=QueueNames.CALLBACKS
         )
     else:
-        current_app.logger.debug('No callbacks found for notification %s.', notification.id)
+        current_app.logger.debug(
+            'No callbacks found for notification %s and service %s.', notification.id, notification.service_id
+        )
 
 
 def _check_and_queue_complaint_callback_task(

--- a/tests/app/celery/test_contact_information_tasks.py
+++ b/tests/app/celery/test_contact_information_tasks.py
@@ -30,7 +30,7 @@ def test_should_get_email_address_and_update_notification(client, mocker, sample
     template = sample_template(template_type=EMAIL_TYPE)
     notification = sample_notification(
         template=template,
-        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}]
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}],
     )
 
     mocked_get_notification_by_id = mocker.patch(
@@ -78,7 +78,7 @@ def test_should_not_retry_on_non_retryable_exception(client, mocker, sample_temp
     template = sample_template(template_type=EMAIL_TYPE)
     notification = sample_notification(
         template=template,
-        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}]
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}],
     )
 
     mocker.patch('app.celery.contact_information_tasks.get_notification_by_id', return_value=notification)
@@ -113,7 +113,7 @@ def test_should_retry_on_retryable_exception(client, mocker, sample_template, sa
     template = sample_template(template_type=EMAIL_TYPE)
     notification = sample_notification(
         template=template,
-        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}]
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}],
     )
     mocker.patch('app.celery.contact_information_tasks.get_notification_by_id', return_value=notification)
 
@@ -136,7 +136,7 @@ def test_lookup_contact_info_should_retry_on_timeout(
     template = sample_template(template_type=notification_type)
     notification = sample_notification(
         template=template,
-        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}]
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}],
     )
 
     mocker.patch('app.celery.contact_information_tasks.get_notification_by_id', return_value=notification)
@@ -182,7 +182,7 @@ def test_should_update_notification_to_technical_failure_on_max_retries(
     template = sample_template(template_type=EMAIL_TYPE)
     notification = sample_notification(
         template=template,
-        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}]
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}],
     )
     mocker.patch('app.celery.contact_information_tasks.get_notification_by_id', return_value=notification)
 
@@ -209,7 +209,7 @@ def test_should_update_notification_to_permanent_failure_on_no_contact_info_exce
     template = sample_template(template_type=EMAIL_TYPE)
     notification = sample_notification(
         template=template,
-        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}]
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}],
     )
     mocker.patch('app.celery.contact_information_tasks.get_notification_by_id', return_value=notification)
 
@@ -277,7 +277,7 @@ def test_exception_sets_failure_reason_if_thrown(
     template = sample_template(template_type=EMAIL_TYPE)
     notification = sample_notification(
         template=template,
-        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}]
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}],
     )
     mocker.patch('app.celery.contact_information_tasks.get_notification_by_id', return_value=notification)
 

--- a/tests/app/celery/test_lookup_va_profile_id_task.py
+++ b/tests/app/celery/test_lookup_va_profile_id_task.py
@@ -19,15 +19,8 @@ from app.va.mpi import (
 )
 
 
-@pytest.fixture(scope='function')
-def notification():
-    notification_id = str(uuid.uuid4())
-    notification = Notification(id=notification_id)
-
-    return notification
-
-
-def test_should_call_mpi_client_and_save_va_profile_id(notify_api, mocker, notification):
+def test_should_call_mpi_client_and_save_va_profile_id(notify_api, mocker, sample_notification):
+    notification = sample_notification()
     vaprofile_id = '1234'
 
     mocker.patch(
@@ -68,8 +61,9 @@ def test_should_call_mpi_client_and_save_va_profile_id(notify_api, mocker, notif
     ],
 )
 def test_should_not_retry_on_other_exception_and_should_update_to_appropriate_failure(
-    client, mocker, notification, exception, reason, failure
+    client, mocker, sample_notification, exception, reason, failure
 ):
+    notification = sample_notification()
     mocked_get_notification_by_id = mocker.patch(
         'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification
     )
@@ -96,7 +90,8 @@ def test_should_not_retry_on_other_exception_and_should_update_to_appropriate_fa
     mocked_retry.assert_not_called()
 
 
-def test_should_retry_on_retryable_exception(client, mocker, notification):
+def test_should_retry_on_retryable_exception(client, mocker, sample_notification):
+    notification = sample_notification()
     mocker.patch(
         'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification
     )
@@ -112,9 +107,15 @@ def test_should_retry_on_retryable_exception(client, mocker, notification):
     mocked_mpi_client.get_va_profile_id.assert_called_with(notification)
 
 
-def test_should_update_notification_to_technical_failure_on_max_retries_and_should_not_call_callback(
-    client, mocker, notification
+def test_should_update_notification_to_technical_failure_on_max_retries_and_should_call_callback(
+    client, mocker, sample_notification
 ):
+    """
+    Raising MpiRetryableException and subsequently determining the the maximum number of retries has been
+    reached should result in a technical failure.
+    """
+
+    notification = sample_notification()
     mocker.patch(
         'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification
     )
@@ -135,7 +136,7 @@ def test_should_update_notification_to_technical_failure_on_max_retries_and_shou
         lookup_va_profile_id(notification.id)
 
     mocked_handle_max_retries_exceeded.assert_called_once()
-    mocked_check_and_queue_callback_task.assert_not_called()
+    mocked_check_and_queue_callback_task.assert_called_once_with(notification)
 
 
 @pytest.mark.parametrize(
@@ -144,11 +145,15 @@ def test_should_update_notification_to_technical_failure_on_max_retries_and_shou
         (BeneficiaryDeceasedException('some error'), BeneficiaryDeceasedException.failure_reason),
         (IdentifierNotFound('some error'), IdentifierNotFound.failure_reason),
         (MultipleActiveVaProfileIdsException('some error'), MultipleActiveVaProfileIdsException.failure_reason),
+        (UnsupportedIdentifierException('some error'), UnsupportedIdentifierException.failure_reason),
+        (IncorrectNumberOfIdentifiersException('some error'), IncorrectNumberOfIdentifiersException.failure_reason),
+        (NoSuchIdentifierException('some error'), NoSuchIdentifierException.failure_reason),
     ],
 )
 def test_should_permanently_fail_and_clear_chain_when_permanent_failure_exception(
-    client, mocker, notification, exception, reason
+    client, mocker, sample_notification, exception, reason
 ):
+    notification = sample_notification()
     mocker.patch(
         'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification
     )
@@ -218,8 +223,9 @@ def test_should_permanently_fail_and_clear_chain_when_permanent_failure_exceptio
     ],
 )
 def test_caught_exceptions_should_set_status_reason_on_notification(
-    client, mocker, notification, exception, notification_status, failure_reason
+    client, mocker, sample_notification, exception, notification_status, failure_reason
 ):
+    notification = sample_notification()
     mocker.patch('app.celery.lookup_va_profile_id_task.mpi_client.get_va_profile_id', side_effect=exception)
     if exception is MpiRetryableException:
         # Ensuring this does not retry and should raise a NotificationTechnicalFailureException
@@ -227,9 +233,8 @@ def test_caught_exceptions_should_set_status_reason_on_notification(
         mocker_handle_max_retries_exceeded = mocker.patch(
             'app.celery.lookup_va_profile_id_task.handle_max_retries_exceeded'
         )
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(NotificationTechnicalFailureException) as exc_info:
             lookup_va_profile_id(notification.id)
-        assert exc_info.type is NotificationTechnicalFailureException
         mocker_handle_max_retries_exceeded.assert_called_once()
     else:
         dao_path = 'app.celery.lookup_va_profile_id_task.notifications_dao.update_notification_status_by_id'
@@ -252,7 +257,8 @@ def test_caught_exceptions_should_set_status_reason_on_notification(
         (NoSuchIdentifierException('some error'), NoSuchIdentifierException.failure_reason),
     ],
 )
-def test_should_call_callback_on_permanent_failure_exception(client, mocker, notification, exception, reason):
+def test_should_call_callback_on_permanent_failure_exception(client, mocker, sample_notification, exception, reason):
+    notification = sample_notification()
     mocker.patch(
         'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification
     )
@@ -279,7 +285,8 @@ def test_should_call_callback_on_permanent_failure_exception(client, mocker, not
     mocked_check_and_queue_callback_task.assert_called_once_with(notification)
 
 
-def test_should_not_call_callback_on_retryable_exception(client, mocker, notification):
+def test_should_not_call_callback_on_retryable_exception(client, mocker, sample_notification):
+    notification = sample_notification()
     mocker.patch(
         'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification
     )
@@ -297,3 +304,40 @@ def test_should_not_call_callback_on_retryable_exception(client, mocker, notific
 
     mocked_mpi_client.get_va_profile_id.assert_called_with(notification)
     mocked_check_and_queue_callback_task.assert_not_called()
+
+
+def test_should_permanently_fail_and_clear_chain_when_technical_failure_exception(
+    client, mocker, sample_notification
+):
+    notification = sample_notification()
+    mocker.patch(
+        'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification
+    )
+
+    mocked_mpi_client = mocker.Mock()
+    mocked_mpi_client.get_va_profile_id = mocker.Mock(side_effect=Exception)
+    mocker.patch('app.celery.lookup_va_profile_id_task.mpi_client', new=mocked_mpi_client)
+
+    mocked_update_notification_status_by_id = mocker.patch(
+        'app.celery.lookup_va_profile_id_task.notifications_dao.update_notification_status_by_id'
+    )
+
+    mocked_check_and_queue_callback_task = mocker.patch(
+        'app.celery.lookup_va_profile_id_task.check_and_queue_callback_task',
+    )
+
+    mocked_request = mocker.Mock()
+    mocked_chain = mocker.PropertyMock()
+    mocked_chain.return_value = ['some-task-to-be-executed-next']
+    type(mocked_request).chain = mocked_chain
+    mocker.patch('celery.app.task.Task.request', new=mocked_request)
+
+    with pytest.raises(NotificationTechnicalFailureException):
+        lookup_va_profile_id(notification.id)
+
+    mocked_update_notification_status_by_id.assert_called_with(
+        notification.id, NOTIFICATION_TECHNICAL_FAILURE, status_reason='Unknown error from MPI'
+    )
+
+    mocked_chain.assert_called_with(None)
+    mocked_check_and_queue_callback_task.assert_called_with(notification)

--- a/tests/app/celery/test_lookup_va_profile_id_task.py
+++ b/tests/app/celery/test_lookup_va_profile_id_task.py
@@ -306,9 +306,7 @@ def test_should_not_call_callback_on_retryable_exception(client, mocker, sample_
     mocked_check_and_queue_callback_task.assert_not_called()
 
 
-def test_should_permanently_fail_and_clear_chain_when_technical_failure_exception(
-    client, mocker, sample_notification
-):
+def test_should_permanently_fail_and_clear_chain_when_technical_failure_exception(client, mocker, sample_notification):
     notification = sample_notification()
     mocker.patch(
         'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Whenever a message reaches its final state, any associated callback functions should be called.  We noted that this was not always happening for failures related to VA Profile look-ups, and these changes amend the behavior.

These changes also remove a module specific "notification" fixture and replace it with the "sample_notification" fixture from tests/app/conftest.py.

These changes are also most of the solution for #1914.

issue #1800

## Type of change

Please check the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Hotfix (quick fix for an urgent bug or issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

I wrote new unit tests, ran the regression tests, and tried to send an SMS notification from Perf using VA Profile ID 1550938, which does not have an associated phone number.  The latter test obligated me to create a new callback in Perf for the VA Notify service that pings https://sandbox-api.va.gov/vanotify/internal/callback.

I have not specifically tested with e-mail notifications.  Problems during the sending of e-mail notifications will end up in the same "except" blocks as SMS, and those except blocks are the code that needs to be tested.

![image](https://github.com/user-attachments/assets/724f7b95-5b5d-4e91-9d1a-fd45cfa2de58)


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/master/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/master/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/master/Process/testing_guide.md)
- [x] I have ensured the latest master is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket is now moved into the DEV test column
- [x] I have added a bullet for this work to the Engineering Key Wins slide for review
