### PR TITLE
#1800 Delivery Status Callbacks

### DIFF
--- a/app/callback/queue_callback_strategy.py
+++ b/app/callback/queue_callback_strategy.py
@@ -28,6 +28,6 @@ class QueueCallbackStrategy(ServiceCallbackStrategyInterface):
         except ClientError as e:
             statsd_client.incr(f'callback.queue.{callback.callback_type}.non_retryable_error')
             raise NonRetryableException(e)
-        else:
-            current_app.logger.info(f'Callback sent to {callback.url}, {tags}')
-            statsd_client.incr(f'callback.queue.{callback.callback_type}.success')
+
+        current_app.logger.info('Callback sent to %s, %s', callback.url, tags)
+        statsd_client.incr(f'callback.queue.{callback.callback_type}.success')

--- a/app/celery/common.py
+++ b/app/celery/common.py
@@ -26,7 +26,10 @@ def handle_max_retries_exceeded(
     notification_id: str,
     method_name: str,
 ) -> str:
-    """Handles sms/email deliver requests that exceeded the retry maximum, updates Notification status"""
+    """
+    Handles sms/email deliver requests that exceeded the retry maximum.  Updates the Notification status.
+    """
+
     current_app.logger.critical('%s: Notification %s failed by exceeding retry limits', method_name, notification_id)
     message = (
         'RETRY FAILED: Max retries reached. '

--- a/app/celery/contact_information_tasks.py
+++ b/app/celery/contact_information_tasks.py
@@ -2,6 +2,7 @@ from flask import current_app
 from app import notify_celery, va_profile_client
 from app.celery.common import can_retry, handle_max_retries_exceeded
 from app.celery.exceptions import AutoRetryException
+from app.celery.service_callback_tasks import check_and_queue_callback_task
 from app.va.identifier import IdentifierType
 from app.va.va_profile import VAProfileRetryableException, VAProfileNonRetryableException, NoContactInfoException
 from app.dao.notifications_dao import get_notification_by_id, dao_update_notification, update_notification_status_by_id
@@ -26,7 +27,7 @@ def lookup_contact_info(
     self,
     notification_id,
 ):
-    current_app.logger.info(f'Looking up contact information for notification_id:{notification_id}.')
+    current_app.logger.info('Looking up contact information for notification_id: %s.', notification_id)
 
     notification = get_notification_by_id(notification_id)
     va_profile_id = notification.recipient_identifiers[IdentifierType.VA_PROFILE_ID.value]
@@ -48,18 +49,20 @@ def lookup_contact_info(
             raise AutoRetryException(f'Found {type(e).__name__}, autoretrying...', e, e.args)
         else:
             msg = handle_max_retries_exceeded(notification_id, 'lookup_contact_info')
+            check_and_queue_callback_task(notification)
             raise NotificationTechnicalFailureException(msg)
     except NoContactInfoException as e:
         message = (
             f"Can't proceed after querying VA Profile for contact information for {notification_id}. "
             'Stopping execution of following tasks. Notification has been updated to permanent-failure.'
         )
-        current_app.logger.warning(f'{e.__class__.__name__} - {str(e)}: ' + message)
-        self.request.chain = None
+        current_app.logger.warning('%s - %s:  %s', e.__class__.__name__, str(e), message)
 
         update_notification_status_by_id(
             notification_id, NOTIFICATION_PERMANENT_FAILURE, status_reason=e.failure_reason
         )
+        check_and_queue_callback_task(notification)
+        raise NotificationPermanentFailureException(message) from e
 
     except (VAProfileIDNotFoundException, VAProfileNonRetryableException) as e:
         current_app.logger.exception(e)
@@ -70,6 +73,7 @@ def lookup_contact_info(
         update_notification_status_by_id(
             notification_id, NOTIFICATION_PERMANENT_FAILURE, status_reason=e.failure_reason
         )
+        check_and_queue_callback_task(notification)
         raise NotificationPermanentFailureException(message) from e
 
     else:

--- a/app/celery/onsite_notification_tasks.py
+++ b/app/celery/onsite_notification_tasks.py
@@ -9,7 +9,10 @@ def send_va_onsite_notification_task(
     template_id: str,
     onsite_enabled: bool = False,
 ):
-    """This function is used by celery to POST a notification to VA_Onsite."""
+    """
+    POST a notification to VA_Onsite.
+    """
+
     current_app.logger.info(
         'Calling va_onsite_notification_task with va_profile_id: %s\ntemplate_id: %s\nonsite_notification set to: %s',
         va_profile_id,
@@ -19,4 +22,6 @@ def send_va_onsite_notification_task(
 
     if onsite_enabled and va_profile_id:
         data = {'onsite_notification': {'template_id': template_id, 'va_profile_id': va_profile_id}}
+
+        # This method catches exceptions.  It should never disrupt execution of the Celery task chain.
         va_onsite_client.post_onsite_notification(data)

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -313,12 +313,15 @@ def check_and_queue_callback_task(
         service_id=notification.service_id, notification_status=notification.status
     )
 
-    # if a row of info is found
     if service_callback_api:
         # build dictionary for notification
         notification_data = create_delivery_status_callback_data(notification, service_callback_api, payload)
         send_delivery_status_to_service.apply_async(
             [service_callback_api.id, str(notification.id), notification_data], queue=QueueNames.CALLBACKS
+        )
+    else:
+        current_app.logger.debug(
+            'No callbacks found for notification %s and service %s.', notification.id, notification.service_id
         )
 
 

--- a/app/va/va_onsite/va_onsite_client.py
+++ b/app/va/va_onsite/va_onsite_client.py
@@ -31,9 +31,8 @@ class VAOnsiteClient:
 
         :param data: The dict onsite_notifications is expecting to see
         """
-        self.logger.info('Calling VAOnsiteClient.post_onsite_notification')
-        self.logger.info('Sending this data with POST request to onsite_notifications: %s', data)
 
+        self.logger.info('Calling VAOnsiteClient.post_onsite_notification with data: %s', data)
         response = None
 
         try:
@@ -43,13 +42,12 @@ class VAOnsiteClient:
                 headers=self._build_header(),
                 timeout=(3.05, 1),
             )
-
+        except Exception as e:
+            self.logger.exception(e)
+        else:
             self.logger.info(
                 'onsite_notifications POST response: status_code=%d, json=%s', response.status_code, response.json()
             )
-
-        except Exception as e:
-            self.logger.exception(e)
 
         return response
 

--- a/tests/app/celery/test_contact_information_tasks.py
+++ b/tests/app/celery/test_contact_information_tasks.py
@@ -26,20 +26,13 @@ EXAMPLE_VA_PROFILE_ID = '135'
 notification_id = str(uuid.uuid4())
 
 
-@pytest.fixture(scope='function')
-def notification():
-    recipient_identifier = RecipientIdentifier(
-        notification_id=notification_id, id_type=IdentifierType.VA_PROFILE_ID.value, id_value=EXAMPLE_VA_PROFILE_ID
+def test_should_get_email_address_and_update_notification(client, mocker, sample_template, sample_notification):
+    template = sample_template(template_type=EMAIL_TYPE)
+    notification = sample_notification(
+        template=template,
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}],
     )
 
-    notification = Notification(id=notification_id)
-    notification.recipient_identifiers.set(recipient_identifier)
-    notification.notification_type = EMAIL_TYPE
-
-    return notification
-
-
-def test_should_get_email_address_and_update_notification(client, mocker, notification):
     mocked_get_notification_by_id = mocker.patch(
         'app.celery.contact_information_tasks.get_notification_by_id', return_value=notification
     )
@@ -61,8 +54,11 @@ def test_should_get_email_address_and_update_notification(client, mocker, notifi
     assert notification.to == 'test@test.org'
 
 
-def test_should_get_phone_number_and_update_notification(client, mocker, notification):
-    notification.notification_type = SMS_TYPE
+def test_should_get_phone_number_and_update_notification(client, mocker, sample_notification):
+    notification = sample_notification(
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}]
+    )
+    assert notification.notification_type == SMS_TYPE
     mocked_get_notification_by_id = mocker.patch(
         'app.celery.contact_information_tasks.get_notification_by_id', return_value=notification
     )
@@ -84,8 +80,18 @@ def test_should_get_phone_number_and_update_notification(client, mocker, notific
     assert notification.to == '+15555555555'
 
 
-def test_should_not_retry_on_non_retryable_exception(client, mocker, notification):
+def test_should_not_retry_on_non_retryable_exception(client, mocker, sample_template, sample_notification):
+    template = sample_template(template_type=EMAIL_TYPE)
+    notification = sample_notification(
+        template=template,
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}],
+    )
+
     mocker.patch('app.celery.contact_information_tasks.get_notification_by_id', return_value=notification)
+
+    mocked_check_and_queue_callback_task = mocker.patch(
+        'app.celery.contact_information_tasks.check_and_queue_callback_task',
+    )
 
     mocked_va_profile_client = mocker.Mock(VAProfileClient)
 
@@ -97,61 +103,92 @@ def test_should_not_retry_on_non_retryable_exception(client, mocker, notificatio
         'app.celery.contact_information_tasks.update_notification_status_by_id'
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(NotificationPermanentFailureException) as exc_info:
         lookup_contact_info(notification.id)
 
-    assert exc_info.type is NotificationPermanentFailureException
-    mocked_va_profile_client.get_email.assert_called_with(mocker.ANY)
-    recipient_identifier = mocked_va_profile_client.get_email.call_args[0][0]
-    assert isinstance(recipient_identifier, RecipientIdentifier)
-    assert recipient_identifier.id_value == EXAMPLE_VA_PROFILE_ID
+    mocked_va_profile_client.get_email.assert_called_with(EXAMPLE_VA_PROFILE_ID)
 
     mocked_update_notification_status_by_id.assert_called_with(
         notification.id, NOTIFICATION_PERMANENT_FAILURE, status_reason=exception.failure_reason
     )
+    mocked_check_and_queue_callback_task.assert_called_once_with(notification)
 
 
 @pytest.mark.parametrize('exception_type', (Timeout, VAProfileRetryableException))
-def test_should_retry_on_retryable_exception(client, mocker, notification, exception_type):
+def test_should_retry_on_retryable_exception(client, mocker, sample_template, sample_notification, exception_type):
+    template = sample_template(template_type=EMAIL_TYPE)
+    notification = sample_notification(
+        template=template,
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}],
+    )
     mocker.patch('app.celery.contact_information_tasks.get_notification_by_id', return_value=notification)
 
     mocked_va_profile_client = mocker.Mock(VAProfileClient)
     mocked_va_profile_client.get_email = mocker.Mock(side_effect=exception_type('some error'))
     mocker.patch('app.celery.contact_information_tasks.va_profile_client', new=mocked_va_profile_client)
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(AutoRetryException) as exc_info:
         lookup_contact_info(notification.id)
 
-    assert exc_info.type is AutoRetryException
-    mocked_va_profile_client.get_email.assert_called_with(mocker.ANY)
-    recipient_identifier = mocked_va_profile_client.get_email.call_args[0][0]
-    assert isinstance(recipient_identifier, RecipientIdentifier)
-    assert recipient_identifier.id_value == EXAMPLE_VA_PROFILE_ID
+    mocked_va_profile_client.get_email.assert_called_with(EXAMPLE_VA_PROFILE_ID)
 
 
-def test_should_retry_on_timeout(client, mocker, notification):
+@pytest.mark.parametrize('notification_type', (SMS_TYPE, EMAIL_TYPE))
+@pytest.mark.parametrize('v3_enabled', (True, False))
+def test_lookup_contact_info_should_retry_on_timeout(
+    client, mocker, sample_template, sample_notification, notification_type, v3_enabled
+):
+    template = sample_template(template_type=notification_type)
+    notification = sample_notification(
+        template=template,
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}],
+    )
+
     mocker.patch('app.celery.contact_information_tasks.get_notification_by_id', return_value=notification)
+    mocker.patch('app.celery.contact_information_tasks.is_feature_enabled', return_value=v3_enabled)
 
     mocked_va_profile_client = mocker.Mock(VAProfileClient)
-    mocked_va_profile_client.get_email = mocker.Mock(side_effect=Timeout('Request timed out'))
+
+    if notification_type == SMS_TYPE and v3_enabled:
+        mocked_va_profile_client.get_telephone_from_profile_v3 = mocker.Mock(side_effect=Timeout('Request timed out'))
+    elif notification_type == SMS_TYPE and not v3_enabled:
+        mocked_va_profile_client.get_telephone = mocker.Mock(side_effect=Timeout('Request timed out'))
+    elif notification_type == EMAIL_TYPE and v3_enabled:
+        mocked_va_profile_client.get_email_from_profile_v3 = mocker.Mock(side_effect=Timeout('Request timed out'))
+    elif notification_type == EMAIL_TYPE and not v3_enabled:
+        mocked_va_profile_client.get_email = mocker.Mock(side_effect=Timeout('Request timed out'))
+
     mocker.patch('app.celery.contact_information_tasks.va_profile_client', new=mocked_va_profile_client)
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(AutoRetryException) as exc_info:
         lookup_contact_info(notification.id)
-
-    assert exc_info.type is AutoRetryException
 
     assert exc_info.value.args[0] == 'Found Timeout, autoretrying...'
     assert isinstance(exc_info.value.args[1], Timeout)
     assert str(exc_info.value.args[1]) == 'Request timed out'
 
-    mocked_va_profile_client.get_email.assert_called_with(mocker.ANY)
-    recipient_identifier = mocked_va_profile_client.get_email.call_args[0][0]
-    assert isinstance(recipient_identifier, RecipientIdentifier)
-    assert recipient_identifier.id_value == EXAMPLE_VA_PROFILE_ID
+    if notification_type == SMS_TYPE and v3_enabled:
+        mocked_va_profile_client.get_telephone_from_profile_v3.assert_called_with(
+            notification.recipient_identifiers[IdentifierType.VA_PROFILE_ID.value]
+        )
+    elif notification_type == SMS_TYPE and not v3_enabled:
+        mocked_va_profile_client.get_telephone.assert_called_with(EXAMPLE_VA_PROFILE_ID)
+    elif notification_type == EMAIL_TYPE and v3_enabled:
+        mocked_va_profile_client.get_email_from_profile_v3.assert_called_with(
+            notification.recipient_identifiers[IdentifierType.VA_PROFILE_ID.value]
+        )
+    elif notification_type == EMAIL_TYPE and not v3_enabled:
+        mocked_va_profile_client.get_email.assert_called_with(EXAMPLE_VA_PROFILE_ID)
 
 
-def test_should_update_notification_to_technical_failure_on_max_retries(client, mocker, notification):
+def test_should_update_notification_to_technical_failure_on_max_retries(
+    client, mocker, sample_template, sample_notification
+):
+    template = sample_template(template_type=EMAIL_TYPE)
+    notification = sample_notification(
+        template=template,
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}],
+    )
     mocker.patch('app.celery.contact_information_tasks.get_notification_by_id', return_value=notification)
 
     mocked_va_profile_client = mocker.Mock(VAProfileClient)
@@ -162,19 +199,22 @@ def test_should_update_notification_to_technical_failure_on_max_retries(client, 
         'app.celery.contact_information_tasks.handle_max_retries_exceeded'
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(NotificationTechnicalFailureException) as exc_info:
         lookup_contact_info(notification.id)
 
-    assert exc_info.type is NotificationTechnicalFailureException
-    mocked_va_profile_client.get_email.assert_called_with(mocker.ANY)
-    recipient_identifier = mocked_va_profile_client.get_email.call_args[0][0]
-    assert isinstance(recipient_identifier, RecipientIdentifier)
-    assert recipient_identifier.id_value == EXAMPLE_VA_PROFILE_ID
+    mocked_va_profile_client.get_email.assert_called_with(EXAMPLE_VA_PROFILE_ID)
 
     mocked_handle_max_retries_exceeded.assert_called_once()
 
 
-def test_should_update_notification_to_permanent_failure_on_no_contact_info_exception(client, mocker, notification):
+def test_should_update_notification_to_permanent_failure_on_no_contact_info_exception(
+    client, mocker, sample_template, sample_notification
+):
+    template = sample_template(template_type=EMAIL_TYPE)
+    notification = sample_notification(
+        template=template,
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}],
+    )
     mocker.patch('app.celery.contact_information_tasks.get_notification_by_id', return_value=notification)
 
     mocked_va_profile_client = mocker.Mock(VAProfileClient)
@@ -182,19 +222,16 @@ def test_should_update_notification_to_permanent_failure_on_no_contact_info_exce
     mocked_va_profile_client.get_email = mocker.Mock(side_effect=exception)
     mocker.patch('app.celery.contact_information_tasks.va_profile_client', new=mocked_va_profile_client)
 
+    mocked_check_and_queue_callback_task = mocker.patch(
+        'app.celery.contact_information_tasks.check_and_queue_callback_task',
+    )
+
     mocked_update_notification_status_by_id = mocker.patch(
         'app.celery.contact_information_tasks.update_notification_status_by_id'
     )
 
-    # This explains the use of "type" below:
-    # https://docs.python.org/3.10/library/unittest.mock.html#unittest.mock.PropertyMock
-    mocked_request = mocker.Mock()
-    mocked_chain = mocker.PropertyMock()
-    mocked_chain.return_value = ['some-task-to-be-executed-next']
-    type(mocked_request).chain = mocked_chain
-    mocker.patch('celery.app.task.Task.request', new=mocked_request)
-
-    lookup_contact_info(notification.id)
+    with pytest.raises(NotificationPermanentFailureException) as exc_info:
+        lookup_contact_info(notification.id)
 
     mocked_va_profile_client.get_email.assert_called_with(mocker.ANY)
     recipient_identifier = mocked_va_profile_client.get_email.call_args[0][0]
@@ -205,7 +242,7 @@ def test_should_update_notification_to_permanent_failure_on_no_contact_info_exce
         notification.id, NOTIFICATION_PERMANENT_FAILURE, status_reason=exception.failure_reason
     )
 
-    mocked_chain.assert_called_with(None)
+    mocked_check_and_queue_callback_task.assert_called_once_with(notification)
 
 
 @pytest.mark.parametrize(
@@ -217,7 +254,12 @@ def test_should_update_notification_to_permanent_failure_on_no_contact_info_exce
             NOTIFICATION_TECHNICAL_FAILURE,
             RETRIES_EXCEEDED,
         ),
-        (NoContactInfoException, False, NOTIFICATION_PERMANENT_FAILURE, NoContactInfoException.failure_reason),
+        (
+            NoContactInfoException,
+            NotificationPermanentFailureException,
+            NOTIFICATION_PERMANENT_FAILURE,
+            NoContactInfoException.failure_reason,
+        ),
         (
             VAProfileNonRetryableException,
             NotificationPermanentFailureException,
@@ -227,14 +269,31 @@ def test_should_update_notification_to_permanent_failure_on_no_contact_info_exce
     ],
 )
 def test_exception_sets_failure_reason_if_thrown(
-    client, mocker, notification, exception, throws_additional_exception, notification_status, exception_reason
+    client,
+    mocker,
+    sample_template,
+    sample_notification,
+    exception,
+    throws_additional_exception,
+    notification_status,
+    exception_reason,
 ):
+    template = sample_template(template_type=EMAIL_TYPE)
+    notification = sample_notification(
+        template=template,
+        recipient_identifiers=[{'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': EXAMPLE_VA_PROFILE_ID}],
+    )
     mocker.patch('app.celery.contact_information_tasks.get_notification_by_id', return_value=notification)
 
     mocked_va_profile_client = mocker.Mock(VAProfileClient)
     mocked_va_profile_client.get_email = mocker.Mock(side_effect=exception)
     mocker.patch('app.celery.contact_information_tasks.va_profile_client', new=mocked_va_profile_client)
     mocker.patch('app.celery.contact_information_tasks.can_retry', return_value=False)
+
+    mocked_check_and_queue_callback_task = mocker.patch(
+        'app.celery.contact_information_tasks.check_and_queue_callback_task',
+    )
+
     if exception_reason == RETRIES_EXCEEDED:
         mocker_handle_max_retries_exceeded = mocker.patch(
             'app.celery.contact_information_tasks.handle_max_retries_exceeded'
@@ -254,3 +313,5 @@ def test_exception_sets_failure_reason_if_thrown(
             mocked_update_notification_status_by_id.assert_called_once_with(
                 notification.id, notification_status, status_reason=exception_reason
             )
+
+    mocked_check_and_queue_callback_task.assert_called_once_with(notification)

--- a/tests/app/celery/test_lookup_va_profile_id_task.py
+++ b/tests/app/celery/test_lookup_va_profile_id_task.py
@@ -19,15 +19,8 @@ from app.va.mpi import (
 )
 
 
-@pytest.fixture(scope='function')
-def notification():
-    notification_id = str(uuid.uuid4())
-    notification = Notification(id=notification_id)
-
-    return notification
-
-
-def test_should_call_mpi_client_and_save_va_profile_id(notify_api, mocker, notification):
+def test_should_call_mpi_client_and_save_va_profile_id(notify_api, mocker, sample_notification):
+    notification = sample_notification()
     vaprofile_id = '1234'
 
     mocker.patch(
@@ -68,8 +61,9 @@ def test_should_call_mpi_client_and_save_va_profile_id(notify_api, mocker, notif
     ],
 )
 def test_should_not_retry_on_other_exception_and_should_update_to_appropriate_failure(
-    client, mocker, notification, exception, reason, failure
+    client, mocker, sample_notification, exception, reason, failure
 ):
+    notification = sample_notification()
     mocked_get_notification_by_id = mocker.patch(
         'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification
     )
@@ -96,7 +90,8 @@ def test_should_not_retry_on_other_exception_and_should_update_to_appropriate_fa
     mocked_retry.assert_not_called()
 
 
-def test_should_retry_on_retryable_exception(client, mocker, notification):
+def test_should_retry_on_retryable_exception(client, mocker, sample_notification):
+    notification = sample_notification()
     mocker.patch(
         'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification
     )
@@ -112,9 +107,15 @@ def test_should_retry_on_retryable_exception(client, mocker, notification):
     mocked_mpi_client.get_va_profile_id.assert_called_with(notification)
 
 
-def test_should_update_notification_to_technical_failure_on_max_retries_and_should_not_call_callback(
-    client, mocker, notification
+def test_should_update_notification_to_technical_failure_on_max_retries_and_should_call_callback(
+    client, mocker, sample_notification
 ):
+    """
+    Raising MpiRetryableException and subsequently determining the the maximum number of retries has been
+    reached should result in a technical failure.
+    """
+
+    notification = sample_notification()
     mocker.patch(
         'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification
     )
@@ -135,7 +136,7 @@ def test_should_update_notification_to_technical_failure_on_max_retries_and_shou
         lookup_va_profile_id(notification.id)
 
     mocked_handle_max_retries_exceeded.assert_called_once()
-    mocked_check_and_queue_callback_task.assert_not_called()
+    mocked_check_and_queue_callback_task.assert_called_once_with(notification)
 
 
 @pytest.mark.parametrize(
@@ -144,11 +145,15 @@ def test_should_update_notification_to_technical_failure_on_max_retries_and_shou
         (BeneficiaryDeceasedException('some error'), BeneficiaryDeceasedException.failure_reason),
         (IdentifierNotFound('some error'), IdentifierNotFound.failure_reason),
         (MultipleActiveVaProfileIdsException('some error'), MultipleActiveVaProfileIdsException.failure_reason),
+        (UnsupportedIdentifierException('some error'), UnsupportedIdentifierException.failure_reason),
+        (IncorrectNumberOfIdentifiersException('some error'), IncorrectNumberOfIdentifiersException.failure_reason),
+        (NoSuchIdentifierException('some error'), NoSuchIdentifierException.failure_reason),
     ],
 )
-def test_should_permanently_fail_and_clear_chain_when_permanent_failure_exception(
-    client, mocker, notification, exception, reason
+def test_should_permanently_fail_when_permanent_failure_exception(
+    client, mocker, sample_notification, exception, reason
 ):
+    notification = sample_notification()
     mocker.patch(
         'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification
     )
@@ -165,12 +170,6 @@ def test_should_permanently_fail_and_clear_chain_when_permanent_failure_exceptio
         'app.celery.lookup_va_profile_id_task.check_and_queue_callback_task',
     )
 
-    mocked_request = mocker.Mock()
-    mocked_chain = mocker.PropertyMock()
-    mocked_chain.return_value = ['some-task-to-be-executed-next']
-    type(mocked_request).chain = mocked_chain
-    mocker.patch('celery.app.task.Task.request', new=mocked_request)
-
     with pytest.raises(NotificationPermanentFailureException):
         lookup_va_profile_id(notification.id)
 
@@ -178,7 +177,6 @@ def test_should_permanently_fail_and_clear_chain_when_permanent_failure_exceptio
         notification.id, NOTIFICATION_PERMANENT_FAILURE, status_reason=reason
     )
 
-    mocked_chain.assert_called_with(None)
     mocked_check_and_queue_callback_task.assert_called_with(notification)
 
 
@@ -218,8 +216,9 @@ def test_should_permanently_fail_and_clear_chain_when_permanent_failure_exceptio
     ],
 )
 def test_caught_exceptions_should_set_status_reason_on_notification(
-    client, mocker, notification, exception, notification_status, failure_reason
+    client, mocker, sample_notification, exception, notification_status, failure_reason
 ):
+    notification = sample_notification()
     mocker.patch('app.celery.lookup_va_profile_id_task.mpi_client.get_va_profile_id', side_effect=exception)
     if exception is MpiRetryableException:
         # Ensuring this does not retry and should raise a NotificationTechnicalFailureException
@@ -227,9 +226,8 @@ def test_caught_exceptions_should_set_status_reason_on_notification(
         mocker_handle_max_retries_exceeded = mocker.patch(
             'app.celery.lookup_va_profile_id_task.handle_max_retries_exceeded'
         )
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(NotificationTechnicalFailureException) as exc_info:
             lookup_va_profile_id(notification.id)
-        assert exc_info.type is NotificationTechnicalFailureException
         mocker_handle_max_retries_exceeded.assert_called_once()
     else:
         dao_path = 'app.celery.lookup_va_profile_id_task.notifications_dao.update_notification_status_by_id'
@@ -252,7 +250,8 @@ def test_caught_exceptions_should_set_status_reason_on_notification(
         (NoSuchIdentifierException('some error'), NoSuchIdentifierException.failure_reason),
     ],
 )
-def test_should_call_callback_on_permanent_failure_exception(client, mocker, notification, exception, reason):
+def test_should_call_callback_on_permanent_failure_exception(client, mocker, sample_notification, exception, reason):
+    notification = sample_notification()
     mocker.patch(
         'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification
     )
@@ -279,7 +278,8 @@ def test_should_call_callback_on_permanent_failure_exception(client, mocker, not
     mocked_check_and_queue_callback_task.assert_called_once_with(notification)
 
 
-def test_should_not_call_callback_on_retryable_exception(client, mocker, notification):
+def test_should_not_call_callback_on_retryable_exception(client, mocker, sample_notification):
+    notification = sample_notification()
     mocker.patch(
         'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification
     )
@@ -297,3 +297,31 @@ def test_should_not_call_callback_on_retryable_exception(client, mocker, notific
 
     mocked_mpi_client.get_va_profile_id.assert_called_with(notification)
     mocked_check_and_queue_callback_task.assert_not_called()
+
+
+def test_should_permanently_fail_when_technical_failure_exception(client, mocker, sample_notification):
+    notification = sample_notification()
+    mocker.patch(
+        'app.celery.lookup_va_profile_id_task.notifications_dao.get_notification_by_id', return_value=notification
+    )
+
+    mocked_mpi_client = mocker.Mock()
+    mocked_mpi_client.get_va_profile_id = mocker.Mock(side_effect=Exception)
+    mocker.patch('app.celery.lookup_va_profile_id_task.mpi_client', new=mocked_mpi_client)
+
+    mocked_update_notification_status_by_id = mocker.patch(
+        'app.celery.lookup_va_profile_id_task.notifications_dao.update_notification_status_by_id'
+    )
+
+    mocked_check_and_queue_callback_task = mocker.patch(
+        'app.celery.lookup_va_profile_id_task.check_and_queue_callback_task',
+    )
+
+    with pytest.raises(NotificationTechnicalFailureException):
+        lookup_va_profile_id(notification.id)
+
+    mocked_update_notification_status_by_id.assert_called_with(
+        notification.id, NOTIFICATION_TECHNICAL_FAILURE, status_reason='Unknown error from MPI'
+    )
+
+    mocked_check_and_queue_callback_task.assert_called_with(notification)


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

You probably will want the side-by-side diff view for this one.

Sending a notification involves the execution of a chain of Celery tasks.  At any point in this chain, a notification reaching a final state should trigger service callbacks, if any, which generally means calling the function `check_and_queue_callback_task`.

I audited the relevant Celery tasks to ensure that `check_and_queue_callback_task` is called when appropriate and found a number of instances where it was not called.  By volume, most of my changes are to unit tests and to logging statements to make them use the C-style syntax instead of f-strings.  I followed the style of the existing unit tests, which do a lot of mocking, rather than try to overhaul everything to be consistent with the TDD approach we recently discussed.

Other than that, I refactored a primary function used to send notifications using contact info, [send_notification_to_queue](https://github.com/department-of-veterans-affairs/notification-api/blob/master/app/notifications/process_notifications.py#L154), to make creating the Celery chain less [kludgey](https://www.dictionary.com/browse/kludge).  This isn't strictly necessary, but that code has been bothering me for a while.  Throw me a bone here.

issue #1800

## Type of change

Please check the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Hotfix (quick fix for an urgent bug or issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Deployed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

Unit and regression tests pass.  QA created a callback and ran specific automated tests:

- 14 notifications sent; 14 callbacks triggered (the logs contains duplicates)
![14_send_14_callbacks](https://github.com/user-attachments/assets/089c7f5e-0471-470c-ae05-fe3575d35b08)

- My previous PR for this issue got reverted because callbacks weren't being triggered for the status "preferences-declined".  That works now.

![Screenshot 2024-08-15 at 8 26 59 AM](https://github.com/user-attachments/assets/98fa9608-5cb1-4e69-8ca2-78faf7604f3b)

![declined](https://github.com/user-attachments/assets/6c7339e5-7c4d-480f-b4e3-37b09f955d33)

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/master/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/master/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/master/Process/testing_guide.md)
- [x] I have ensured the latest master is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket is now moved into the DEV test column
- [x] I have added a bullet for this work to the Engineering Key Wins slide for review
