### PR TITLE
HOTFIX - Log Replay Notification IDs

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -158,6 +158,7 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
     self,
     response,
 ):
+    current_app.logger.debug('Full SES result response: %s', response)
     try:
         ses_message = json.loads(response['Message'])
         notification_type = ses_message.get('eventType')

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -148,6 +148,7 @@ def replay_created_notifications():
             )
 
         for n in notifications_to_resend:
+            current_app.logger.info('Replaying notification: %s', n.id)
             send_notification_to_queue(notification=n, research_mode=n.service.research_mode)
 
 


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Every day there are replays of notifications that have been stuck in "created" status, but the replay code does not log what notification id was stuck in created. This PR is to log the notification id so we can investigate further without having to resort to entering the database/BQ/etc.

issue N/A

## Type of change

Please check the relevant option(s).
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Hotfix (quick fix for an urgent bug or issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->
Unit tests cover this part of the code. No logic has been changed.

SES results logs as expected:
![image](https://github.com/user-attachments/assets/0e93d1a2-fa06-4927-87c3-67d092a29e4a)


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/master/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/master/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/master/Process/testing_guide.md)
- [x] I have ensured the latest master is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket is now moved into the DEV test column
- [ ] I have added a bullet for this work to the Engineering Key Wins slide for review
