### PR TITLE
#1711 - Remove unnecessary secret keys from task definitions

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -438,8 +438,6 @@ class Config(object):
     GITHUB_CLIENT_ID = os.getenv('GITHUB_CLIENT_ID', '')
     GITHUB_CLIENT_SECRET = os.getenv('GITHUB_CLIENT_SECRET', '')
 
-    VA_SSO_CLIENT_ID = os.getenv('VA_SSO_CLIENT_ID', '')
-    VA_SSO_CLIENT_SECRET = os.getenv('VA_SSO_CLIENT_SECRET', '')
     VA_SSO_SERVER_METADATA_URL = os.getenv('VA_SSO_SERVER_METADATA_URL', '')
     VA_SSO_AUTHORIZE_URL = os.getenv('VA_SSO_AUTHORIZE_URL', '')
     VA_SSO_ACCESS_TOKEN_URL = os.getenv('VA_SSO_ACCESS_TOKEN_URL', '')

--- a/cd/application-deployment/dev/vaec-api-task-definition.json
+++ b/cd/application-deployment/dev/vaec-api-task-definition.json
@@ -180,10 +180,6 @@
           "value": "https://int.vaprofile.va.gov"
         },
         {
-          "name": "VANOTIFY_SSL_KEY_PATH",
-          "value": "/app/certs/vanotify_ssl_key.pem"
-        },
-        {
           "name": "VA_FLAGSHIP_APP_SID",
           "value": "A20623E2321D4053A6C34C9307C6C221"
         },

--- a/cd/application-deployment/dev/vaec-api-task-definition.json
+++ b/cd/application-deployment/dev/vaec-api-task-definition.json
@@ -234,10 +234,6 @@
       ],
       "secrets": [
         {
-          "name": "COMP_AND_PEN_TEMPLATE_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/comp-and-pen/template-id"
-        },
-        {
           "name": "ADMIN_CLIENT_USER_NAME",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/admin-client-user"
         },

--- a/cd/application-deployment/dev/vaec-api-task-definition.json
+++ b/cd/application-deployment/dev/vaec-api-task-definition.json
@@ -238,10 +238,6 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/comp-and-pen/template-id"
         },
         {
-          "name": "COMP_AND_PEN_SMS_SENDER_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/comp-and-pen/sms-sender-id"
-        },
-        {
           "name": "ADMIN_CLIENT_USER_NAME",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/admin-client-user"
         },

--- a/cd/application-deployment/dev/vaec-api-task-definition.json
+++ b/cd/application-deployment/dev/vaec-api-task-definition.json
@@ -180,10 +180,6 @@
           "value": "https://int.vaprofile.va.gov"
         },
         {
-          "name": "VANOTIFY_SSL_CERT_PATH",
-          "value": "/app/certs/vanotify_ssl_cert.pem"
-        },
-        {
           "name": "VANOTIFY_SSL_KEY_PATH",
           "value": "/app/certs/vanotify_ssl_key.pem"
         },
@@ -296,10 +292,6 @@
         {
           "name": "VETEXT_PASSWORD",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/vetext/password"
-        },
-        {
-          "name": "VA_SSO_CLIENT_SECRET",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/iam-sso-client-secret"
         }
       ]
     },

--- a/cd/application-deployment/dev/vaec-api-task-definition.json
+++ b/cd/application-deployment/dev/vaec-api-task-definition.json
@@ -234,10 +234,6 @@
       ],
       "secrets": [
         {
-          "name": "COMP_AND_PEN_SERVICE_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/comp-and-pen/service-id"
-        },
-        {
           "name": "COMP_AND_PEN_TEMPLATE_ID",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/comp-and-pen/template-id"
         },

--- a/cd/application-deployment/dev/vaec-api-task-definition.json
+++ b/cd/application-deployment/dev/vaec-api-task-definition.json
@@ -304,10 +304,6 @@
         {
           "name": "VA_SSO_CLIENT_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/iam-sso-client-secret"
-        },
-        {
-          "name": "VA_ONSITE_SECRET",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/onsite/notification-priv"
         }
       ]
     },

--- a/cd/application-deployment/dev/vaec-api-task-definition.json
+++ b/cd/application-deployment/dev/vaec-api-task-definition.json
@@ -298,10 +298,6 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/vetext/password"
         },
         {
-          "name": "VA_SSO_CLIENT_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/iam-sso-client-id"
-        },
-        {
           "name": "VA_SSO_CLIENT_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/iam-sso-client-secret"
         }

--- a/cd/application-deployment/dev/vaec-celery-task-definition.json
+++ b/cd/application-deployment/dev/vaec-celery-task-definition.json
@@ -300,14 +300,6 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/vetext/password"
         },
         {
-          "name": "VA_SSO_CLIENT_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/iam-sso-client-id"
-        },
-        {
-          "name": "VA_SSO_CLIENT_SECRET",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/iam-sso-client-secret"
-        },
-        {
           "name": "VA_ONSITE_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/onsite/notification-priv"
         },

--- a/cd/application-deployment/dev/vaec-celery-task-definition.json
+++ b/cd/application-deployment/dev/vaec-celery-task-definition.json
@@ -292,14 +292,6 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/cert/vanotify-va-key"
         },
         {
-          "name": "VETEXT_USERNAME",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/vetext/user"
-        },
-        {
-          "name": "VETEXT_PASSWORD",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/vetext/password"
-        },
-        {
           "name": "VA_ONSITE_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/dev/notification-api/onsite/notification-priv"
         },

--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -210,10 +210,6 @@
       ],
       "secrets": [
         {
-          "name": "COMP_AND_PEN_SERVICE_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/comp-and-pen/service-id"
-        },
-        {
           "name": "COMP_AND_PEN_TEMPLATE_ID",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/comp-and-pen/template-id"
         },

--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -104,10 +104,6 @@
           "value": "https://perf.notifications.va.gov"
         },
         {
-          "name": "VANOTIFY_SSL_KEY_PATH",
-          "value": "/app/certs/vanotify_ssl_key.pem"
-        },
-        {
           "name": "MPI_URL",
           "value": "https://sqa.services.eauth.va.gov:9303/sqa"
         },

--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -266,10 +266,6 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/vetext/password"
         },
         {
-          "name": "VA_SSO_CLIENT_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/iam-sso-client-id"
-        },
-        {
           "name": "VA_SSO_CLIENT_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/iam-sso-client-secret"
         }

--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -104,10 +104,6 @@
           "value": "https://perf.notifications.va.gov"
         },
         {
-          "name": "VANOTIFY_SSL_CERT_PATH",
-          "value": "/app/certs/vanotify_ssl_cert.pem"
-        },
-        {
           "name": "VANOTIFY_SSL_KEY_PATH",
           "value": "/app/certs/vanotify_ssl_key.pem"
         },
@@ -264,10 +260,6 @@
         {
           "name": "VETEXT_PASSWORD",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/vetext/password"
-        },
-        {
-          "name": "VA_SSO_CLIENT_SECRET",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/iam-sso-client-secret"
         }
       ]
     },

--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -210,10 +210,6 @@
       ],
       "secrets": [
         {
-          "name": "COMP_AND_PEN_TEMPLATE_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/comp-and-pen/template-id"
-        },
-        {
           "name": "TWILIO_ACCOUNT_SID",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/twilio/account-sid"
         },

--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -272,10 +272,6 @@
         {
           "name": "VA_SSO_CLIENT_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/iam-sso-client-secret"
-        },
-        {
-          "name": "VA_ONSITE_SECRET",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/onsite/notification-priv"
         }
       ]
     },

--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -214,10 +214,6 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/comp-and-pen/template-id"
         },
         {
-          "name": "COMP_AND_PEN_SMS_SENDER_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/comp-and-pen/sms-sender-id"
-        },
-        {
           "name": "TWILIO_ACCOUNT_SID",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/twilio/account-sid"
         },

--- a/cd/application-deployment/perf/vaec-celery-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-task-definition.json
@@ -256,14 +256,6 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/onsite/notification-priv"
         },
         {
-          "name": "VETEXT_USERNAME",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/vetext/user"
-        },
-        {
-          "name": "VETEXT_PASSWORD",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/vetext/password"
-        },
-        {
           "name": "VA_PROFILE_TOKEN",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/perf/notification-api/va-profile/auth-token"
         }

--- a/cd/application-deployment/prod/vaec-api-task-definition.json
+++ b/cd/application-deployment/prod/vaec-api-task-definition.json
@@ -284,10 +284,6 @@
         {
           "name": "VA_SSO_CLIENT_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/iam-sso-client-secret"
-        },
-        {
-          "name": "VA_ONSITE_SECRET",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/onsite/notification-priv"
         }
       ]
     },

--- a/cd/application-deployment/prod/vaec-api-task-definition.json
+++ b/cd/application-deployment/prod/vaec-api-task-definition.json
@@ -278,10 +278,6 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/vetext/password"
         },
         {
-          "name": "VA_SSO_CLIENT_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/iam-sso-client-id"
-        },
-        {
           "name": "VA_SSO_CLIENT_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/iam-sso-client-secret"
         }

--- a/cd/application-deployment/prod/vaec-api-task-definition.json
+++ b/cd/application-deployment/prod/vaec-api-task-definition.json
@@ -214,10 +214,6 @@
       ],
       "secrets": [
         {
-          "name": "COMP_AND_PEN_TEMPLATE_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/comp-and-pen/template-id"
-        },
-        {
           "name": "TWILIO_ACCOUNT_SID",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/twilio/account-sid"
         },

--- a/cd/application-deployment/prod/vaec-api-task-definition.json
+++ b/cd/application-deployment/prod/vaec-api-task-definition.json
@@ -92,10 +92,6 @@
           "value": "https://www.vaprofile.va.gov"
         },
         {
-          "name": "VANOTIFY_SSL_CERT_PATH",
-          "value": "/app/certs/vanotify_ssl_cert.pem"
-        },
-        {
           "name": "VANOTIFY_SSL_KEY_PATH",
           "value": "/app/certs/vanotify_ssl_key.pem"
         },
@@ -276,10 +272,6 @@
         {
           "name": "VETEXT_PASSWORD",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/vetext/password"
-        },
-        {
-          "name": "VA_SSO_CLIENT_SECRET",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/iam-sso-client-secret"
         }
       ]
     },

--- a/cd/application-deployment/prod/vaec-api-task-definition.json
+++ b/cd/application-deployment/prod/vaec-api-task-definition.json
@@ -92,10 +92,6 @@
           "value": "https://www.vaprofile.va.gov"
         },
         {
-          "name": "VANOTIFY_SSL_KEY_PATH",
-          "value": "/app/certs/vanotify_ssl_key.pem"
-        },
-        {
           "name": "MPI_URL",
           "value": "https://services.eauth.va.gov:9303/prod"
         },

--- a/cd/application-deployment/prod/vaec-api-task-definition.json
+++ b/cd/application-deployment/prod/vaec-api-task-definition.json
@@ -218,10 +218,6 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/comp-and-pen/template-id"
         },
         {
-          "name": "COMP_AND_PEN_SMS_SENDER_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/comp-and-pen/sms-sender-id"
-        },
-        {
           "name": "TWILIO_ACCOUNT_SID",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/twilio/account-sid"
         },

--- a/cd/application-deployment/prod/vaec-api-task-definition.json
+++ b/cd/application-deployment/prod/vaec-api-task-definition.json
@@ -214,10 +214,6 @@
       ],
       "secrets": [
         {
-          "name": "COMP_AND_PEN_SERVICE_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/comp-and-pen/service-id"
-        },
-        {
           "name": "COMP_AND_PEN_TEMPLATE_ID",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/comp-and-pen/template-id"
         },

--- a/cd/application-deployment/prod/vaec-celery-task-definition.json
+++ b/cd/application-deployment/prod/vaec-celery-task-definition.json
@@ -264,14 +264,6 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/redis/url"
         },
         {
-          "name": "VETEXT_USERNAME",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/vetext/user"
-        },
-        {
-          "name": "VETEXT_PASSWORD",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/vetext/password"
-        },
-        {
           "name": "VA_ONSITE_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/onsite/notification-priv"
         },

--- a/cd/application-deployment/staging/vaec-api-task-definition.json
+++ b/cd/application-deployment/staging/vaec-api-task-definition.json
@@ -100,10 +100,6 @@
           "value": "https://qa.vaprofile.va.gov"
         },
         {
-          "name": "VANOTIFY_SSL_KEY_PATH",
-          "value": "/app/certs/vanotify_ssl_key.pem"
-        },
-        {
           "name": "MPI_URL",
           "value": "https://sqa.services.eauth.va.gov:9303/sqa"
         },

--- a/cd/application-deployment/staging/vaec-api-task-definition.json
+++ b/cd/application-deployment/staging/vaec-api-task-definition.json
@@ -234,10 +234,6 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/comp-and-pen/template-id"
         },
         {
-          "name": "COMP_AND_PEN_SMS_SENDER_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/comp-and-pen/sms-sender-id"
-        },
-        {
           "name": "TWILIO_ACCOUNT_SID",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/twilio/account-sid"
         },

--- a/cd/application-deployment/staging/vaec-api-task-definition.json
+++ b/cd/application-deployment/staging/vaec-api-task-definition.json
@@ -100,10 +100,6 @@
           "value": "https://qa.vaprofile.va.gov"
         },
         {
-          "name": "VANOTIFY_SSL_CERT_PATH",
-          "value": "/app/certs/vanotify_ssl_cert.pem"
-        },
-        {
           "name": "VANOTIFY_SSL_KEY_PATH",
           "value": "/app/certs/vanotify_ssl_key.pem"
         },
@@ -292,10 +288,6 @@
         {
           "name": "VETEXT_PASSWORD",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/vetext/password"
-        },
-        {
-          "name": "VA_SSO_CLIENT_SECRET",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/iam-sso-client-secret"
         }
       ]
     },

--- a/cd/application-deployment/staging/vaec-api-task-definition.json
+++ b/cd/application-deployment/staging/vaec-api-task-definition.json
@@ -230,10 +230,6 @@
       ],
       "secrets": [
         {
-          "name": "COMP_AND_PEN_TEMPLATE_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/comp-and-pen/template-id"
-        },
-        {
           "name": "TWILIO_ACCOUNT_SID",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/twilio/account-sid"
         },

--- a/cd/application-deployment/staging/vaec-api-task-definition.json
+++ b/cd/application-deployment/staging/vaec-api-task-definition.json
@@ -300,10 +300,6 @@
         {
           "name": "VA_SSO_CLIENT_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/iam-sso-client-secret"
-        },
-        {
-          "name": "VA_ONSITE_SECRET",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/onsite/notification-priv"
         }
       ]
     },

--- a/cd/application-deployment/staging/vaec-api-task-definition.json
+++ b/cd/application-deployment/staging/vaec-api-task-definition.json
@@ -230,10 +230,6 @@
       ],
       "secrets": [
         {
-          "name": "COMP_AND_PEN_SERVICE_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/comp-and-pen/service-id"
-        },
-        {
           "name": "COMP_AND_PEN_TEMPLATE_ID",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/comp-and-pen/template-id"
         },

--- a/cd/application-deployment/staging/vaec-api-task-definition.json
+++ b/cd/application-deployment/staging/vaec-api-task-definition.json
@@ -294,10 +294,6 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/vetext/password"
         },
         {
-          "name": "VA_SSO_CLIENT_ID",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/iam-sso-client-id"
-        },
-        {
           "name": "VA_SSO_CLIENT_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/iam-sso-client-secret"
         }

--- a/cd/application-deployment/staging/vaec-celery-task-definition.json
+++ b/cd/application-deployment/staging/vaec-celery-task-definition.json
@@ -280,14 +280,6 @@
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/redis/url"
         },
         {
-          "name": "VETEXT_USERNAME",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/vetext/user"
-        },
-        {
-          "name": "VETEXT_PASSWORD",
-          "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/vetext/password"
-        },
-        {
           "name": "VA_ONSITE_SECRET",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/staging/notification-api/onsite/notification-priv"
         },


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

issue #1711 

[Spreadsheet Tracking Secret Keys and Environment Variables](https://docs.google.com/spreadsheets/d/1WYtI4Ky_p0ajRszOakhwV94EYzdDYS2XgQNEhX0fLIE/edit?gid=0#gid=0)
- Reviewed and removed all unused **secret keys** (Only secret keys, not environment) in the notification-api and notification-celery container from the 4 environments: dev, perf, staging, prod
- Ignoring the notification-celery-beats container.
- Documented old feature flags and create a ticket to remove them - [new ticket](https://app.zenhub.com/workspaces/va-notify-620d21369d810a00146ed9c8/issues/gh/department-of-veterans-affairs/notification-api/1936)
- Documented all environment variables and created a ticket to move all envs into a shared env file - [new ticket WIP](https://app.zenhub.com/workspaces/va-notify-620d21369d810a00146ed9c8/issues/gh/department-of-veterans-affairs/notification-api/1945)
- Manually tested three celery tasks (Notes in How Has This Been Tested below).

### Removed Secret Keys and Container Removed From 

- COMP_AND_PEN_SERVICE_ID: notification-api
- COMP_AND_PEN_SMS_SENDER_ID: notification-api
- COMP_AND_PEN_TEMPLATE_ID: notification-api
- VA_ONSITE_SECRET: notification-api
- VA_SSO_CLIENT_ID:
  - notification-api
  - notification-celery
- VA_SSO_CLIENT_SECRET:
  - notification-api
  - notification-celery
- VANOTIFY_SSL_CERT: notification-api
- VANOTIFY_SSL_KEY: notification-api
- VETEXT_PASSWORD: notification-celery
- VETEXT_USERNAME: notification-celery


## Type of change

Please check the relevant option(s).

- [x] Internal
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Hotfix (quick fix for an urgent bug or issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->
- Noted in [spreadsheet how removed Secret Keys were test](https://docs.google.com/spreadsheets/d/1WYtI4Ky_p0ajRszOakhwV94EYzdDYS2XgQNEhX0fLIE/edit?gid=0#gid=0). See "testing removal notes" column
- Secret Keys that were not obvious (More than 1-2 branching code paths), not covered by the QA Suite, or were not a part of route removal were manually tested.
- Removed 4-5 Secret Keys at a time and deployed. Confirmed each deployment was OK.
- @mchlwellman, @EvanParish , and I manually tested the following celery tasks by deploying changes and reviewing logs to confirm no errors were thrown.
  - send_va_onsite_notification_task
    Note: We did check the logs with no `set : False`. We did not find any errors in the logs. We did find this celery task is called several times but because of the `False` flag, no code is executed. We informed @k-macmillan and this may be addressed in a later ticket. 
    ![image](https://github.com/user-attachments/assets/fff826ff-26cd-4231-a072-8e632bd5deb0)
  - lookup_va_profile_id
    Tested with @EvanParish. Sent a notification email from Postman and checked the logs that celery task was successfully ran and notification was sent. 
       <img width="1177" alt="Screenshot 2024-08-16 at 9 42 35 AM" src="https://github.com/user-attachments/assets/92a17f5e-12c6-45c8-b6f2-07cdcd81a9ae">
  - send_scheduled_comp_and_pen_sms 
    This task we changed the schedule manually for every two minutes and deployed this morning - then reviewed logs for errors. 
     ![image](https://github.com/user-attachments/assets/f5bfc2f3-5009-4cd4-99cb-045dd7a9f1cb)




## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/master/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/master/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/master/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to any documentation
- [N/A] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/master/Process/testing_guide.md)
- [x] I have ensured the latest master is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ N/A] Any dependent changes have been merged and published in downstream modules
- [x] The ticket is now moved into the DEV test column
- [x] I have added a bullet for this work to the Engineering Key Wins slide for review
