### PR TITLE
#1895 Provider Service log level

### DIFF
--- a/app/provider_details/provider_service.py
+++ b/app/provider_details/provider_service.py
@@ -53,7 +53,9 @@ class ProviderService:
 
         # This is a UUID (ProviderDetails primary key).
         provider_id = self._get_template_or_service_provider_id(notification)
-        current_app.logger.debug('notification = %s, provider_id = %s', notification.id, provider_id)
+        current_app.logger.debug(
+            'Provider service getting provider for notification = %s, provider_id = %s', notification.id, provider_id
+        )
 
         if provider_id:
             provider = get_provider_details_by_id(provider_id)

--- a/app/provider_details/provider_service.py
+++ b/app/provider_details/provider_service.py
@@ -1,5 +1,3 @@
-import logging
-
 from flask import current_app
 
 from app.dao.provider_details_dao import get_provider_details_by_id
@@ -11,12 +9,6 @@ from app.provider_details.provider_selection_strategy_interface import (
     STRATEGY_REGISTRY,
 )
 from typing import Type, Dict, Optional
-
-logging.basicConfig(format='%(levelname)s %(asctime)s %(pathname)s:%(lineno)d: %(message)s')
-logger = logging.getLogger('notification-api.provider_switching')
-
-# Set the logger's level to the current_app log level.
-logger.setLevel(current_app.logger.level)
 
 
 class ProviderService:
@@ -61,15 +53,15 @@ class ProviderService:
 
         # This is a UUID (ProviderDetails primary key).
         provider_id = self._get_template_or_service_provider_id(notification)
-        logger.debug('notification = %s', notification)
-        logger.debug('provider_id = %s', provider_id)
+        current_app.logger.debug('notification = %s', notification)
+        current_app.logger.debug('provider_id = %s', provider_id)
 
         if provider_id:
             provider = get_provider_details_by_id(provider_id)
         elif notification.notification_type != NotificationType.SMS:
             # Use an alternative strategy to determine the provider.
             provider_selection_strategy = self._strategies.get(NotificationType(notification.notification_type))
-            logger.debug('Provider selection strategy: %s', provider_selection_strategy)
+            current_app.logger.debug('Provider selection strategy: %s', provider_selection_strategy)
             provider = (
                 None
                 if (provider_selection_strategy is None)
@@ -94,7 +86,7 @@ class ProviderService:
         elif not provider.active:
             raise InvalidProviderException(f'The provider {provider.display_name} is not active.')
 
-        logger.debug('Returning provider: %s', None if provider is None else provider.display_name)
+        current_app.logger.debug('Returning provider: %s', None if provider is None else provider.display_name)
         return provider
 
     @staticmethod
@@ -111,18 +103,18 @@ class ProviderService:
         # TODO #957 - The field is nullable, but what does SQLAlchemy return?  An empty string?
         # Testing for None broke a user flows test; user flows is since removed but this is possibly an issue?
         if notification.template.provider_id:
-            logger.debug('Found template provider ID %s', notification.template.provider_id)
+            current_app.logger.debug('Found template provider ID %s', notification.template.provider_id)
             return notification.template.provider_id
 
         # A template provider_id is not available.  Try using a service provider_id, which might also be None.
         if notification.notification_type == NotificationType.EMAIL.value:
-            logger.debug('Service provider e-mail ID %s', notification.service.email_provider_id)
+            current_app.logger.debug('Service provider e-mail ID %s', notification.service.email_provider_id)
             return notification.service.email_provider_id
         elif notification.notification_type == NotificationType.SMS.value:
-            logger.debug('Service provider SMS ID %s', notification.service.sms_provider_id)
+            current_app.logger.debug('Service provider SMS ID %s', notification.service.sms_provider_id)
             return notification.service.sms_provider_id
 
         # TODO #957 - What about letters?  That is the 3rd enumerated value in NotificationType
         # and Notification.notification_type.
-        logger.critical('Unanticipated notification type: %s', notification.notification_type)
+        current_app.logger.critical('Unanticipated notification type: %s', notification.notification_type)
         return None

--- a/app/provider_details/provider_service.py
+++ b/app/provider_details/provider_service.py
@@ -61,7 +61,7 @@ class ProviderService:
             # Use an alternative strategy to determine the provider.
             provider_selection_strategy = self._strategies.get(NotificationType(notification.notification_type))
             current_app.logger.debug(
-                'Provider selection strategy: %s, for notification: ', provider_selection_strategy, notification.id
+                'Provider selection strategy: %s, for notification: %s', provider_selection_strategy, notification.id
             )
             provider = (
                 None

--- a/app/provider_details/provider_service.py
+++ b/app/provider_details/provider_service.py
@@ -53,7 +53,7 @@ class ProviderService:
 
         # This is a UUID (ProviderDetails primary key).
         provider_id = self._get_template_or_service_provider_id(notification)
-        current_app.logger.debug('notification = %s, provider_id = %s', notification, provider_id)
+        current_app.logger.debug('notification = %s, provider_id = %s', notification.id, provider_id)
 
         if provider_id:
             provider = get_provider_details_by_id(provider_id)
@@ -61,7 +61,7 @@ class ProviderService:
             # Use an alternative strategy to determine the provider.
             provider_selection_strategy = self._strategies.get(NotificationType(notification.notification_type))
             current_app.logger.debug(
-                'Provider selection strategy: %s, for notification: ', provider_selection_strategy, notification
+                'Provider selection strategy: %s, for notification: ', provider_selection_strategy, notification.id
             )
             provider = (
                 None
@@ -90,7 +90,7 @@ class ProviderService:
         current_app.logger.debug(
             'Returning provider: %s, for notification %s',
             None if provider is None else provider.display_name,
-            notification,
+            notification.id,
         )
         return provider
 
@@ -109,7 +109,7 @@ class ProviderService:
         # Testing for None broke a user flows test; user flows is since removed but this is possibly an issue?
         if notification.template.provider_id:
             current_app.logger.debug(
-                'Found template provider ID %s, for notification %s', notification.template.provider_id, notification
+                'Found template provider ID %s, for notification %s', notification.template.provider_id, notification.id
             )
             return notification.template.provider_id
 
@@ -118,12 +118,12 @@ class ProviderService:
             current_app.logger.debug(
                 'Service provider e-mail ID %s, for notification %s',
                 notification.service.email_provider_id,
-                notification,
+                notification.id,
             )
             return notification.service.email_provider_id
         elif notification.notification_type == NotificationType.SMS.value:
             current_app.logger.debug(
-                'Service provider SMS ID %s, for notification %s', notification.service.sms_provider_id, notification
+                'Service provider SMS ID %s, for notification %s', notification.service.sms_provider_id, notification.id
             )
             return notification.service.sms_provider_id
 

--- a/app/provider_details/provider_service.py
+++ b/app/provider_details/provider_service.py
@@ -129,5 +129,7 @@ class ProviderService:
 
         # TODO #957 - What about letters?  That is the 3rd enumerated value in NotificationType
         # and Notification.notification_type.
-        current_app.logger.critical('Unanticipated notification type: %s', notification.notification_type)
+        current_app.logger.critical(
+            'Unanticipated notification type: %s for notification %s', notification.notification_type, notification.id
+        )
         return None

--- a/app/provider_details/provider_service.py
+++ b/app/provider_details/provider_service.py
@@ -1,4 +1,7 @@
 import logging
+
+from flask import current_app
+
 from app.dao.provider_details_dao import get_provider_details_by_id
 from app.exceptions import InvalidProviderException
 from app.models import Notification, ProviderDetails
@@ -11,7 +14,9 @@ from typing import Type, Dict, Optional
 
 logging.basicConfig(format='%(levelname)s %(asctime)s %(pathname)s:%(lineno)d: %(message)s')
 logger = logging.getLogger('notification-api.provider_switching')
-logger.setLevel(logging.DEBUG)
+
+# Set the logger's level to the current_app log level.
+logger.setLevel(current_app.logger.level)
 
 
 class ProviderService:


### PR DESCRIPTION
# Description

This PR updates the provider service to use the current_app logger instead of its current custom logger.

issue #1895 

## Type of change

Please check the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Hotfix (quick fix for an urgent bug or issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation changes only

## How Has This Been Tested?

- [Deployed to dev](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/10584578739) and inspected logs.  Dev has DEBUG logging, so they are there which verifies that the flask current app logger is working correctly.



## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/main/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket is now moved into the DEV test column
- [x] I have added a bullet for this work to the Engineering Key Wins slide for review
