### PR TITLE
#1970 - Simplify labeling scheme to major, minor, patch

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -5,22 +5,9 @@ changelog:
     authors:
       - dependabot
   categories:
-    - title: Breaking Changes 🛠
+    - title: Major Changes
       labels:
-        - breaking-change
-    - title: Exciting New Features 🎉
-      labels:
-        - enhancement
-    - title: Bug Fixes 🐜
-      labels:
-        - bug
-        - hotfix
-    - title: Security Fixes 🔐
-      labels:
-        - security
-    - title: Internal Upgrades 📈
-      labels:
-        - internal
-    - title: Other Changes 🧑‍💻
+        - major
+    - title: Other Changes
       labels:
         - "*"

--- a/.github/scripts/prLabelSemver.js
+++ b/.github/scripts/prLabelSemver.js
@@ -12,17 +12,14 @@ function determineSemverValue(label) {
   console.log('Received label:', label);
 
   try {
-    if (label.includes('breaking change')) {
+    if (label.includes('major')) {
       return 'MAJOR';
     } else if (
-      label.includes('hotfix') ||
-      label.includes('security') ||
-      label.includes('internal') ||
-      label.includes('bug')
+      label.includes('minor')
     ) {
-      return 'PATCH';
-    } else {
       return 'MINOR';
+    } else {
+      return 'PATCH';
     }
   } catch (error) {
     console.error('Error determining semver value:', error);


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR introduces the following changes:
* Simplifies our labeling scheme to map major, minor, and patch labels to their respective semver bumps
* Defaults to using a patch bump when no label is specified
* Allows multiple labels to be used on a PR (for example, minor and devops) to allow devs to continue using whatever labeling they want in addition to major, minor, and patch
* Cleaned up the `release.yaml` file to only create release notes for Major and Other categories

issue #1970 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

## Testing Summary
Patch label:
<img width="1896" alt="image" src="https://github.com/user-attachments/assets/16e3dfa0-0780-4d5b-87e7-2733c1cfa8eb">

Minor label:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/0d7ea2c8-87f1-4307-874c-bd4954eed0d8">

Major label:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/1f992407-1c8d-4035-b63e-989adf4ff349">

No labels (defaults to patch):
<img width="1908" alt="image" src="https://github.com/user-attachments/assets/421bee33-22a9-481c-88cf-4d602b7500c1">

## Testing Tags
Major:
<img width="1558" alt="image" src="https://github.com/user-attachments/assets/44e02595-231d-438c-a083-145ec9c88956">

Minor:
<img width="1914" alt="image" src="https://github.com/user-attachments/assets/af688ec8-e8f1-4045-8aec-b9f295cfea1d">

NO LABELS (bumps to patch):
<img width="1914" alt="image" src="https://github.com/user-attachments/assets/31349f27-bc18-4b98-9fed-4b6911c224a9">

Multiple labels (minor and devops):
<img width="1912" alt="image" src="https://github.com/user-attachments/assets/5220b903-9533-4ca1-a0b5-91cf91b296c8">



## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/notification-api/blob/main/.github/release.yaml) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
