### PR TITLE
#2011 - Notification status and status_reason consistency

### DIFF
--- a/app/celery/process_delivery_status_result_tasks.py
+++ b/app/celery/process_delivery_status_result_tasks.py
@@ -209,7 +209,7 @@ def _calculate_pricing_and_update_notification(
     current_app.logger.debug('Calculate pricing and update notification %s', notification.id)
 
     # Delivered messages should not have an associated reason.
-    status_reason = '' if (notification_status == NOTIFICATION_DELIVERED) else notification.status_reason
+    status_reason = None if (notification_status == NOTIFICATION_DELIVERED) else notification.status_reason
 
     if price_in_millicents_usd > 0.0:
         dao_update_notification_by_id(

--- a/app/celery/process_delivery_status_result_tasks.py
+++ b/app/celery/process_delivery_status_result_tasks.py
@@ -70,7 +70,7 @@ def process_delivery_status(
         price_in_millicents_usd,
     ) = _get_notification_parameters(notification_platform_status)
 
-    # Retrieve the inbound message for this provider.  (We are updating the status of the outbound message.)
+    # Retrieve the inbound message for this provider.  We are updating the status of the outbound message.
     notification, should_exit = attempt_to_get_notification(
         reference, notification_status, self.request.retries * self.default_retry_delay
     )

--- a/app/celery/process_delivery_status_result_tasks.py
+++ b/app/celery/process_delivery_status_result_tasks.py
@@ -37,7 +37,9 @@ def process_delivery_status(
     self,
     event: CeleryEvent,
 ) -> bool:
-    """Celery task for updating the delivery status of a notification"""
+    """
+    This is a Celery task for updating the delivery status of a notification.
+    """
 
     # preset variables to address "unbounded local variable"
     sqs_message = None
@@ -56,7 +58,7 @@ def process_delivery_status(
     current_app.logger.info('retrieved delivery status body: %s', body)
 
     # get notification_platform_status
-    notification_platform_status = _get_notification_platform_status(self, provider, body, sqs_message)
+    notification_platform_status: dict = _get_notification_platform_status(self, provider, body, sqs_message)
 
     # get parameters from notification platform status
     current_app.logger.info('Get Notification Parameters')
@@ -68,7 +70,7 @@ def process_delivery_status(
         price_in_millicents_usd,
     ) = _get_notification_parameters(notification_platform_status)
 
-    # retrieves the inbound message for this provider we are updating the status of the outbound message
+    # Retrieve the inbound message for this provider.  (We are updating the status of the outbound message.)
     notification, should_exit = attempt_to_get_notification(
         reference, notification_status, self.request.retries * self.default_retry_delay
     )
@@ -90,7 +92,10 @@ def process_delivery_status(
             number_of_message_parts,
             getattr(notification, 'id', 'unknown'),
         )
-        _calculate_pricing(price_in_millicents_usd, notification, notification_status, number_of_message_parts)
+
+        _calculate_pricing_and_update_notification(
+            price_in_millicents_usd, notification, notification_status, number_of_message_parts
+        )
 
         current_app.logger.info(
             '%s callback return status of %s for notification: %s',
@@ -194,20 +199,30 @@ def _get_notification_parameters(notification_platform_status: dict) -> Tuple[st
     return payload, reference, notification_status, number_of_message_parts, price_in_millicents_usd
 
 
-def _calculate_pricing(
+def _calculate_pricing_and_update_notification(
     price_in_millicents_usd: float, notification: Notification, notification_status: str, number_of_message_parts: int
 ):
-    """Calculate pricing"""
+    """
+    Calculate pricing, and update the notification.
+    """
+
     current_app.logger.debug('Calculate pricing and update notification %s', notification.id)
+
+    # Delivered messages should not have an associated reason.
+    status_reason = '' if (notification_status == NOTIFICATION_DELIVERED) else notification.status_reason
+
     if price_in_millicents_usd > 0.0:
         dao_update_notification_by_id(
             notification_id=notification.id,
             status=notification_status,
+            status_reason=status_reason,
             segments_count=number_of_message_parts,
             cost_in_millicents=price_in_millicents_usd,
         )
     else:
-        update_notification_delivery_status(notification_id=notification.id, new_status=notification_status)
+        update_notification_delivery_status(
+            notification_id=notification.id, new_status=notification_status, new_status_reason=status_reason
+        )
 
 
 def _get_notification_platform_status(

--- a/app/celery/process_pinpoint_receipt_tasks.py
+++ b/app/celery/process_pinpoint_receipt_tasks.py
@@ -136,7 +136,7 @@ def process_pinpoint_results(
                 notification.status_reason = 'The veteran is opted-out at the Pinpoint level.'
         elif notification_status == NOTIFICATION_DELIVERED:
             # Never include a status reason for a delivered notification.
-            notification.status_reason = ''
+            notification.status_reason = None
 
         if price_in_millicents_usd > 0.0:
             dao_update_notification_by_id(

--- a/app/celery/process_pinpoint_receipt_tasks.py
+++ b/app/celery/process_pinpoint_receipt_tasks.py
@@ -117,6 +117,7 @@ def process_pinpoint_results(
     )
 
     try:
+        # This is the new status.
         notification_status = get_notification_status(event_type, record_status, reference)
 
         notification, should_exit = attempt_to_get_notification(
@@ -133,11 +134,15 @@ def process_pinpoint_results(
                 notification.status_reason = 'The veteran responded with STOP.'
             elif record_status == 'OPTED_OUT':
                 notification.status_reason = 'The veteran is opted-out at the Pinpoint level.'
+        elif notification_status == NOTIFICATION_DELIVERED:
+            # Never include a status reason for a delivered notification.
+            notification.status_reason = ''
 
         if price_in_millicents_usd > 0.0:
             dao_update_notification_by_id(
                 notification_id=notification.id,
                 status=notification_status,
+                status_reason=notification.status_reason,
                 segments_count=number_of_message_parts,
                 cost_in_millicents=price_in_millicents_usd,
             )
@@ -215,8 +220,8 @@ def attempt_to_get_notification(
 def check_notification_status(notification: Notification, notification_status: str) -> bool:
     """
     Check if the notification status should be updated. If the status has not changed, or if the status is in a final
-    state, do not update the notification. *Unless* the status is being updated to delivered from a different final
-    status, in which case, the notification should always be updated.
+    state, do not update the notification *unless* the status is being updated to delivered from a different final
+    status.  In that case, always update the notification.
 
     Args:
         notification (Notification): The notification to check.

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -173,6 +173,7 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
 
         aws_response_dict = get_aws_responses(notification_type)
 
+        # This is the prospective, updated status.
         notification_status = aws_response_dict['notification_status']
         reference = ses_message['mail']['messageId']
 
@@ -188,6 +189,25 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
                 )
             return
 
+        # Prevent regressing bounce status.  Note that this is a test of the existing status; not the new status.
+        if (
+            notification.status_reason
+            and 'bounce' in notification.status_reason
+            and notification.status
+            in {
+                NOTIFICATION_TEMPORARY_FAILURE,
+                NOTIFICATION_PERMANENT_FAILURE,
+            }
+        ):
+            # async from AWS means we may get a delivered status after a bounce, in rare cases
+            current_app.logger.warning(
+                'Notification: %s was marked as a bounce, cannot be updated to: %s',
+                notification.id,
+                notification_status,
+            )
+            return
+
+        # This is a test of the new status.  Is it a bounce?
         if notification_status in (NOTIFICATION_TEMPORARY_FAILURE, NOTIFICATION_PERMANENT_FAILURE):
             # Add the failure status reason to the notification.
             if notification_status == NOTIFICATION_PERMANENT_FAILURE:
@@ -212,7 +232,7 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
             return
         elif notification_status == NOTIFICATION_DELIVERED:
             # Delivered messages should never have a status reason.
-            notification.status_reason = ''
+            notification.status_reason = None
 
         if notification.status not in (NOTIFICATION_SENDING, NOTIFICATION_PENDING):
             notifications_dao.duplicate_update_warning(notification, notification_status)

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -25,6 +25,7 @@ from app.models import (
     Notification,
     EMAIL_TYPE,
     KEY_TYPE_NORMAL,
+    NOTIFICATION_DELIVERED,
     NOTIFICATION_SENDING,
     NOTIFICATION_PENDING,
     NOTIFICATION_PERMANENT_FAILURE,
@@ -187,8 +188,8 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
                 )
             return
 
-        # Add status reason to notification if the status is some kind of failure
         if notification_status in (NOTIFICATION_TEMPORARY_FAILURE, NOTIFICATION_PERMANENT_FAILURE):
+            # Add the failure status reason to the notification.
             if notification_status == NOTIFICATION_PERMANENT_FAILURE:
                 status_reason = 'Failed to deliver email due to hard bounce'
             else:
@@ -209,24 +210,9 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
             check_and_queue_va_profile_email_status_callback(notification)
 
             return
-
-        # Prevent regressing bounce status
-        if (
-            notification.status_reason
-            and 'bounce' in notification.status_reason
-            and notification.status
-            in {
-                NOTIFICATION_TEMPORARY_FAILURE,
-                NOTIFICATION_PERMANENT_FAILURE,
-            }
-        ):
-            # async from AWS means we may get a delivered status after a bounce, in rare cases
-            current_app.logger.warning(
-                'Notification: %s was marked as a bounce, cannot be updated to: %s',
-                notification.id,
-                notification_status,
-            )
-            return
+        elif notification_status == NOTIFICATION_DELIVERED:
+            # Delivered messages should never have a status reason.
+            notification.status_reason = ''
 
         if notification.status not in (NOTIFICATION_SENDING, NOTIFICATION_PENDING):
             notifications_dao.duplicate_update_warning(notification, notification_status)

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -128,6 +128,7 @@ def country_records_delivery(phone_prefix):
 def _get_notification_status_update_statement(
     notification_id: str,
     incoming_status: str,
+    incoming_status_reason: str | None,
     **kwargs,
 ):
     """
@@ -136,13 +137,15 @@ def _get_notification_status_update_statement(
 
     Args:
         notification_id (str): String value of notification uuid to be updated
-        incoming_status (str): String value of the status the given notification will attempt to update to
-        notification (Notification): The notification to update, or None
+        incoming_status (str): String value of the status to which the given notification will attempt to update
+        incoming_status_reason (str): String value of the status reason to which the given notification will
+            attempt to update, or None
         **kwargs: Additional key-value pairs to be updated
 
     Returns:
         update_statement: An update statement to be executed, or None if the notification should not be updated
     """
+
     notification = db.session.get(Notification, notification_id)
     if notification is None:
         current_app.logger.error(
@@ -155,6 +158,9 @@ def _get_notification_status_update_statement(
         kwargs['status'] = incoming_status
     elif incoming_status == NOTIFICATION_TEMPORARY_FAILURE:
         kwargs['status'] = NOTIFICATION_TEMPORARY_FAILURE
+
+    if incoming_status_reason is not None:
+        kwargs['status_reason'] = incoming_status_reason
 
     kwargs['updated_at'] = datetime.utcnow()
 
@@ -193,6 +199,7 @@ def _get_notification_status_update_statement(
 def _update_notification_status(
     notification: Notification,
     status: str,
+    status_reason: str | None = None
 ) -> Notification:
     """
     Update the notification status if it should be updated.
@@ -212,7 +219,7 @@ def _update_notification_status(
             'Attempting to update notification %s to a status that does not exist %s', notification.id, status
         )
 
-    update_statement = _get_notification_status_update_statement(notification.id, status)
+    update_statement = _get_notification_status_update_statement(notification.id, status, status_reason)
 
     try:
         db.session.execute(update_statement)
@@ -277,6 +284,7 @@ def update_notification_status_by_id(
 def update_notification_delivery_status(
     notification_id: UUID,
     new_status: str,
+    new_status_reason: str = None,
 ) -> None:
     """
     Update a notification's delivery status.
@@ -287,10 +295,15 @@ def update_notification_delivery_status(
         notification_id (UUID): Notification id,
         new_status (str): Status to update the notification to,
     """
+
     current_app.logger.info('Update notification: %s to status: %s', notification_id, new_status)
+    stmt = _get_notification_status_update_statement(
+        notification_id=notification_id,
+        incoming_status=new_status,
+        incoming_status_reason=new_status_reason,
+    )
 
     try:
-        stmt = _get_notification_status_update_statement(notification_id=notification_id, incoming_status=new_status)
         db.session.execute(stmt)
         db.session.commit()
     except Exception as e:
@@ -302,8 +315,9 @@ def update_notification_delivery_status(
 @statsd(namespace='dao')
 @transactional
 def update_notification_status_by_reference(
-    reference,
-    status,
+    reference: UUID,
+    status: str,
+    status_reason: str | None = None
 ):
     # this is used to update letters and emails
     stmt = select(Notification).where(Notification.reference == reference)
@@ -323,7 +337,7 @@ def update_notification_status_by_reference(
     if current_index < sending_index:
         return None
 
-    return _update_notification_status(notification=notification, status=status)
+    return _update_notification_status(notification=notification, status=status, status_reason=status_reason)
 
 
 @statsd(namespace='dao')
@@ -343,12 +357,14 @@ def dao_update_notification_by_id(
     Returns:
         Notification: The updated notification or None if the notification was not found
     """
+
     kwargs['updated_at'] = datetime.utcnow()
     status = kwargs.get('status')
+    status_reason = kwargs.get('status_reason')
 
     if notification_id and status is not None:
         update_statement = _get_notification_status_update_statement(
-            notification_id=notification_id, incoming_status=status, **kwargs
+            notification_id=notification_id, incoming_status=status, incoming_status_reason=status_reason, **kwargs
         )
     elif notification_id:
         update_statement = update(Notification).where(Notification.id == notification_id).values(kwargs)
@@ -820,6 +836,10 @@ def dao_update_notifications_by_reference(
     references,
     update_dict,
 ):
+    """
+    references - A list or tuple; update or notificaitons in this iterable.
+    """
+
     stmt = update(Notification).where(Notification.reference.in_(references)).values(**update_dict)
     updated_count = db.session.execute(stmt, execution_options={'synchronize_session': False}).rowcount
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -197,9 +197,7 @@ def _get_notification_status_update_statement(
 
 
 def _update_notification_status(
-    notification: Notification,
-    status: str,
-    status_reason: str | None = None
+    notification: Notification, status: str, status_reason: str | None = None
 ) -> Notification:
     """
     Update the notification status if it should be updated.
@@ -314,11 +312,7 @@ def update_notification_delivery_status(
 
 @statsd(namespace='dao')
 @transactional
-def update_notification_status_by_reference(
-    reference: UUID,
-    status: str,
-    status_reason: str | None = None
-):
+def update_notification_status_by_reference(reference: UUID, status: str, status_reason: str | None = None):
     # this is used to update letters and emails
     stmt = select(Notification).where(Notification.reference == reference)
     notification = db.session.scalar(stmt)

--- a/tests/app/celery/test_process_delivery_status_result_tasks.py
+++ b/tests/app/celery/test_process_delivery_status_result_tasks.py
@@ -10,7 +10,7 @@ from app.celery.process_delivery_status_result_tasks import (
     attempt_to_get_notification,
     process_delivery_status,
 )
-from app.models import Notification, NOTIFICATION_DELIVERED, SMS_TYPE
+from app.models import Notification, NOTIFICATION_DELIVERED, NOTIFICATION_SENT, SMS_TYPE
 
 
 @pytest.fixture
@@ -33,7 +33,7 @@ def sample_notification_platform_status():
         'lbGl2ZXJlZCZUbz0lMkIxMTExMTExMTExMSZNZXNzYWdlU2lkPVNNaGFyZGNvZGVkS1dNJkFjY291bnRTaWQ9QUN6enomRnJvbT'
         '0lMkIxMjIyMzMzNDQ0NCZBcGlWZXJzaW9uPTIwMTAtMDQtMDE=',
         'reference': 'SMhardcodedKWM',
-        'record_status': 'delivered',
+        'record_status': NOTIFICATION_DELIVERED,
     }
 
 
@@ -133,7 +133,7 @@ def test_get_provider_info_with_twilio(notify_api, sample_sqs_message_with_provi
 def test_attempt_to_get_notification_with_good_data(sample_template, sample_notification):
     """Test that we will exit the celery task when sqs message matches what has already been reported in the database"""
 
-    notification_status = 'delivered'
+    notification_status = NOTIFICATION_DELIVERED
     reference = str(uuid4())
 
     sample_notification(
@@ -151,14 +151,13 @@ def test_attempt_to_get_notification_with_good_data(sample_template, sample_noti
 
 
 def test_attempt_to_get_notification_duplicate_notification(
-    sample_notification_platform_status,
     sample_template,
     sample_notification,
 ):
     """Test that duplicate notifications will make notification = None, should_exit=True"""
 
     template = sample_template()
-    notification_status = 'delivered'
+    notification_status = NOTIFICATION_DELIVERED
     reference = str(uuid4())
 
     sample_notification(
@@ -211,10 +210,12 @@ def test_attempt_to_get_notification_NoResultFound(notify_api, event_duration_in
     if event_duration_in_seconds < 300:
         with pytest.raises(Exception) as exc_info:
             # Ignore the returns, we are expecting an exception
-            attempt_to_get_notification('bad_reference', 'delivered', event_duration_in_seconds)
+            attempt_to_get_notification('bad_reference', NOTIFICATION_DELIVERED, event_duration_in_seconds)
         assert exc_info.type is AutoRetryException
     else:
-        notification, should_exit = attempt_to_get_notification('bad_reference', 'delivered', event_duration_in_seconds)
+        notification, should_exit = attempt_to_get_notification(
+            'bad_reference', NOTIFICATION_DELIVERED, event_duration_in_seconds
+        )
         assert notification is None
         assert should_exit
 
@@ -236,9 +237,10 @@ def test_process_delivery_status_with_valid_message_with_no_payload(
     Test that the Celery task will complete if correct data is provided.
     """
 
-    # Reference is used by many tests, can lead to trouble
+    # This test is marked "serial" because the reference is used by many tests.  Making it a random
+    # value causes the test to fail.
     notification = sample_notification(
-        template=sample_template(), reference='SMyyy', sent_at=datetime.datetime.utcnow(), status='sent'
+        template=sample_template(), reference='SMyyy', sent_at=datetime.datetime.utcnow(), status=NOTIFICATION_SENT
     )
 
     callback_mock = mocker.patch('app.celery.process_delivery_status_result_tasks.check_and_queue_callback_task')
@@ -255,11 +257,14 @@ def test_process_delivery_status_with_valid_message_with_payload(
     sample_template,
     sample_notification,
 ):
-    """Test that celery task will complete if correct data is provided"""
+    """
+    Test that the Celery task will complete if correct data is provided.
+    """
 
-    # Reference is used by many tests, can lead to trouble
+    # This test is marked "serial" because the reference is used by many tests.  Making it a random
+    # value causes the test to fail.
     sample_notification(
-        template=sample_template(), reference='SMyyy', sent_at=datetime.datetime.utcnow(), status='sent'
+        template=sample_template(), reference='SMyyy', sent_at=datetime.datetime.utcnow(), status=NOTIFICATION_SENT
     )
 
     mocker.patch('app.celery.process_delivery_status_result_tasks._get_include_payload_status', returns=True)
@@ -279,7 +284,7 @@ def test_get_notification_parameters(notify_api, sample_notification_platform_st
 
     """Test our ability to get parameters such as payload or reference from notification_platform_status"""
 
-    assert notification_status == 'delivered'
+    assert notification_status == NOTIFICATION_DELIVERED
     assert reference == 'SMhardcodedKWM'
     assert number_of_message_parts == 1
     assert price_in_millicents_usd >= 0
@@ -297,7 +302,7 @@ def test_wt_delivery_status_callback_should_log_total_time(
     mock_log_total_time = mocker.patch('app.celery.common.log_notification_total_time')
     mocker.patch('app.celery.service_callback_tasks.check_and_queue_callback_task')
 
-    notification = sample_notification(template=sample_template(), status='sent', reference='SMyyy')
+    notification = sample_notification(template=sample_template(), status=NOTIFICATION_SENT, reference='SMyyy')
     # Mock db call
     mocker.patch(
         'app.dao.notifications_dao.dao_get_notification_by_reference',
@@ -313,3 +318,46 @@ def test_wt_delivery_status_callback_should_log_total_time(
         NOTIFICATION_DELIVERED,
         'twilio',
     )
+
+
+@pytest.mark.serial
+def test_process_delivery_status_no_status_reason_for_delivered(
+    notify_db_session,
+    mocker,
+    sample_template,
+    sample_notification,
+    sample_delivery_status_result_message,
+    sample_notification_platform_status,
+):
+    """
+    When a notification is updated to "delivered" status, its "status_reason" should be set to
+    the empty string.
+    """
+
+    # This test is marked "serial" because the reference is used by many tests.  Making it a random
+    # value causes the test to fail.
+    notification = sample_notification(
+        template=sample_template(),
+        reference='SMhardcodedKWM',
+        sent_at=datetime.datetime.utcnow(),
+        status=NOTIFICATION_SENT,
+        status_reason='This is not the empty string.',
+    )
+    assert notification.reference == 'SMhardcodedKWM'
+    assert notification.status == NOTIFICATION_SENT
+    assert notification.status_reason
+
+    mocker.patch('app.celery.process_delivery_status_result_tasks._get_include_payload_status', returns=True)
+    mocker.patch(
+        'app.celery.process_delivery_status_result_tasks._get_notification_parameters',
+        return_value=tuple(sample_notification_platform_status.values()) + (1, 1),
+    )
+    callback_mock = mocker.patch('app.celery.process_delivery_status_result_tasks.check_and_queue_callback_task')
+
+    assert process_delivery_status(event=sample_delivery_status_result_message)
+    callback_mock.assert_called_once()
+
+    notify_db_session.session.refresh(notification)
+    assert notification.reference == 'SMhardcodedKWM'
+    assert notification.status == NOTIFICATION_DELIVERED
+    assert not notification.status_reason, 'This should be the empty string.'

--- a/tests/app/celery/test_process_delivery_status_result_tasks.py
+++ b/tests/app/celery/test_process_delivery_status_result_tasks.py
@@ -360,4 +360,4 @@ def test_process_delivery_status_no_status_reason_for_delivered(
     notify_db_session.session.refresh(notification)
     assert notification.reference == 'SMhardcodedKWM'
     assert notification.status == NOTIFICATION_DELIVERED
-    assert not notification.status_reason, 'This should be the empty string.'
+    assert notification.status_reason is None

--- a/tests/app/celery/test_process_pinpoint_receipt_tasks.py
+++ b/tests/app/celery/test_process_pinpoint_receipt_tasks.py
@@ -77,7 +77,11 @@ def test_process_pinpoint_results_notification_final_status(
     test_reference = str(uuid4())
     template = sample_template()
     sample_notification(
-        template=template, reference=test_reference, sent_at=datetime.datetime.utcnow(), status='sending'
+        template=template,
+        reference=test_reference,
+        sent_at=datetime.datetime.utcnow(),
+        status=NOTIFICATION_SENDING,
+        status_reason='just because',
     )
     process_pinpoint_receipt_tasks.process_pinpoint_results(
         response=pinpoint_notification_callback_record(
@@ -86,12 +90,16 @@ def test_process_pinpoint_results_notification_final_status(
     )
     notification = notifications_dao.dao_get_notification_by_reference(test_reference)
     assert notification.status == expected_notification_status
+
     if expected_notification_status == NOTIFICATION_PREFERENCES_DECLINED:
         assert notification.status_reason == (
             'The veteran is opted-out at the Pinpoint level.'
             if (record_status == 'OPTED_OUT')
             else 'The veteran responded with STOP.'
         )
+    elif expected_notification_status == NOTIFICATION_DELIVERED:
+        assert not notification.status_reason, 'The status reason should be the empty string.'
+
     mock_callback.assert_called_once()
 
 
@@ -109,7 +117,7 @@ def test_process_pinpoint_results_should_not_update_notification_status_if_uncha
     test_reference = f'{uuid4()}-sms-reference-1'
     template = sample_template()
     sample_notification(
-        template=template, reference=test_reference, sent_at=datetime.datetime.utcnow(), status='sending'
+        template=template, reference=test_reference, sent_at=datetime.datetime.utcnow(), status=NOTIFICATION_SENDING
     )
     process_pinpoint_receipt_tasks.process_pinpoint_results(
         response=pinpoint_notification_callback_record(
@@ -172,7 +180,13 @@ def test_process_pinpoint_results_should_update_notification_status_with_deliver
 
     test_reference = f'{uuid4()}=sms-reference-1'
     template = sample_template()
-    sample_notification(template=template, reference=test_reference, sent_at=datetime.datetime.utcnow(), status=status)
+    sample_notification(
+        template=template,
+        reference=test_reference,
+        sent_at=datetime.datetime.utcnow(),
+        status=status,
+        status_reason='' if (status == NOTIFICATION_DELIVERED) else 'just because',
+    )
     process_pinpoint_receipt_tasks.process_pinpoint_results(
         response=pinpoint_notification_callback_record(
             reference=test_reference,
@@ -182,6 +196,7 @@ def test_process_pinpoint_results_should_update_notification_status_with_deliver
     )
     notification = notifications_dao.dao_get_notification_by_reference(test_reference)
     assert notification.status == NOTIFICATION_DELIVERED
+    assert not notification.status_reason, 'The status reason should be the empty string.'
 
     update_notification_status.assert_not_called()
 
@@ -199,7 +214,7 @@ def test_process_pinpoint_results_segments_and_price_buffered_first(
     notify_db_session,
 ):
     """
-    Test process a Pinpoint SMS stream event.  Messages long enough to require multiple segments only
+    Test processing a Pinpoint SMS stream event.  Messages long enough to require multiple segments only
     result in one event that contains the aggregate cost.
     """
 
@@ -207,7 +222,7 @@ def test_process_pinpoint_results_segments_and_price_buffered_first(
     test_reference = f'{uuid4()}=sms-reference-1'
     template = sample_template()
     notification = sample_notification(
-        template=template, reference=test_reference, sent_at=datetime.datetime.utcnow(), status='sending'
+        template=template, reference=test_reference, sent_at=datetime.datetime.utcnow(), status=NOTIFICATION_SENDING
     )
     assert notification.segments_count == 0, 'This is the default.'
     assert notification.cost_in_millicents == 0.0, 'This is the default.'
@@ -223,11 +238,11 @@ def test_process_pinpoint_results_segments_and_price_buffered_first(
         )
     )
 
-    notification = notifications_dao.dao_get_notification_by_reference(test_reference)
     notify_db_session.session.refresh(notification)
-
+    assert notification.status == NOTIFICATION_DELIVERED
     assert notification.segments_count == 6
     assert notification.cost_in_millicents == 4986.0
+    assert not notification.status_reason, 'The status reason should be the empty string.'
 
     # A subsequent _SMS.SUCCESS+DELIVERED event should not alter the segments and price columns.
     process_pinpoint_receipt_tasks.process_pinpoint_results(
@@ -240,14 +255,18 @@ def test_process_pinpoint_results_segments_and_price_buffered_first(
         )
     )
 
-    notification = notifications_dao.dao_get_notification_by_reference(test_reference)
+    notify_db_session.session.refresh(notification)
+    assert notification.status == NOTIFICATION_DELIVERED
     assert notification.segments_count == 6
     assert notification.cost_in_millicents == 4986.0
+    assert not notification.status_reason, 'The status reason should be the empty string.'
 
 
-def test_process_pinpoint_results_segments_and_price_success_first(mocker, sample_template, sample_notification):
+def test_process_pinpoint_results_segments_and_price_success_first(
+    notify_db_session, mocker, sample_template, sample_notification
+):
     """
-    Test process a Pinpoint SMS stream event.  Messages long enough to require multiple segments only
+    Test processing a Pinpoint SMS stream event.  Messages long enough to require multiple segments only
     result in one event that contains the aggregate cost.
 
     Receiving a _SMS.SUCCESS+DELIVERED without any preceeding _SMS.BUFFERED event should update the
@@ -257,8 +276,8 @@ def test_process_pinpoint_results_segments_and_price_success_first(mocker, sampl
     mocker.patch('app.celery.process_pinpoint_receipt_tasks.is_feature_enabled', return_value=True)
     test_reference = f'{uuid4()}-sms-reference-1'
     template = sample_template()
-    sample_notification(
-        template=template, reference=test_reference, sent_at=datetime.datetime.utcnow(), status='sending'
+    notification = sample_notification(
+        template=template, reference=test_reference, sent_at=datetime.datetime.utcnow(), status=NOTIFICATION_SENDING
     )
 
     process_pinpoint_receipt_tasks.process_pinpoint_results(
@@ -271,9 +290,11 @@ def test_process_pinpoint_results_segments_and_price_success_first(mocker, sampl
         )
     )
 
-    notification = notifications_dao.dao_get_notification_by_reference(test_reference)
+    notify_db_session.session.refresh(notification)
+    assert notification.status == NOTIFICATION_DELIVERED
     assert notification.segments_count == 4
     assert notification.cost_in_millicents == 2986.0
+    assert not notification.status_reason, 'The status reason should be the empty string.'
 
 
 def pinpoint_notification_callback_record(
@@ -324,7 +345,7 @@ def test_wt_process_pinpoint_callback_should_log_total_time(
     mocker.patch('app.celery.service_callback_tasks.check_and_queue_callback_task')
 
     # Reference is used by many tests, can lead to trouble
-    notification = sample_notification(template=sample_template(), status='sending', reference='SMyyy')
+    notification = sample_notification(template=sample_template(), status=NOTIFICATION_SENDING, reference='SMyyy')
     # Mock db call
     mocker.patch(
         'app.dao.notifications_dao.dao_get_notification_by_reference',

--- a/tests/app/celery/test_process_pinpoint_receipt_tasks.py
+++ b/tests/app/celery/test_process_pinpoint_receipt_tasks.py
@@ -98,7 +98,7 @@ def test_process_pinpoint_results_notification_final_status(
             else 'The veteran responded with STOP.'
         )
     elif expected_notification_status == NOTIFICATION_DELIVERED:
-        assert not notification.status_reason, 'The status reason should be the empty string.'
+        assert notification.status_reason is None
 
     mock_callback.assert_called_once()
 
@@ -185,7 +185,7 @@ def test_process_pinpoint_results_should_update_notification_status_with_deliver
         reference=test_reference,
         sent_at=datetime.datetime.utcnow(),
         status=status,
-        status_reason='' if (status == NOTIFICATION_DELIVERED) else 'just because',
+        status_reason=None if (status == NOTIFICATION_DELIVERED) else 'just because',
     )
     process_pinpoint_receipt_tasks.process_pinpoint_results(
         response=pinpoint_notification_callback_record(
@@ -196,7 +196,7 @@ def test_process_pinpoint_results_should_update_notification_status_with_deliver
     )
     notification = notifications_dao.dao_get_notification_by_reference(test_reference)
     assert notification.status == NOTIFICATION_DELIVERED
-    assert not notification.status_reason, 'The status reason should be the empty string.'
+    assert notification.status_reason is None
 
     update_notification_status.assert_not_called()
 
@@ -242,7 +242,7 @@ def test_process_pinpoint_results_segments_and_price_buffered_first(
     assert notification.status == NOTIFICATION_DELIVERED
     assert notification.segments_count == 6
     assert notification.cost_in_millicents == 4986.0
-    assert not notification.status_reason, 'The status reason should be the empty string.'
+    assert notification.status_reason is None
 
     # A subsequent _SMS.SUCCESS+DELIVERED event should not alter the segments and price columns.
     process_pinpoint_receipt_tasks.process_pinpoint_results(
@@ -259,7 +259,7 @@ def test_process_pinpoint_results_segments_and_price_buffered_first(
     assert notification.status == NOTIFICATION_DELIVERED
     assert notification.segments_count == 6
     assert notification.cost_in_millicents == 4986.0
-    assert not notification.status_reason, 'The status reason should be the empty string.'
+    assert notification.status_reason is None
 
 
 def test_process_pinpoint_results_segments_and_price_success_first(
@@ -294,7 +294,7 @@ def test_process_pinpoint_results_segments_and_price_success_first(
     assert notification.status == NOTIFICATION_DELIVERED
     assert notification.segments_count == 4
     assert notification.cost_in_millicents == 2986.0
-    assert not notification.status_reason, 'The status reason should be the empty string.'
+    assert notification.status_reason is None
 
 
 def pinpoint_notification_callback_record(

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -37,18 +37,31 @@ from tests.app.db import (
 )
 
 
-def test_process_ses_results(sample_template, sample_notification):
+def test_process_ses_results(notify_db_session, sample_template, sample_notification):
     template = sample_template(template_type=EMAIL_TYPE)
     ref = str(uuid4())
-    sample_notification(template=template, reference=ref, sent_at=datetime.utcnow(), status='sending')
+
+    notification = sample_notification(
+        template=template,
+        reference=ref,
+        sent_at=datetime.utcnow(),
+        status=NOTIFICATION_SENDING,
+        status_reason='just because',
+    )
+    assert notification.status == NOTIFICATION_SENDING
+    assert notification.status_reason == 'just because'
 
     assert process_ses_receipts_tasks.process_ses_results(response=ses_notification_callback(reference=ref))
+
+    notify_db_session.session.refresh(notification)
+    assert notification.status == NOTIFICATION_DELIVERED
+    assert not notification.status_reason, 'This should be the empty string.'
 
 
 def test_process_ses_results_retry_called(mocker, sample_template, sample_notification):
     template = sample_template(template_type=EMAIL_TYPE)
     ref = str(uuid4())
-    sample_notification(template=template, reference=ref, sent_at=datetime.utcnow(), status='sending')
+    sample_notification(template=template, reference=ref, sent_at=datetime.utcnow(), status=NOTIFICATION_SENDING)
 
     mocker.patch('app.dao.notifications_dao._update_notification_status', side_effect=Exception('EXPECTED'))
     mocked = mocker.patch('app.celery.process_ses_receipts_tasks.process_ses_results.retry')
@@ -90,7 +103,7 @@ def test_ses_callback_should_call_send_delivery_status_to_service(
 
     template = sample_template(template_type=EMAIL_TYPE)
     ref = str(uuid4())
-    notification = sample_notification(template=template, status='sending', reference=ref)
+    notification = sample_notification(template=template, status=NOTIFICATION_SENDING, reference=ref)
 
     service_callback = create_service_callback_api(service=template.service, url='https://original_url.com')
 
@@ -116,7 +129,7 @@ def test_wt_ses_callback_should_log_total_time(
         mocker.patch('app.celery.service_callback_tasks.check_and_queue_callback_task')
         ref = str(uuid4())
 
-        notification = sample_notification(template=template, status='sending', reference=ref)
+        notification = sample_notification(template=template, status=NOTIFICATION_SENDING, reference=ref)
         # Mock db call
         mocker.patch(
             'app.dao.notifications_dao.dao_get_notification_by_reference',
@@ -344,7 +357,7 @@ def test_ses_callback_does_not_call_send_delivery_status_if_no_db_entry(
     with freeze_time('2001-01-01T12:00:00'):
         ref = str(uuid4())
         send_mock = mocker.patch('app.celery.service_callback_tasks.send_delivery_status_to_service.apply_async')
-        notification_id = sample_notification(template=template, status='sending', reference=ref).id
+        notification_id = sample_notification(template=template, status=NOTIFICATION_SENDING, reference=ref).id
 
         assert process_ses_receipts_tasks.process_ses_results(ses_notification_callback(reference=ref))
         # The ORM does not update the notification object for some reason, so query it again (only affects tests)
@@ -364,17 +377,17 @@ def test_ses_callback_should_update_multiple_notification_status_sent(
     template = sample_template(template_type=EMAIL_TYPE)
     sample_notification(
         template=template,
-        status='sending',
+        status=NOTIFICATION_SENDING,
         reference='ref1',
     )
     sample_notification(
         template=template,
-        status='sending',
+        status=NOTIFICATION_SENDING,
         reference='ref2',
     )
     sample_notification(
         template=template,
-        status='sending',
+        status=NOTIFICATION_SENDING,
         reference='ref3',
     )
     create_service_callback_api(service=template.service, url='https://original_url.com')
@@ -583,7 +596,7 @@ def get_complaint_notification_and_email(mocker):
         service=template.service,
         template_id=template.id,
         template=template,
-        status='sending',
+        status=NOTIFICATION_SENDING,
         reference='ref1',
     )
     complaint = mocker.Mock(

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1636,7 +1636,7 @@ def test_dao_update_notifications_by_reference_updated_notifications(
     for notification_id in (notification_1.id, notification_2.id):
         updated_notification = notify_db_session.session.get(Notification, notification_id)
         assert updated_notification.status == NOTIFICATION_DELIVERED
-        assert updated_notification.status_reason == ''
+        assert not updated_notification.status_reason, 'This should be the empty string.'
         assert updated_notification.billable_units == 2
 
 

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -2046,8 +2046,8 @@ def test_update_notification_status_by_id_can_update_status_in_order_when_given_
     use_current_status,
 ):
     reference = str(uuid4())
-    initial_status_reason = '' if (current_status == NOTIFICATION_DELIVERED) else 'Because I said so!'
-    final_status_reason = initial_status_reason if (next_status == current_status) else 'just because'
+    initial_status_reason = 'Because I said so!'
+    final_status_reason = 'just because'
 
     notification = sample_notification(
         template=sample_template(),

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -18,6 +18,7 @@ from app.dao.notifications_dao import (
     dao_get_scheduled_notifications,
     dao_timeout_notifications,
     dao_update_notification,
+    dao_update_notification_by_id,
     dao_update_notifications_by_reference,
     delete_notifications_older_than_retention_by_type,
     get_notification_by_id,
@@ -1616,24 +1617,27 @@ def test_dao_update_notifications_by_reference_updated_notifications(
     sample_template,
     sample_notification,
 ):
-    ref_0 = str(uuid4())
-    ref_1 = str(uuid4())
     template = sample_template()
-    notification_1 = sample_notification(template=template, reference=ref_0)
-    notification_2 = sample_notification(template=template, reference=ref_1)
+    notification_1 = sample_notification(
+        template=template, reference=str(uuid4()), status=NOTIFICATION_CREATED, status_reason='just because'
+    )
+    notification_2 = sample_notification(
+        template=template, reference=str(uuid4()), status=NOTIFICATION_CREATED, status_reason='just because'
+    )
 
     updated_count, updated_history_count = dao_update_notifications_by_reference(
-        references=[ref_0, ref_1], update_dict={'status': 'delivered', 'billable_units': 2}
+        references=(notification_1.reference, notification_2.reference),
+        update_dict={'status': NOTIFICATION_DELIVERED, 'status_reason': '', 'billable_units': 2}
     )
-    assert updated_count == 2
-    updated_1 = notify_db_session.session.get(Notification, notification_1.id)
-    assert updated_1.billable_units == 2
-    assert updated_1.status == 'delivered'
-    updated_2 = notify_db_session.session.get(Notification, notification_2.id)
-    assert updated_2.billable_units == 2
-    assert updated_2.status == 'delivered'
 
+    assert updated_count == 2
     assert updated_history_count == 0
+
+    for notification_id in (notification_1.id, notification_2.id):
+        updated_notification = notify_db_session.session.get(Notification, notification_id)
+        assert updated_notification.status == NOTIFICATION_DELIVERED
+        assert updated_notification.status_reason == ''
+        assert updated_notification.billable_units == 2
 
 
 def test_dao_update_notifications_by_reference_updates_history_some_notifications_exist(
@@ -1648,7 +1652,7 @@ def test_dao_update_notifications_by_reference_updates_history_some_notification
     sample_notification_history(template=template, reference=ref_1)
 
     updated_count, updated_history_count = dao_update_notifications_by_reference(
-        references=[ref_0, ref_1], update_dict={'status': 'delivered', 'billable_units': 2}
+        references=[ref_0, ref_1], update_dict={'status': NOTIFICATION_DELIVERED, 'billable_units': 2}
     )
     assert updated_count == 1
     assert updated_history_count == 1
@@ -2025,6 +2029,7 @@ def test_update_notification_status_by_id_cannot_update_status_out_of_order_with
     assert notification.status == current_status
 
 
+@pytest.mark.parametrize('use_current_status', (True, False))
 @pytest.mark.parametrize(
     'current_status, next_status',
     [
@@ -2034,39 +2039,42 @@ def test_update_notification_status_by_id_cannot_update_status_out_of_order_with
     ],
 )
 def test_update_notification_status_by_id_can_update_status_in_order_when_given_valid_values(
-    current_status,
-    next_status,
     sample_notification,
     sample_template,
+    current_status,
+    next_status,
+    use_current_status,
 ):
-    reference_tuple = (str(uuid4()), str(uuid4()))
-    notification_list = []
+    reference = str(uuid4())
+    initial_status_reason = '' if (current_status == NOTIFICATION_DELIVERED) else 'Because I said so!'
+    final_status_reason = initial_status_reason if (next_status == current_status) else 'just because'
 
-    for ref in reference_tuple:
-        # create first notification object
-        sample_notification(template=sample_template(), reference=ref, sent_at=datetime.now(), status=current_status)
-
-        # add the notification object to the notification list
-        notification_list.append(dao_get_notification_by_reference(ref))
-
-        # make sure we pass all the init setup
-        i = len(notification_list) - 1
-        assert isinstance(notification_list[i], Notification)
-        assert notification_list[i].status == current_status
-
-    # attempt update without the condition current state
-    update_notification_status_by_id(notification_id=notification_list[0].id, status=next_status)
-
-    # attempt update with the conditional current state
-    update_notification_status_by_id(
-        notification_id=notification_list[1].id, status=next_status, current_status=current_status
+    notification = sample_notification(
+        template=sample_template(),
+        reference=reference,
+        sent_at=datetime.now(),
+        status=current_status,
+        status_reason=initial_status_reason
     )
+    assert notification.status == current_status
+    assert notification.status_reason == initial_status_reason
 
-    # get the notification object and make sure the values have changed
-    for ref in reference_tuple:
-        notification = dao_get_notification_by_reference(ref)
-        assert isinstance(notification, Notification)
-        assert notification.status == next_status
+    if use_current_status:
+        update_notification_status_by_id(
+            notification_id=notification.id,
+            status=next_status,
+            status_reason=final_status_reason,
+            current_status=current_status
+        )
+    else:
+        update_notification_status_by_id(
+            notification_id=notification.id, status=next_status, status_reason=final_status_reason
+        )
+
+    notification = dao_get_notification_by_reference(reference)
+    assert isinstance(notification, Notification)
+    assert notification.status == next_status
+    assert notification.status_reason == final_status_reason
 
 
 @pytest.mark.parametrize(
@@ -2107,19 +2115,26 @@ def test_update_notification_delivery_status_valid_updates(
     current_status,
     new_status,
 ):
+    initial_status_reason = '' if (current_status == NOTIFICATION_DELIVERED) else 'Because I said so!'
+    final_status_reason = initial_status_reason if (new_status == current_status) else 'just because'
+
     notification = sample_notification(
         template=sample_template(),
         status=current_status,
+        status_reason=initial_status_reason,
     )
 
     assert notification.status == current_status
+    assert notification.status_reason == initial_status_reason
 
     update_notification_delivery_status(
         notification_id=notification.id,
         new_status=new_status,
+        new_status_reason=final_status_reason,
     )
 
     assert notification.status == new_status
+    assert notification.status_reason == final_status_reason
 
 
 @pytest.mark.parametrize(
@@ -2149,16 +2164,69 @@ def test_update_notification_delivery_status_invalid_updates(
     current_status,
     new_status,
 ):
+    status_reason = '' if (current_status == NOTIFICATION_DELIVERED) else 'Because I said so!'
+
     notification = sample_notification(
         template=sample_template(),
         status=current_status,
+        status_reason=status_reason,
     )
 
     assert notification.status == current_status
+    assert notification.status_reason == status_reason
 
     update_notification_delivery_status(
         notification_id=notification.id,
         new_status=new_status,
+    )
+
+    assert notification.status != new_status
+    assert notification.status_reason == status_reason
+
+
+@pytest.mark.parametrize(
+    'current_status, new_status',
+    [
+        (NOTIFICATION_TEMPORARY_FAILURE, NOTIFICATION_CREATED),
+        (NOTIFICATION_TEMPORARY_FAILURE, NOTIFICATION_SENDING),
+        (NOTIFICATION_TEMPORARY_FAILURE, NOTIFICATION_PENDING),
+        (NOTIFICATION_SENT, NOTIFICATION_CREATED),
+        (NOTIFICATION_SENT, NOTIFICATION_SENDING),
+        (NOTIFICATION_SENT, NOTIFICATION_PENDING),
+        (NOTIFICATION_DELIVERED, NOTIFICATION_CREATED),
+        (NOTIFICATION_DELIVERED, NOTIFICATION_SENDING),
+        (NOTIFICATION_DELIVERED, NOTIFICATION_PENDING),
+        (NOTIFICATION_DELIVERED, NOTIFICATION_TEMPORARY_FAILURE),
+        (NOTIFICATION_DELIVERED, NOTIFICATION_SENT),
+        (NOTIFICATION_PERMANENT_FAILURE, NOTIFICATION_CREATED),
+        (NOTIFICATION_PERMANENT_FAILURE, NOTIFICATION_SENDING),
+        (NOTIFICATION_PERMANENT_FAILURE, NOTIFICATION_PENDING),
+        (NOTIFICATION_PERMANENT_FAILURE, NOTIFICATION_TEMPORARY_FAILURE),
+        (NOTIFICATION_PERMANENT_FAILURE, NOTIFICATION_SENT),
+    ],
+)
+def test_dao_update_notification_by_id(
+    sample_template,
+    sample_notification,
+    current_status,
+    new_status,
+):
+    initial_status_reason = '' if (current_status == NOTIFICATION_DELIVERED) else 'Because I said so!'
+    final_status_reason = initial_status_reason if (new_status == current_status) else 'just because'
+
+    notification = sample_notification(
+        template=sample_template(),
+        status=current_status,
+        status_reason=initial_status_reason,
+    )
+
+    assert notification.status == current_status
+    assert notification.status_reason == initial_status_reason
+
+    dao_update_notification_by_id(
+        notification_id=notification.id,
+        status=new_status,
+        status_reason=final_status_reason,
     )
 
     assert notification.status != new_status

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1627,7 +1627,7 @@ def test_dao_update_notifications_by_reference_updated_notifications(
 
     updated_count, updated_history_count = dao_update_notifications_by_reference(
         references=(notification_1.reference, notification_2.reference),
-        update_dict={'status': NOTIFICATION_DELIVERED, 'status_reason': '', 'billable_units': 2}
+        update_dict={'status': NOTIFICATION_DELIVERED, 'status_reason': '', 'billable_units': 2},
     )
 
     assert updated_count == 2
@@ -2054,7 +2054,7 @@ def test_update_notification_status_by_id_can_update_status_in_order_when_given_
         reference=reference,
         sent_at=datetime.now(),
         status=current_status,
-        status_reason=initial_status_reason
+        status_reason=initial_status_reason,
     )
     assert notification.status == current_status
     assert notification.status_reason == initial_status_reason
@@ -2064,7 +2064,7 @@ def test_update_notification_status_by_id_can_update_status_in_order_when_given_
             notification_id=notification.id,
             status=next_status,
             status_reason=final_status_reason,
-            current_status=current_status
+            current_status=current_status,
         )
     else:
         update_notification_status_by_id(


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

These changes ensure that a notification's "status reason" is always the empty string when the status is "delivered."

The underlying ticket cited a problem without an explicit way to reproduce it, so I went looking for problems.  These changes cover all code paths as far as I can tell without a specific problem to fix.

issue #2011

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

This is not easy to test because I don't know how to force providers to return a particular status.  I'm relying heavily on unit tests.

- [x] new and modified unit tests pass
- [x] Send myself a text message, reply with STOP, and see that the status reason of the delivered message isn't overwritten with the "opted-out" blurb.  See the full documentation of my testing [here](https://github.com/department-of-veterans-affairs/notification-api/issues/2011#issuecomment-2397743760).

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
