### PR TITLE
#2012 - Update Callback Logic for Notification Level Callback URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,11 @@ var/
 *.manifest
 *.spec
 
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+.python-version
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
@@ -80,7 +85,6 @@ celerybeat-schedule
 .cf
 
 /scripts/run_my_tests.sh
-.vscode
 
 # Terraform
 .terraform
@@ -89,6 +93,7 @@ celerybeat-schedule
 user_flows_exit_code.txt
 
 # These files can get written in the notification_api directory if you run bash commands on a container with read-write access.
+.ash_history
 .bash_history
 .python_history
 

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,38 +1,42 @@
 fileignoreconfig:
-  - filename: README.md
-    checksum: b2cbbb8508af49abccae8b35b317f7ce09215f3508430ed31440add78f450e5a
-  - filename: app/celery/contact_information_tasks.py
-    checksum: 80d0acf88bafb1358583016b9e143f4523ef1160d6eacdc9754ca68859b90eae
-  - filename: app/notifications/process_notifications.py
-    checksum: ae4e31c6eb56d91ec80ae09d13baf4558cf461c65f08893b93fee43f036a17a7
-  - filename: app/service/rest.py
-    checksum: b42aefd1ae0e6ea76e75db4cf14d425facd0941943b17f7ba2e41f850ad1ec23
-  - filename: app/template/rest.py
-    checksum: 1e5bdac8bc694d50f8f656dec127dd036b7b1b5b6156e3282d3411956c71ba0b
-  - filename: lambda_functions/pinpoint_callback/pinpoint_callback_lambda.py
-    checksum: 7bd4900e14b1fa789bbb2568b8a8d7a400e3c8350ba32fb44cc0b5b66a2df037
-  - filename: lambda_functions/ses_callback/ses_callback_lambda.py
-    checksum: b20c36921290a9609f158784e2a3278c36190887e6054ea548004a67675fd79b
-  - filename: poetry.lock
-    checksum: 34d12acdf749363555c31add4e7e7afa9e2a27afd792bd98c85f331b87bd7112
-  - filename: scripts/trigger_task.py
-    checksum: 0e9d244dbe285de23fc84bb643407963dacf7d25a3358373f01f6272fb217778
-  - filename: tests/app/celery/test_process_ga4_measurement_task.py
-    checksum: d33a6911258922f4bd3d149c90c2ee16c021a8e59e462594e4b1cd972902d689
-  - filename: tests/app/conftest.py
-    checksum: a80aa727586db82ed1b50bdb81ddfe1379e649a9dfc1ece2c36047486b41b83d
-  - filename: tests/app/notifications/test_process_notifications_for_profile_v3.py
-    checksum: 4e15e63d349635131173ffdd7aebcd547621db08de877ef926d3a41fde72d065
-  - filename: tests/app/v2/notifications/test_post_notifications.py
-    checksum: 3181930a13e3679bb2f17eaa3f383512eb9caf4ed5d5e14496ca4193c6083965
-  - filename: tests/app/callback/test_webhook_callback_strategy.py
-    checksum: 288841d3209dc3ca885cd0bb08591221f7f15e5b3406fb7140505096db212554
-  - filename: app/callback/webhook_callback_strategy.py
-    checksum: 47846ab651c27512d3ac7864c08cb25d647f63bb84321953f907551fd9d2e85f
-  - filename: app/dao/api_key_dao.py
-    checksum: ab93313f306c8a3f6576141e8f32d9fc99b0de7da8d44a1ddbe6ea55d167dcdb
-  - filename: ci/docker-compose-test.yml
-    checksum: e3efec2749e8c19e60f5bfc68eafabe24eba647530a482ceccfc4e0e62cff424
-  - filename: cd/application-deployment/dev/vaec-api-task-definition.json
-    checksum: f328ff821339b802eb1d82559e624d5b719857c813d427da5aaa39b240331ddd
+- filename: README.md
+  checksum: b2cbbb8508af49abccae8b35b317f7ce09215f3508430ed31440add78f450e5a
+- filename: app/callback/webhook_callback_strategy.py
+  checksum: 47846ab651c27512d3ac7864c08cb25d647f63bb84321953f907551fd9d2e85f
+- filename: app/celery/contact_information_tasks.py
+  checksum: 80d0acf88bafb1358583016b9e143f4523ef1160d6eacdc9754ca68859b90eae
+- filename: app/celery/service_callback_tasks.py
+  checksum: b1d6fd97cdaebbadf80a7dd7798940c90ddec13e9af51fed6411e366ad735f41
+- filename: app/dao/api_key_dao.py
+  checksum: ab93313f306c8a3f6576141e8f32d9fc99b0de7da8d44a1ddbe6ea55d167dcdb
+- filename: app/notifications/process_notifications.py
+  checksum: ae4e31c6eb56d91ec80ae09d13baf4558cf461c65f08893b93fee43f036a17a7
+- filename: app/service/rest.py
+  checksum: b42aefd1ae0e6ea76e75db4cf14d425facd0941943b17f7ba2e41f850ad1ec23
+- filename: app/template/rest.py
+  checksum: 1e5bdac8bc694d50f8f656dec127dd036b7b1b5b6156e3282d3411956c71ba0b
+- filename: cd/application-deployment/dev/vaec-api-task-definition.json
+  checksum: f328ff821339b802eb1d82559e624d5b719857c813d427da5aaa39b240331ddd
+- filename: ci/docker-compose-test.yml
+  checksum: e3efec2749e8c19e60f5bfc68eafabe24eba647530a482ceccfc4e0e62cff424
+- filename: lambda_functions/pinpoint_callback/pinpoint_callback_lambda.py
+  checksum: 7bd4900e14b1fa789bbb2568b8a8d7a400e3c8350ba32fb44cc0b5b66a2df037
+- filename: lambda_functions/ses_callback/ses_callback_lambda.py
+  checksum: b20c36921290a9609f158784e2a3278c36190887e6054ea548004a67675fd79b
+- filename: poetry.lock
+  checksum: 34d12acdf749363555c31add4e7e7afa9e2a27afd792bd98c85f331b87bd7112
+- filename: scripts/trigger_task.py
+  checksum: 0e9d244dbe285de23fc84bb643407963dacf7d25a3358373f01f6272fb217778
+- filename: tests/app/callback/test_webhook_callback_strategy.py
+  checksum: 288841d3209dc3ca885cd0bb08591221f7f15e5b3406fb7140505096db212554
+- filename: tests/app/celery/test_process_ga4_measurement_task.py
+  checksum: d33a6911258922f4bd3d149c90c2ee16c021a8e59e462594e4b1cd972902d689
+- filename: tests/app/celery/test_service_callback_tasks.py
+  checksum: be1cf7706106bbf7778e26772f4a771c32bb2a9b81bcca7f9b2566e6b5ac520d
+- filename: tests/app/conftest.py
+  checksum: a80aa727586db82ed1b50bdb81ddfe1379e649a9dfc1ece2c36047486b41b83d
+- filename: tests/app/notifications/test_process_notifications_for_profile_v3.py
+  checksum: 4e15e63d349635131173ffdd7aebcd547621db08de877ef926d3a41fde72d065
+- filename: tests/app/v2/notifications/test_post_notifications.py
+  checksum: 3181930a13e3679bb2f17eaa3f383512eb9caf4ed5d5e14496ca4193c6083965
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -32,7 +32,7 @@ fileignoreconfig:
 - filename: tests/app/celery/test_process_ga4_measurement_task.py
   checksum: 6ffb8742a19c5b834c608826fd459cc1b6ea35ebfffd2d929a3a0f269c74183d
 - filename: tests/app/celery/test_service_callback_tasks.py
-  checksum: be1cf7706106bbf7778e26772f4a771c32bb2a9b81bcca7f9b2566e6b5ac520d
+  checksum: 70575434f7a4fedd43d4c9164bc899a606768526d432c364db372524eec26542
 - filename: tests/app/conftest.py
   checksum: a80aa727586db82ed1b50bdb81ddfe1379e649a9dfc1ece2c36047486b41b83d
 - filename: tests/app/notifications/test_process_notifications_for_profile_v3.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -6,7 +6,7 @@ fileignoreconfig:
 - filename: app/celery/contact_information_tasks.py
   checksum: 80d0acf88bafb1358583016b9e143f4523ef1160d6eacdc9754ca68859b90eae
 - filename: app/celery/service_callback_tasks.py
-  checksum: b1d6fd97cdaebbadf80a7dd7798940c90ddec13e9af51fed6411e366ad735f41
+  checksum: 83b61b21668c1b1a0ea33a4c3130e82c9b14edbd6542079f1dd3d7493f3e9a79
 - filename: app/dao/api_key_dao.py
   checksum: ab93313f306c8a3f6576141e8f32d9fc99b0de7da8d44a1ddbe6ea55d167dcdb
 - filename: app/notifications/process_notifications.py

--- a/app/callback/README.md
+++ b/app/callback/README.md
@@ -1,4 +1,13 @@
-## Callbacks
+# Callbacks
+
+> [!Note]
+> SQS callbacks are not supported at this time, as of 2024. The permissions around setting them up is tricky and makes for a bad experience for our clients.
+
+## Notification Level Callbacks
+
+Clients can send a `callback_url` with their notification request. They will then receive callbacks for notification updates to the specified endpoint.
+
+## Service Level Callbacks
 
 Can configure callbacks to be sent either via queue or webhook.
 

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -435,7 +435,8 @@ def send_delivery_status_from_notification(
 
 def check_and_queue_notification_callback_task(notification: Notification) -> None:
     """
-    When a callback URL is included in the notification, collect the required information and queue a task to send the callback.
+    When a callback URL is included in the notification, collect the required information and
+    queue a task to send the callback.
 
     Args:
         notification (Notification): Notification object

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -433,7 +433,13 @@ def send_delivery_status_from_notification(
     )
 
 
-def check_and_queue_notification_callback_task(notification: Notification, payload=None) -> None:
+def check_and_queue_notification_callback_task(notification: Notification) -> None:
+    """
+    When a callback URL is included in the notification, collect the required information and queue a task to send the callback.
+
+    Args:
+        notification (Notification): Notification object
+    """
     notification_data = create_delivery_status_callback_data_v3(notification)
 
     callback_signature = generate_callback_signature(notification.api_key_id, notification_data)
@@ -446,10 +452,18 @@ def check_and_queue_notification_callback_task(notification: Notification, paylo
 
 def check_and_queue_callback_task(
     notification: Notification,
-    payload=None,
+    payload: dict[str, str] | None = None,
 ):
+    """
+    Check if a callback url is included in the notification and call the appropriate funcation to queue the callback.
+
+    Args:
+        notification (Notification): a Notification object which includes the callback information
+        payload (dict[str, str]): the payload from the provider to include in the callback if the service requires it
+    """
     if notification.callback_url:
-        check_and_queue_notification_callback_task(notification, payload)
+        # payload is not passed here because the service callback indicates whether the payload should be included
+        check_and_queue_notification_callback_task(notification)
     else:
         check_and_queue_service_callback_task(notification, payload)
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -271,6 +271,7 @@ def replay_service_callbacks(
     service_id,
     notification_status,
 ):
+    # not updated for notification callback_url as it doesn't appear to be used
     print('Start send service callbacks for service: ', service_id)
     callback_api = get_service_delivery_status_callback_api_for_service(
         service_id=service_id, notification_status=notification_status

--- a/app/internal/rest.py
+++ b/app/internal/rest.py
@@ -36,7 +36,7 @@ def handler(generic):
           data. The status code is always 200.
 
     """
-    status_code = 200
+    status_code = 500
     request_attrs = (
         'method',
         'root_path',

--- a/app/internal/rest.py
+++ b/app/internal/rest.py
@@ -36,7 +36,7 @@ def handler(generic):
           data. The status code is always 200.
 
     """
-    status_code = 500
+    status_code = 200
     request_attrs = (
         'method',
         'root_path',

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -630,8 +630,8 @@ def test_send_delivery_status_from_notification_posts_https_request_to_service(r
     assert rmock.request_history[0].text == json.dumps(notification_data)
 
 
-@pytest.mark.parametrize('status_code', [429, 500, 502, 503, 504])
-def test_send_delivery_status_from_notification_raises_retryable_exception(rmock, status_code):
+@pytest.mark.parametrize('status_code', [429, 500, 502])
+def test_send_delivery_status_from_notification_raises_auto_retry_exception(rmock, status_code):
     callback_signature = '6842b32e800372de4079e20d6e7e753bad182e44f7f3e19a46fd8509889a0014'
     callback_url = 'https://test_url.com/'
     notification_data = {'callback_url': callback_url}
@@ -641,11 +641,12 @@ def test_send_delivery_status_from_notification_raises_retryable_exception(rmock
         send_delivery_status_from_notification(callback_signature, callback_url, notification_data)
 
 
-def test_send_delivery_status_from_notification_raises_non_retryable_exception(rmock):
+@pytest.mark.parametrize('status_code', [400, 403, 404])
+def test_send_delivery_status_from_notification_raises_non_retryable_exception(rmock, status_code):
     callback_signature = '6842b32e800372de4079e20d6e7e753bad182e44f7f3e19a46fd8509889a0014'
     callback_url = 'https://test_url.com/'
     notification_data = {'callback_url': callback_url}
 
-    rmock.post(callback_url, json=notification_data, status_code=400)
+    rmock.post(callback_url, json=notification_data, status_code=status_code)
     with pytest.raises(NonRetryableException):
         send_delivery_status_from_notification(callback_signature, callback_url, notification_data)

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from app import DATETIME_FORMAT, encryption
 from app.celery.exceptions import AutoRetryException, NonRetryableException
 from app.celery.service_callback_tasks import (
+    check_and_queue_notification_callback_task,
     send_complaint_to_service,
     send_complaint_to_vanotify,
     check_and_queue_callback_task,
@@ -264,28 +265,59 @@ def test_send_email_complaint_to_vanotify_fails(
     )
 
 
-def test_check_and_queue_callback_task_does_not_queue_task_if_service_callback_api_does_not_exist(
+def test_check_and_queue_callback_task_does_not_queue_task_if_callback_does_not_exist(
     notify_api,
     mocker,
+    sample_notification,
 ):
-    mock_notification = create_mock_notification(mocker)
+    mock_notification = sample_notification()
     mocker.patch(
         'app.celery.service_callback_tasks.get_service_delivery_status_callback_api_for_service', return_value=None
     )
-
     mock_send_delivery_status = mocker.patch(
         'app.celery.service_callback_tasks.send_delivery_status_to_service.apply_async'
+    )
+    mock_notification_callback = mocker.patch(
+        'app.celery.service_callback_tasks.check_and_queue_notification_callback_task'
     )
 
     check_and_queue_callback_task(mock_notification)
     mock_send_delivery_status.assert_not_called()
+    mock_notification_callback.assert_not_called()
+
+
+def test_check_and_queue_callback_task_queues_task_if_notification_callback_exists(
+    notify_api,
+    mocker,
+    sample_notification,
+):
+    notification = sample_notification(callback_url='https://test.com')
+    mock_get_service_callback = mocker.patch(
+        'app.celery.service_callback_tasks.get_service_delivery_status_callback_api_for_service'
+    )
+    mock_send_delivery_status = mocker.patch(
+        'app.celery.service_callback_tasks.send_delivery_status_to_service.apply_async'
+    )
+    mock_notification_callback = mocker.patch(
+        'app.celery.service_callback_tasks.check_and_queue_notification_callback_task'
+    )
+
+    check_and_queue_callback_task(notification)
+
+    # service level callback is not needed
+    mock_get_service_callback.assert_not_called()
+    mock_send_delivery_status.assert_not_called()
+
+    # notification level callback called
+    mock_notification_callback.assert_called_once_with(notification, None)
 
 
 def test_check_and_queue_callback_task_queues_task_if_service_callback_api_exists(
     notify_api,
     mocker,
+    sample_notification,
 ):
-    mock_notification = create_mock_notification(mocker)
+    mock_notification = sample_notification()
     mock_service_callback_api = mocker.Mock(ServiceCallback)
     mock_notification_data = mocker.Mock()
 
@@ -377,13 +409,6 @@ def get_complaint_notification_and_email(mocker):
         created_at=datetime.now(),
     )
     return complaint, notification, 'recipient1@example.com'
-
-
-def create_mock_notification(mocker):
-    notification = mocker.Mock(Notification)
-    notification.id = uuid.uuid4()
-    notification.service_id = uuid.uuid4()
-    return notification
 
 
 def _set_up_test_data(
@@ -556,3 +581,34 @@ def test_create_delivery_status_callback_data_v3(
     assert data['status_reason'] == notification.status_reason
     assert data['provider'] == notification.sent_by
     assert data['provider_payload'] is None
+
+
+def test_check_and_queue_notification_callback_task_queues_task_with_proper_data(mocker, sample_notification):
+    test_url = 'https://test_url.com'
+    notification = sample_notification(callback_url=test_url)
+
+    notification_data = {'callback_url': test_url}
+    callback_signature_value = '6842b32e800372de4079e20d6e7e753bad182e44f7f3e19a46fd8509889a0014'
+
+    mocker.patch(
+        'app.celery.service_callback_tasks.create_delivery_status_callback_data_v3',
+        return_value=notification_data,
+    )
+    mocker.patch(
+        'app.celery.service_callback_tasks.generate_callback_signature',
+        return_value='6842b32e800372de4079e20d6e7e753bad182e44f7f3e19a46fd8509889a0014',
+    )
+    mock_delivery_status_from_notification = mocker.patch(
+        'app.celery.service_callback_tasks.send_delivery_status_from_notification.apply_async'
+    )
+
+    check_and_queue_notification_callback_task(notification, None)
+
+    # mock_create_callback_data.assert_called_once_with(notification, None, {})
+    # mock_send_delivery_status.assert_called_once_with(
+    #     [None, str(notification.id), 'encrypted_data'], queue=QueueNames.CALLBACKS
+    # )
+    mock_delivery_status_from_notification.assert_called_once_with(
+        [callback_signature_value, test_url, notification_data],
+        queue=QueueNames.CALLBACKS,
+    )

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -310,7 +310,7 @@ def test_check_and_queue_callback_task_queues_task_if_notification_callback_exis
     mock_send_delivery_status.assert_not_called()
 
     # notification level callback called
-    mock_notification_callback.assert_called_once_with(notification, None)
+    mock_notification_callback.assert_called_once_with(notification)
 
 
 def test_check_and_queue_callback_task_queues_task_if_service_callback_api_exists(
@@ -603,7 +603,7 @@ def test_check_and_queue_notification_callback_task_queues_task_with_proper_data
         'app.celery.service_callback_tasks.send_delivery_status_from_notification.apply_async'
     )
 
-    check_and_queue_notification_callback_task(notification, None)
+    check_and_queue_notification_callback_task(notification)
 
     # mock_create_callback_data.assert_called_once_with(notification, None, {})
     # mock_send_delivery_status.assert_called_once_with(

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -605,10 +605,6 @@ def test_check_and_queue_notification_callback_task_queues_task_with_proper_data
 
     check_and_queue_notification_callback_task(notification)
 
-    # mock_create_callback_data.assert_called_once_with(notification, None, {})
-    # mock_send_delivery_status.assert_called_once_with(
-    #     [None, str(notification.id), 'encrypted_data'], queue=QueueNames.CALLBACKS
-    # )
     mock_delivery_status_from_notification.assert_called_once_with(
         [callback_signature_value, test_url, notification_data],
         queue=QueueNames.CALLBACKS,


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This work is connecting the pieces together for sending notification level callbacks. The app will now send callbacks to the endpoint indicated in the `callback_url` field when making a request by default. If there's nothing included in the `callback_url` field, it will default to the previous behavior.

issue #2012 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- [x] Added new unit tests
- [x] Deployed to dev and sent callback to our internal endpoint

Logs captured from notification callback tests: (formatted for easier reading)
Debug log when successfully sending callback
```
Callback successfully sent for notification 8dd31563-0a11-4a3c-8a1e-2664958a4e2f,
url: https://dev.api.notifications.va.gov/internal/callback-test | status code: 200
```

POST response from internal endpoint
```
2024-10-10T19:50:11 app app INFO None 
"Generic Internal Request: METHOD: POST 
| ROOT_PATH:  
| PATH: /internal/callback-test 
| QUERY_STRING: b'' 
| URL_RULE: /internal/<generic> 
| TRACE_ID: None 
| JSON: {'id': '8dd31563-0a11-4a3c-8a1e-2664958a4e2f', 'reference': None, 'to': 'evan@email', 'status': 'delivered', 'created_at': '2024-10-10T19:50:06.519910Z', 'completed_at': '2024-10-10T19:50:11.274349Z', 'sent_at': '2024-10-10T19:50:07.145803Z', 'notification_type': 'email', 'status_reason': None, 'provider': 'ses', 'provider_payload': None} 
| HEADERS: X-Forwarded-For: xxx.xxx.xxx.xxx, X-Forwarded-Proto: https, X-Forwarded-Port: 443, Host: dev.api.notifications.va.gov, X-Amzn-Trace-Id: Root=1-x-727b03e674cab6xxxxx, Content-Length: 352, User-Agent: python-requests/2.32.3, Accept-Encoding: gzip, deflate, Accept: */*, Content-Type: application/json, X-Enp-Signature: efb1c4d0a9af0df66166d256b9e6f978430207c2d9d6116882859ad40ec07e55" 
[in /app/app/internal/rest.py:53]
```

retrying on 500 response:
```
Task send-notification-delivery-status[7465e57a-4656-4b74-a8c2-abfa4b8621b8] 
retry: Retry in 563s: AutoRetryException(
  'Found HTTPError, autoretrying...', 
  HTTPError('500 Server Error: INTERNAL SERVER ERROR for url: https://dev.api.notifications.va.gov/internal/qa-automation-callback'), 
  ('500 Server Error: INTERNAL SERVER ERROR for url: https://dev.api.notifications.va.gov/internal/qa-automation-callback',))
```

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
