### PR TITLE
HOTFIX - Added status reason to Twilio delivery status

### DIFF
--- a/app/celery/process_delivery_status_result_tasks.py
+++ b/app/celery/process_delivery_status_result_tasks.py
@@ -2,7 +2,7 @@ from app.models import DELIVERY_STATUS_CALLBACK_TYPE, NOTIFICATION_DELIVERED
 from app.celery.common import log_notification_total_time
 from app.celery.service_callback_tasks import check_and_queue_callback_task
 from app.celery.process_pinpoint_inbound_sms import CeleryEvent
-
+from app.clients.sms import SmsStatusRecord
 from app.dao.notifications_dao import (
     dao_get_notification_by_reference,
     dao_update_notification_by_id,
@@ -58,27 +58,27 @@ def process_delivery_status(
     current_app.logger.info('retrieved delivery status body: %s', body)
 
     # get notification_platform_status
-    notification_platform_status: dict = _get_notification_platform_status(self, provider, body, sqs_message)
-
-    # get parameters from notification platform status
-    current_app.logger.info('Get Notification Parameters')
-    (
-        payload,
-        reference,
-        notification_status,
-        number_of_message_parts,
-        price_in_millicents_usd,
-    ) = _get_notification_parameters(notification_platform_status)
+    notification_platform_status: SmsStatusRecord = _get_notification_platform_status(self, provider, body, sqs_message)
+    current_app.logger.info(
+        'Processing Notification Delivery Status. | reference=%s | notification_status=%s | '
+        'number_of_message_parts=%s | price_in_millicents_usd=%s',
+        notification_platform_status.reference,
+        notification_platform_status.status,
+        notification_platform_status.message_parts,
+        notification_platform_status.price_millicents,
+    )
 
     # Retrieve the inbound message for this provider.  We are updating the status of the outbound message.
     notification, should_exit = attempt_to_get_notification(
-        reference, notification_status, self.request.retries * self.default_retry_delay
+        notification_platform_status.reference,
+        notification_platform_status.status,
+        self.request.retries * self.default_retry_delay,
     )
 
     if should_exit:
         current_app.logger.warning(
             'Updating notification: %s resulted in should_exit - event: %s',
-            notification.id if notification is not None else f'{reference} (aws ref)',
+            notification.id if notification is not None else f'{notification_platform_status.reference} (aws ref)',
             event,
         )
         return False
@@ -88,33 +88,37 @@ def process_delivery_status(
         current_app.logger.info(
             'Calculate Pricing: %s and update notification_status: %s with number_of_message_parts: %s for notification: %s',
             provider_name,
-            notification_status,
-            number_of_message_parts,
+            notification_platform_status.status,
+            notification_platform_status.message_parts,
             getattr(notification, 'id', 'unknown'),
         )
 
         _calculate_pricing_and_update_notification(
-            price_in_millicents_usd, notification, notification_status, number_of_message_parts
+            notification_platform_status.price_millicents,
+            notification,
+            notification_platform_status.status,
+            notification_platform_status.message_parts,
+            notification_platform_status.status_reason,
         )
 
         current_app.logger.info(
             '%s callback return status of %s for notification: %s',
             provider_name,
-            notification_status,
+            notification_platform_status.status,
             notification.id,
         )
 
         log_notification_total_time(
             notification.id,
             notification.created_at,
-            notification_status,
+            notification_platform_status.status,
             provider_name,
         )
 
         # check if payload is to be include in cardinal set in the service callback is (service_id, callback_type)
         if not _get_include_payload_status(self, notification):
-            payload = {}
-        check_and_queue_callback_task(notification, payload)
+            notification_platform_status.payload = {}
+        check_and_queue_callback_task(notification, notification_platform_status.payload)
         return True
     except Exception as e:
         # why are we here logging.warning indicate the step that was being performed
@@ -181,26 +185,12 @@ def check_notification_status(
     return False
 
 
-def _get_notification_parameters(notification_platform_status: dict) -> Tuple[str, str, str, int, float]:
-    """Get the payload, notification reference, notification status, etc from the notification_platform_status"""
-    payload = notification_platform_status.get('payload')
-    reference = notification_platform_status.get('reference')
-    notification_status = notification_platform_status.get('record_status')
-    number_of_message_parts = notification_platform_status.get('number_of_message_parts', 1)
-    price_in_millicents_usd = notification_platform_status.get('price_in_millicents_usd', 0.0)
-    current_app.logger.info(
-        'Processing Notification Delivery Status. | reference=%s | notification_status=%s | '
-        'number_of_message_parts=%s | price_in_millicents_usd=%s',
-        reference,
-        notification_status,
-        number_of_message_parts,
-        price_in_millicents_usd,
-    )
-    return payload, reference, notification_status, number_of_message_parts, price_in_millicents_usd
-
-
 def _calculate_pricing_and_update_notification(
-    price_in_millicents_usd: float, notification: Notification, notification_status: str, number_of_message_parts: int
+    price_in_millicents_usd: float,
+    notification: Notification,
+    notification_status: str,
+    number_of_message_parts: int,
+    status_reason: str = None,
 ):
     """
     Calculate pricing, and update the notification.
@@ -209,7 +199,9 @@ def _calculate_pricing_and_update_notification(
     current_app.logger.debug('Calculate pricing and update notification %s', notification.id)
 
     # Delivered messages should not have an associated reason.
-    status_reason = None if (notification_status == NOTIFICATION_DELIVERED) else notification.status_reason
+    status_reason = (
+        None if (notification_status == NOTIFICATION_DELIVERED) else status_reason or notification.status_reason
+    )
 
     if price_in_millicents_usd > 0.0:
         dao_update_notification_by_id(
@@ -236,7 +228,7 @@ def _get_notification_platform_status(
     current_app.logger.info('Get Notification Platform Status')
     notification_platform_status = None
     try:
-        notification_platform_status = provider.translate_delivery_status(body)
+        notification_platform_status: SmsStatusRecord = provider.translate_delivery_status(body)
     except (ValueError, KeyError) as e:
         current_app.logger.error('The event stream body could not be translated.')
         current_app.logger.exception(e)

--- a/app/celery/process_delivery_status_result_tasks.py
+++ b/app/celery/process_delivery_status_result_tasks.py
@@ -190,7 +190,7 @@ def _calculate_pricing_and_update_notification(
     notification: Notification,
     notification_status: str,
     number_of_message_parts: int,
-    status_reason: str = None,
+    incoming_status_reason: str = None,
 ):
     """
     Calculate pricing, and update the notification.
@@ -200,7 +200,9 @@ def _calculate_pricing_and_update_notification(
 
     # Delivered messages should not have an associated reason.
     status_reason = (
-        None if (notification_status == NOTIFICATION_DELIVERED) else status_reason or notification.status_reason
+        None
+        if (notification_status == NOTIFICATION_DELIVERED)
+        else incoming_status_reason or notification.status_reason
     )
 
     if price_in_millicents_usd > 0.0:

--- a/app/clients/sms/__init__.py
+++ b/app/clients/sms/__init__.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from app.clients import Client, ClientException
 
 
@@ -16,6 +18,16 @@ class SmsClientResponseException(ClientException):
         return 'Message {}'.format(self.message)
 
 
+@dataclass
+class SmsStatusRecord:
+    payload: str
+    reference: str
+    status: str
+    status_reason: str | None
+    message_parts: int = 1
+    price_millicents: float = 0.0
+
+
 class SmsClient(Client):
     """
     Base Sms client for sending smss.
@@ -32,5 +44,5 @@ class SmsClient(Client):
     def get_name(self):
         raise NotImplementedError('TODO Need to implement.')
 
-    def translate_delivery_status(self) -> dict:
+    def translate_delivery_status(self) -> SmsStatusRecord:
         raise NotImplementedError('TODO Need to implement.')

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -159,7 +159,7 @@ def _get_notification_status_update_statement(
     elif incoming_status == NOTIFICATION_TEMPORARY_FAILURE:
         kwargs['status'] = NOTIFICATION_TEMPORARY_FAILURE
 
-    if incoming_status_reason is not None:
+    if incoming_status_reason is not None or incoming_status == NOTIFICATION_DELIVERED:
         kwargs['status_reason'] = incoming_status_reason
 
     kwargs['updated_at'] = datetime.utcnow()

--- a/tests/app/celery/test_process_delivery_status_result_tasks.py
+++ b/tests/app/celery/test_process_delivery_status_result_tasks.py
@@ -308,7 +308,6 @@ def test_process_delivery_status_no_status_reason_for_delivered(
     sample_template,
     sample_notification,
     sample_delivery_status_result_message,
-    sample_notification_platform_status,
 ):
     """
     When a notification is updated to "delivered" status, its "status_reason" should be set to
@@ -319,12 +318,12 @@ def test_process_delivery_status_no_status_reason_for_delivered(
     # value causes the test to fail.
     notification = sample_notification(
         template=sample_template(),
-        reference='SMhardcodedKWM',
+        reference='SMyyy',
         sent_at=datetime.datetime.utcnow(),
         status=NOTIFICATION_SENT,
         status_reason='This is not the empty string.',
     )
-    assert notification.reference == 'SMhardcodedKWM'
+    assert notification.reference == 'SMyyy'
     assert notification.status == NOTIFICATION_SENT
     assert notification.status_reason
 
@@ -335,6 +334,6 @@ def test_process_delivery_status_no_status_reason_for_delivered(
     callback_mock.assert_called_once()
 
     notify_db_session.session.refresh(notification)
-    assert notification.reference == 'SMhardcodedKWM'
+    assert notification.reference == 'SMyyy'
     assert notification.status == NOTIFICATION_DELIVERED
     assert notification.status_reason is None


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Saw many messages end up in a permanent failure or technical failure status with no status reason. This should not happen. Adjusted Twilio's delivery status to correctly fill that information in.

There was a bug with updating status_reason to None when a notification is put in the delivered status.
`if incoming_status_reason is not None` led to it ignoring the updated status_reason. The test mocked it out and the mock has been removed.

issue #N/A

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->
Updated tests. Regression [passes](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/11335358817).


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change
