### PR TITLE
TEAM-1379 - Modify datadog dockerfile and workflow to take version tag as input

### DIFF
--- a/.github/workflows/update-datadog-image.yaml
+++ b/.github/workflows/update-datadog-image.yaml
@@ -1,4 +1,5 @@
 name: Datadog image update
+
 on:
   workflow_dispatch:
     inputs:
@@ -6,16 +7,20 @@ on:
         required: true
         type: string
         default: main
-  workflow_call:
+      version_tag:
+        required: true
+        type: string
+        description: "The version tag to use for the base Datadog agent image"
 
 jobs:
   update-image:
     runs-on: ubuntu-latest
     env:
       IMAGE_REPOSITORY: "datadog/agent"
-      IMAGE_TAG: "latest"
+      IMAGE_TAG: ${{ github.event.inputs.version_tag }}  # Use the provided version tag for the image
     steps:
       - uses: actions/checkout@v4
+      
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
@@ -36,6 +41,6 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr-vaec.outputs.registry }}
         run: |
-          docker build -t $IMAGE_REPOSITORY:$IMAGE_TAG -f ci/Dockerfile.datadog .
+          docker build --build-arg DD_AGENT_VERSION=${{ github.event.inputs.version_tag }} -t $IMAGE_REPOSITORY:$IMAGE_TAG -f ci/Dockerfile.datadog .
           docker tag $IMAGE_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$IMAGE_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$IMAGE_REPOSITORY:$IMAGE_TAG

--- a/cd/application-deployment/dev/vaec-api-task-definition.json
+++ b/cd/application-deployment/dev/vaec-api-task-definition.json
@@ -297,7 +297,7 @@
     },
     {
       "name": "datadog-agent",
-      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:latest",
+      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/cd/application-deployment/dev/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/dev/vaec-celery-beat-task-definition.json
@@ -260,7 +260,7 @@
     },
     {
       "name": "datadog-agent",
-      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:latest",
+      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/cd/application-deployment/dev/vaec-celery-task-definition.json
+++ b/cd/application-deployment/dev/vaec-celery-task-definition.json
@@ -327,7 +327,7 @@
     },
     {
       "name": "datadog-agent",
-      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:latest",
+      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -265,7 +265,7 @@
     },
     {
       "name": "datadog-agent",
-      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:latest",
+      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/cd/application-deployment/perf/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-beat-task-definition.json
@@ -232,7 +232,7 @@
     },
     {
       "name": "datadog-agent",
-      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:latest",
+      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/cd/application-deployment/perf/vaec-celery-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-task-definition.json
@@ -287,7 +287,7 @@
     },
     {
       "name": "datadog-agent",
-      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:latest",
+      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/cd/application-deployment/prod/vaec-api-task-definition.json
+++ b/cd/application-deployment/prod/vaec-api-task-definition.json
@@ -277,7 +277,7 @@
     },
     {
       "name": "datadog-agent",
-      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:latest",
+      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/cd/application-deployment/prod/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/prod/vaec-celery-beat-task-definition.json
@@ -248,7 +248,7 @@
     },
     {
       "name": "datadog-agent",
-      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:latest",
+      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/cd/application-deployment/prod/vaec-celery-task-definition.json
+++ b/cd/application-deployment/prod/vaec-celery-task-definition.json
@@ -299,7 +299,7 @@
     },
     {
       "name": "datadog-agent",
-      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:latest",
+      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/cd/application-deployment/staging/vaec-api-task-definition.json
+++ b/cd/application-deployment/staging/vaec-api-task-definition.json
@@ -293,7 +293,7 @@
     },
     {
       "name": "datadog-agent",
-      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:latest",
+      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/cd/application-deployment/staging/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/staging/vaec-celery-beat-task-definition.json
@@ -264,7 +264,7 @@
     },
     {
       "name": "datadog-agent",
-      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:latest",
+      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/cd/application-deployment/staging/vaec-celery-task-definition.json
+++ b/cd/application-deployment/staging/vaec-celery-task-definition.json
@@ -315,7 +315,7 @@
     },
     {
       "name": "datadog-agent",
-      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:latest",
+      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/ci/Dockerfile.datadog
+++ b/ci/Dockerfile.datadog
@@ -1,4 +1,8 @@
-FROM datadog/agent:latest
+# Define a build argument for the base image version
+ARG DD_AGENT_VERSION
+
+# Use the build argument in the FROM instruction
+FROM datadog/agent:${DD_AGENT_VERSION}
 
 RUN \
   DEBIAN_FRONTEND=noninteractive apt-get update \
@@ -9,7 +13,7 @@ RUN \
 # Copy the host's build context directory (notification-api/) to the image's working directory (/app).
 COPY --chown=vanotify ./scripts/import-va-certs.sh /scripts/
 
-# Transfer VA certificates to the image.  These certificates are grabbed from a public VA HTTP server.
+# Transfer VA certificates to the image. These certificates are grabbed from a public VA HTTP server.
 RUN /scripts/import-va-certs.sh \
   && apt-get remove --auto-remove -y wget openssl \
   && apt-get clean


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR does the following:
1. Updates the datadog Dockerfile to require a version tag to be passed in.
2. Updates the Github Action that mirrors the Datadog image to require the version tag to be passed in, which then passes it to the Dockerfile
3. Uses the newest datadog agent version 7.57.2 in all envs

I changed the way we do this because using the `latest` tag throughout the process introduces a lot of risk now that we autoscale Celery tasks. Imagine a scenario where we update the DD image in ECR and tag it as `latest` (which the old workflow was doing) and shortly after Celery tasks start scaling up. Those new Celery tasks would be using an untested version of the Datadog agent in prod.

This new change to the Dockerfile and the workflow requires us to pass through the version tag we want to use when building the Docker image and when updating the task definitions. This allows us to be more explicit AND ensure we don't accidentally deploy untested agent images to production.

The tradeoff being made here is that we will now require a PR to explicitly set the image tag we want to use in the task definition every time we want to upgrade the DD agent image. I feel that this tradeoff is acceptable given the risks with keeping this set to latest which are outlined above.

I will update our documentation to reflect this additional step.

Snipped showing this was updated everywhere:
```
coreycarvalho@Mac:~/code/notification-api [team-1379-datadog-dockerfile|✔] $ ag "datadog\/agent\:" cd/
cd/application-deployment/prod/vaec-celery-beat-task-definition.json
251:      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",

cd/application-deployment/dev/vaec-celery-beat-task-definition.json
263:      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",

cd/application-deployment/staging/vaec-celery-task-definition.json
318:      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",

cd/application-deployment/dev/vaec-api-task-definition.json
300:      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",

cd/application-deployment/staging/vaec-celery-beat-task-definition.json
267:      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",

cd/application-deployment/prod/vaec-api-task-definition.json
280:      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",

cd/application-deployment/staging/vaec-api-task-definition.json
296:      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",

cd/application-deployment/dev/vaec-celery-task-definition.json
330:      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",

cd/application-deployment/prod/vaec-celery-task-definition.json
302:      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",

cd/application-deployment/perf/vaec-celery-beat-task-definition.json
235:      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",

cd/application-deployment/perf/vaec-celery-task-definition.json
290:      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",

cd/application-deployment/perf/vaec-api-task-definition.json
268:      "image": "171875617347.dkr.ecr.us-gov-west-1.amazonaws.com/datadog/agent:7.57.2",
```

issue [TEAM#1379](https://app.zenhub.com/workspaces/va-notify-620d21369d810a00146ed9c8/issues/gh/department-of-veterans-affairs/vanotify-team/1379)

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

Task running version 7.57.2 (in dev):
<img width="1121" alt="image" src="https://github.com/user-attachments/assets/0aa155d2-fc7f-46c5-a6db-e12af3a76a0c">

APM metrics still reporting (in dev):
<img width="1844" alt="image" src="https://github.com/user-attachments/assets/4a99d1e4-044f-4e5e-8796-ae99b05d335e">

Monitors reporting "OK" (in dev):
<img width="1587" alt="image" src="https://github.com/user-attachments/assets/adc6f8b8-4d2b-4f94-a2f0-d8d45df4bb9a">

Successful workflow run specifying the image tag to use for the Datadog Agent image: https://github.com/department-of-veterans-affairs/notification-api/actions/runs/11350212114

Image tag in ECR:
<img width="1068" alt="image" src="https://github.com/user-attachments/assets/3b20cf47-10f1-49ae-b3b6-22c719f2a36e">

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
