### PR TITLE
#1979 - add notification column to VA Profile Local Cache

### DIFF
--- a/migrations/versions/0373_va_profile_cache_notification_id.py
+++ b/migrations/versions/0373_va_profile_cache_notification_id.py
@@ -1,5 +1,5 @@
 """
-Revision ID: 0373_va_profiile_cache_notification_id
+Revision ID: 0373_va_profile_cache_notification_id
 Revises: 0372_remove_service_id_index
 Create Date: 2024-10-22 12:56:00
 """
@@ -7,7 +7,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import UUID
 
-revision = '0373_va_profiile_cache_notification_id'
+revision = '0373_va_profile_cache_notification_id'
 down_revision = '0372_remove_service_id_index'
 
 def upgrade():

--- a/migrations/versions/0373_va_profile_cache_notification_id.py
+++ b/migrations/versions/0373_va_profile_cache_notification_id.py
@@ -1,0 +1,17 @@
+"""
+Revision ID: 0373_va_profiile_cache_notification_id
+Revises: 0372_remove_service_id_index
+Create Date: 2024-10-22 12:56:00
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = '0373_va_profiile_cache_notification_id'
+down_revision = '0372_remove_service_id_index'
+
+def upgrade():
+    op.add_column('va_profile_local_cache', sa.Column('notification_id', UUID(), nullable=True))
+
+def downgrade():
+    op.drop_column('va_profile_local_cache', 'notification_id')

--- a/migrations/versions/0373_va_profile_notification.py
+++ b/migrations/versions/0373_va_profile_notification.py
@@ -1,5 +1,5 @@
 """
-Revision ID: 0373_va_profile_cache_notification_id
+Revision ID: 0373_va_profile_notification
 Revises: 0372_remove_service_id_index
 Create Date: 2024-10-22 12:56:00
 """
@@ -7,7 +7,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import UUID
 
-revision = '0373_va_profile_cache_notification_id'
+revision = '0373_va_profile_notification'
 down_revision = '0372_remove_service_id_index'
 
 def upgrade():


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

issue #1979 

- This ticket requires that the `notification_id` from the send Comp and Pen Opt-In confirmation be saved to the `va_profile_local_cache` table. 
- I am doing the migration work as a separate PR to make deploying and reviewing easier.
- [The rest of the work will be finished in this ticket. ](https://github.com/department-of-veterans-affairs/notification-api/pull/2056)

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

### [Migration OK ](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/11465976124)
<img width="1327" alt="Screenshot 2024-10-22 at 2 17 49 PM" src="https://github.com/user-attachments/assets/da6a80f6-4400-4297-8e32-30126f949f70">


### [Downgrade OK](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/11466396454)
<img width="1117" alt="Screenshot 2024-10-22 at 2 37 49 PM" src="https://github.com/user-attachments/assets/ef2b2911-64dc-4855-aa63-2f1bf0a5f048">


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change
