### PR TITLE
HOTFIX - Use the merge commit when cutting a tag for release

### DIFF
--- a/.github/scripts/prData.js
+++ b/.github/scripts/prData.js
@@ -24,11 +24,11 @@ async function fetchPullRequests(github, owner, repo, sha) {
  * @param {string} repo - The repository name.
  * @returns {Promise<string>} - A promise resolving to the SHA of the latest commit on the main branch.
  */
-async function fetchMainBranchSha(github, owner, repo) {
+async function fetchMainBranchSha(github, owner, repo, ref) {
   const { data } = await github.rest.repos.getCommit({
     owner,
     repo,
-    ref: 'heads/main',
+    ref: ref
   });
 
   if (data && data.sha) {
@@ -94,7 +94,7 @@ async function prData(params) {
   try {
     const pullRequestData = await fetchPullRequests(github, owner, repo, sha);
     const currentVersion = await getReleaseVersionValue(github, owner, repo);
-    const mainBranchSha = await fetchMainBranchSha(github, owner, repo);
+    const mainBranchSha = await fetchMainBranchSha(github, owner, repo, sha);
 
     const labels = pullRequestData.data[0].labels;
     const prNumber = pullRequestData.data[0].number;

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -16,7 +16,7 @@ name: Continuous Deployment Pipeline
 on:
   push:
     branches:
-      - hotfix-tag-pr-sha
+      - main
 
 jobs:
   prepare-deployment:

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -16,7 +16,7 @@ name: Continuous Deployment Pipeline
 on:
   push:
     branches:
-      - main
+      - hotfix-tag-pr-sha
 
 jobs:
   prepare-deployment:

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.set-outputs.outputs.tag }}
+          ref: ${{ needs.setup-environment.outputs.tag }}
       - name: Build and Push Artifacts
         uses: ./.github/actions/build-push-artifacts
         with:


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR fixes a bug where the CD pipeline would tag the latest main instead of tagging the commit sha that triggered the pipeline. This caused confusion with what was being sent up to production in our pipeline and generating incorrect release notes.

The fix in this PR is to have our tagging script take in the ref being tagged instead of defaulting to `origin/main`.

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

I tested this with @cris-oddball. We triggered the CD pipeline form my branch, specifically from the SHA 13f62e440e2b55fc43870da139ac70d915e31ddc.

The new tag being generated:
<img width="393" alt="image" src="https://github.com/user-attachments/assets/6ebba6ad-f95d-4d28-9129-5953d4b82569">

The SHA tied to the tag:
<img width="910" alt="image" src="https://github.com/user-attachments/assets/15ef48d7-497e-4680-84cd-89c3c2b83ea8">


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change
