### PR TITLE
PORTAL-2480 - creates migration to add expected_cadence to promoted_templates

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1045,6 +1045,7 @@ class PromotedTemplate(db.Model):
     promoted_template_content_digest = db.Column(db.Text(), nullable=True)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    expected_cadence = db.Column(db.Text(), nullable=True)
 
 
 class ProviderRates(db.Model):

--- a/migrations/versions/0374_add_expected_cadence.py
+++ b/migrations/versions/0374_add_expected_cadence.py
@@ -1,6 +1,6 @@
 """
 
-Revision ID: 0641de8adbdc
+Revision ID: 0374_add_expected_cadence
 Revises: 0373_va_profile_notification
 Create Date: 2024-11-13 18:59:38.418467
 

--- a/migrations/versions/0374_add_expected_cadence.py
+++ b/migrations/versions/0374_add_expected_cadence.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0641de8adbdc
+Revises: 0373_va_profile_notification
+Create Date: 2024-11-13 18:59:38.418467
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0374_add_expected_cadence'
+down_revision = '0373_va_profile_notification'
+
+
+def upgrade():
+    op.add_column('promoted_templates', sa.Column('expected_cadence', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('promoted_templates', 'expected_cadence')


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Adds the `expected_cadence` text field to the `promoted_templates` table

issue [2480](https://github.com/orgs/department-of-veterans-affairs/projects/1415/views/1?pane=issue&itemId=84874824&issue=department-of-veterans-affairs%7Cnotification-portal%7C2480) of the notification-portal

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

ran `flask db upgrade` and then `flask db downgrade` locally

[deploy to dev - api action run successful](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/11843301849) - verifies migration run successfully
[DB downgrade action run successful](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/11843979399) - verifies migration rollback successful



## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [na] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [na] The ticket was moved into the DEV test column when I began testing this change
