### PR TITLE
#2092 opt out status reason

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,8 @@
 fileignoreconfig:
 - filename: README.md
   checksum: b2cbbb8508af49abccae8b35b317f7ce09215f3508430ed31440add78f450e5a
+- filename: tests/README.md
+  checksum: 4de2edc5ca36f266118231611036c7ccc6d9328bcceefafd8ca5ca92021f8aed
 - filename: app/callback/webhook_callback_strategy.py
   checksum: 47846ab651c27512d3ac7864c08cb25d647f63bb84321953f907551fd9d2e85f
 - filename: app/celery/contact_information_tasks.py

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -77,11 +77,17 @@ def deliver_sms(
         raise NotificationTechnicalFailureException from e
     except NonRetryableException as e:
         # Likely an opted out from pinpoint
+
+        if 'opted out' in str(e).lower():
+            status_reason = 'Destination phone number opted out'
+        else:
+            status_reason = 'ERROR: NonRetryableException - permanent failure, not retrying'
+
         log_and_update_permanent_failure(
             notification.id,
             'deliver_sms',
             e,
-            'ERROR: NonRetryableException - permanent failure, not retrying',
+            status_reason,
         )
         # Expected chain termination
         self.request.chain = None

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -8,6 +8,7 @@ from app.celery.common import (
 from app.celery.exceptions import NonRetryableException, AutoRetryException
 from app.celery.service_callback_tasks import check_and_queue_callback_task
 from app.clients.email.aws_ses import AwsSesClientThrottlingSendRateException
+from app.clients.sms import OPT_OUT_MESSAGE
 from app.config import QueueNames
 from app.constants import NOTIFICATION_TECHNICAL_FAILURE
 from app.dao import notifications_dao
@@ -79,7 +80,7 @@ def deliver_sms(
         # Likely an opted out from pinpoint
 
         if 'opted out' in str(e).lower():
-            status_reason = 'Destination phone number opted out'
+            status_reason = OPT_OUT_MESSAGE
         else:
             status_reason = 'ERROR: NonRetryableException - permanent failure, not retrying'
 

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -5,7 +5,13 @@ from app.celery.exceptions import NonRetryableException, AutoRetryException
 from app.celery.provider_tasks import deliver_sms, deliver_email, deliver_sms_with_rate_limiting
 from app.clients.email.aws_ses import AwsSesClientThrottlingSendRateException
 from app.config import QueueNames
-from app.constants import EMAIL_TYPE, NOTIFICATION_PERMANENT_FAILURE, NOTIFICATION_TECHNICAL_FAILURE, SMS_TYPE
+from app.constants import (
+    EMAIL_TYPE,
+    NOTIFICATION_CREATED,
+    NOTIFICATION_PERMANENT_FAILURE,
+    NOTIFICATION_TECHNICAL_FAILURE,
+    SMS_TYPE,
+)
 from app.exceptions import (
     NotificationTechnicalFailureException,
     InvalidProviderException,
@@ -440,3 +446,40 @@ def test_deliver_sms_with_rate_limiting_max_retries_exceeded(
     assert notification.status == NOTIFICATION_TECHNICAL_FAILURE
     assert notification.status_reason == RETRIES_EXCEEDED
     mocked_check_and_queue_callback_task.assert_called_once()
+
+
+def test_deliver_sms_opt_out(
+    notify_db_session,
+    mocker,
+    sample_service,
+    sample_sms_sender,
+    sample_template,
+    sample_notification,
+):
+    """
+    An SMS notification sent to a recipient who has opted out of receiving notifications
+    from the given SMS sender should result in permanent failure with a relevant status reason.
+    """
+
+    service=sample_service()
+    sms_sender = sample_sms_sender(service_id=service.id, sms_sender='17045555555')
+    template=sample_template(service=service)
+    notification = sample_notification(
+        template=template,
+        status=NOTIFICATION_CREATED,
+        sms_sender_id=sms_sender.id,
+    )
+    assert notification.status == NOTIFICATION_CREATED
+    assert notification.sms_sender_id == sms_sender.id
+    assert notification.status_reason is None
+
+    mock_send_sms_to_provider = mocker.patch(
+        'app.delivery.send_to_providers.send_sms_to_provider',
+        side_effect=NonRetryableException('Destination phone number opted out')
+    )
+    deliver_sms(notification.id, sms_sender_id=notification.sms_sender_id)
+    mock_send_sms_to_provider.assert_called_once()
+
+    notify_db_session.session.refresh(notification)
+    assert notification.status == NOTIFICATION_PERMANENT_FAILURE
+    assert notification.status_reason == 'Destination phone number opted out'

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -4,6 +4,7 @@ from app.celery.common import RETRIES_EXCEEDED
 from app.celery.exceptions import NonRetryableException, AutoRetryException
 from app.celery.provider_tasks import deliver_sms, deliver_email, deliver_sms_with_rate_limiting
 from app.clients.email.aws_ses import AwsSesClientThrottlingSendRateException
+from app.clients.sms import OPT_OUT_MESSAGE
 from app.config import QueueNames
 from app.constants import (
     EMAIL_TYPE,
@@ -469,6 +470,7 @@ def test_deliver_sms_opt_out(
         status=NOTIFICATION_CREATED,
         sms_sender_id=sms_sender.id,
     )
+    assert notification.notification_type == SMS_TYPE
     assert notification.status == NOTIFICATION_CREATED
     assert notification.sms_sender_id == sms_sender.id
     assert notification.status_reason is None
@@ -482,4 +484,4 @@ def test_deliver_sms_opt_out(
 
     notify_db_session.session.refresh(notification)
     assert notification.status == NOTIFICATION_PERMANENT_FAILURE
-    assert notification.status_reason == 'Destination phone number opted out'
+    assert notification.status_reason == OPT_OUT_MESSAGE

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -461,9 +461,9 @@ def test_deliver_sms_opt_out(
     from the given SMS sender should result in permanent failure with a relevant status reason.
     """
 
-    service=sample_service()
+    service = sample_service()
     sms_sender = sample_sms_sender(service_id=service.id, sms_sender='17045555555')
-    template=sample_template(service=service)
+    template = sample_template(service=service)
     notification = sample_notification(
         template=template,
         status=NOTIFICATION_CREATED,
@@ -475,7 +475,7 @@ def test_deliver_sms_opt_out(
 
     mock_send_sms_to_provider = mocker.patch(
         'app.delivery.send_to_providers.send_sms_to_provider',
-        side_effect=NonRetryableException('Destination phone number opted out')
+        side_effect=NonRetryableException('Destination phone number opted out'),
     )
     deliver_sms(notification.id, sms_sender_id=notification.sms_sender_id)
     mock_send_sms_to_provider.assert_called_once()


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

We want a more descriptive "status_reason" for SMS notifications that fail permanently due to the recipient having opted-out.  I wrote a new unit test for the changes.  The test mocks out a lot of downstream code, but I don't see an easy way not to mock given the layers of downstream code.

I also revised the testing README.md, which was not well organized.

issue #2092

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

I deployed API Dev.  All unit and regression tests pass.  @cris-oddball sent an SMS notification to an opted-out number and inspected the results with Postman and in DD.  We observed the expected behavior.

This is the error message returned from Pinpoint:
![2092_DD](https://github.com/user-attachments/assets/a0324c15-c2b0-4c54-a5c9-4519d66c7273)

This is the "status_reason" recorded in our database:
![2092_Postman](https://github.com/user-attachments/assets/1628c998-baa7-407c-b568-c45a3b9cfbd1)

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
