### PR TITLE
HOT FIX - #2041 increase prod ecs celery service memory

### DIFF
--- a/cd/application-deployment/prod/vaec-celery-task-definition.json
+++ b/cd/application-deployment/prod/vaec-celery-task-definition.json
@@ -208,7 +208,7 @@
   ],
   "cpu": "2048",
   "pidMode": "task",
-  "memory": "4096",
+  "memory": "8192",
   "tags": [
     {
       "key": "Stack",


### PR DESCRIPTION
A hot, hot fix.  [Memory in PROD spiking.](https://us-gov-west-1.console.amazonaws-us-gov.com/ecs/v2/clusters/prod-notification-cluster/services/prod-notification-celery-service/health?region=us-gov-west-1) 

Increasing PROD ECS Celery service Memory  from 4096 to 8192. 

Keep CPU at 2048