### PR TITLE
#2159 - Update Total Time For Twilio Delivery Status 

### DIFF
--- a/app/celery/common.py
+++ b/app/celery/common.py
@@ -102,10 +102,15 @@ def log_notification_total_time(
     """Logs how long it took a notification to go from created to delivered"""
     if status == NOTIFICATION_DELIVERED:
         end_time = event_timestamp or datetime.now(timezone.utc).replace(tzinfo=None)
+        total_time = (end_time - start_time).total_seconds()
+
+        # Twilio RawDlrDoneDate can make this negative
+        # https://www.twilio.com/en-us/changelog/addition-of-rawdlrdonedate-to-delivered-and-undelivered-status-webhooks
+        corrected_total_time = total_time if total_time > 0.0 else 0.0
         current_app.logger.info(
             'notification %s took %ss total time to reach %s status - %s',
             notification_id,
-            (end_time - start_time).total_seconds(),
+            corrected_total_time,
             status,
             provider,
         )

--- a/app/celery/common.py
+++ b/app/celery/common.py
@@ -106,7 +106,11 @@ def log_notification_total_time(
 
         # Twilio RawDlrDoneDate can make this negative
         # https://www.twilio.com/en-us/changelog/addition-of-rawdlrdonedate-to-delivered-and-undelivered-status-webhooks
-        corrected_total_time = total_time if total_time > 0.0 else 0.0
+        corrected_total_time = (
+            total_time
+            if total_time > 0.0
+            else (datetime.now(timezone.utc).replace(tzinfo=None) - start_time).total_seconds()
+        )
         current_app.logger.info(
             'notification %s took %ss total time to reach %s status - %s',
             notification_id,

--- a/tests/app/celery/test_common.py
+++ b/tests/app/celery/test_common.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 from freezegun import freeze_time
@@ -11,6 +11,7 @@ from app.constants import (
     NOTIFICATION_PENDING,
     NOTIFICATION_SENDING,
     NOTIFICATION_SENT,
+    TWILIO_PROVIDER,
 )
 
 
@@ -23,7 +24,7 @@ def test_ut_log_notification_total_time(
     mock_logger = mocker.patch('app.celery.common.current_app.logger.info')
     notification_id = uuid4()
     with freeze_time('2024-04-04 17:16:43'):
-        created_at = datetime.datetime.fromisoformat('2024-04-04 17:16:41')
+        created_at = datetime.fromisoformat('2024-04-04 17:16:41')
 
         log_notification_total_time(
             notification_id=notification_id,
@@ -35,7 +36,7 @@ def test_ut_log_notification_total_time(
         mock_logger.assert_called_once_with(
             'notification %s took %ss total time to reach %s status - %s',
             notification_id,
-            (datetime.datetime.now() - created_at).total_seconds(),
+            (datetime.now() - created_at).total_seconds(),
             NOTIFICATION_DELIVERED,
             provider,
         )
@@ -60,9 +61,30 @@ def test_ut_skip_log_notification_total_time(
     mock_logger = mocker.patch('app.celery.common.current_app.logger.info')
     log_notification_total_time(
         notification_id=uuid4(),
-        start_time=datetime.datetime.now(),
+        start_time=datetime.now(),
         status=status,
         provider=provider,
     )
 
     mock_logger.assert_not_called()
+
+
+def test_log_total_time_negative_value(
+    mocker,
+    client,
+):
+    mock_logger = mocker.patch('app.celery.common.current_app.logger.info')
+    start_time = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(seconds=1)
+    event_timestamp = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(seconds=3)
+
+    notification_id = str(uuid4())
+    log_notification_total_time(
+        notification_id,
+        start_time,
+        NOTIFICATION_DELIVERED,
+        TWILIO_PROVIDER,
+        event_timestamp,
+    )
+
+    # Test that the total time logged is > 0
+    assert float(mock_logger.call_args[0][2]) > 0


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Twilio delivery status can come in with a negative timestamp due to only having minute granularity. This only affects our logging but has been updated so our internal charts and logs are not confusing.

issue #2159 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->
Wrote a new test. Deployed.
Ran requests using Twilio at various times to attempt to trigger a negative number, all were positive:
![image](https://github.com/user-attachments/assets/9c6d4761-bbd5-4d07-a244-d8dd83f53668)



## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
