### PR TITLE
#1357 Redact Personalization in Serialized Notifications

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -69,6 +69,8 @@ fileignoreconfig:
   checksum: 6ffb8742a19c5b834c608826fd459cc1b6ea35ebfffd2d929a3a0f269c74183d
 - filename: tests/app/celery/test_service_callback_tasks.py
   checksum: 70575434f7a4fedd43d4c9164bc899a606768526d432c364db372524eec26542
+- filename: tests/app/clients/test_twilio.py
+  checksum: cad49e634cc5ba56157358aa3dfba2dafe7b9dbd3a0c580ec5cda3072f6a76e5
 - filename: tests/app/conftest.py
   checksum: a80aa727586db82ed1b50bdb81ddfe1379e649a9dfc1ece2c36047486b41b83d
 - filename: tests/app/dao/test_api_key_dao.py
@@ -77,6 +79,8 @@ fileignoreconfig:
   checksum: 4e15e63d349635131173ffdd7aebcd547621db08de877ef926d3a41fde72d065
 - filename: tests/app/notifications/test_send_notifications.py
   checksum: 69304e1edd6993acd9a842a87dba8ee16854befc643863e1589b15c303a71464
+- filename: tests/app/v2/notifications/test_get_notifications.py
+  checksum: f7cef983750a27dfdedb6db88c791fe9e20fd34768577dbcaeb0c42bfc7457b4
 - filename: tests/app/v2/notifications/test_post_notifications.py
   checksum: 3181930a13e3679bb2f17eaa3f383512eb9caf4ed5d5e14496ca4193c6083965
 - filename: tests/app/v3/notifications/test_rest.py
@@ -85,6 +89,4 @@ fileignoreconfig:
   checksum: 4f0f4d7a4113762219e45a51f7b26a7c0cb83f1d8f10c5598533f6cdcf0e0ada
 - filename: tests/lambda_functions/vetext_incoming_forwarder_lambda/test_vetext_incoming_forwarder_lambda.py
   checksum: 7494eb4321fd2fbc3ff3915d8753d8fec7a936a69dc6ab78f0b532a701f032eb
-- filename: tests/app/clients/test_twilio.py
-  checksum: cad49e634cc5ba56157358aa3dfba2dafe7b9dbd3a0c580ec5cda3072f6a76e5
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -80,7 +80,7 @@ fileignoreconfig:
 - filename: tests/app/notifications/test_send_notifications.py
   checksum: 69304e1edd6993acd9a842a87dba8ee16854befc643863e1589b15c303a71464
 - filename: tests/app/v2/notifications/test_get_notifications.py
-  checksum: f7cef983750a27dfdedb6db88c791fe9e20fd34768577dbcaeb0c42bfc7457b4
+  checksum: f2460d8b22ff7ff2e89778dbbf3e0740cbb41dead60c49c32648d367aa05fe0e
 - filename: tests/app/v2/notifications/test_post_notifications.py
   checksum: 3181930a13e3679bb2f17eaa3f383512eb9caf4ed5d5e14496ca4193c6083965
 - filename: tests/app/v3/notifications/test_rest.py

--- a/app/models.py
+++ b/app/models.py
@@ -1331,7 +1331,7 @@ class Notification(db.Model):
     def content(self):
         from app.utils import get_template_instance
 
-        template_object = get_template_instance(self.template.__dict__, self.personalisation)
+        template_object = get_template_instance(self.template.__dict__, {k: '<redacted>' for k in self.personalisation})
         return str(template_object)
 
     @property

--- a/app/models.py
+++ b/app/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 
 import datetime
+import html
 import itertools
 import uuid
 
@@ -1342,7 +1343,7 @@ class Notification(db.Model):
             template_object = get_template_instance(
                 self.template.__dict__, {k: '<redacted>' for k in self.personalisation}
             )
-            return str(template_object.subject)
+            return html.unescape(str(template_object.subject))
 
     @property
     def formatted_status(self):

--- a/app/models.py
+++ b/app/models.py
@@ -1339,8 +1339,10 @@ class Notification(db.Model):
         from app.utils import get_template_instance
 
         if self.notification_type != SMS_TYPE:
-            template_object = get_template_instance(self.template.__dict__, self.personalisation)
-            return template_object.subject
+            template_object = get_template_instance(
+                self.template.__dict__, {k: '<redacted>' for k in self.personalisation}
+            )
+            return str(template_object.subject)
 
     @property
     def formatted_status(self):

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -133,7 +133,7 @@ def test_notification_subject_fills_in_placeholders(
 ):
     template = sample_template(template_type=EMAIL_TYPE, subject='((name))')
     notification = sample_notification(template=template, personalisation={'name': 'hello'})
-    assert notification.subject == 'hello'
+    assert notification.subject == '&lt;redacted&gt;'
 
 
 def test_notification_serializes_created_by_name_with_no_created_by_id(client, sample_notification):

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -133,7 +133,7 @@ def test_notification_subject_fills_in_placeholders(
 ):
     template = sample_template(template_type=EMAIL_TYPE, subject='((name))')
     notification = sample_notification(template=template, personalisation={'name': 'hello'})
-    assert notification.subject == '&lt;redacted&gt;'
+    assert notification.subject == '<redacted>'
 
 
 def test_notification_serializes_created_by_name_with_no_created_by_id(client, sample_notification):

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -933,4 +933,4 @@ def test_get_notifications_removes_personalisation_from_subject(
 
     json_response = json.loads(response.get_data(as_text=True))
     assert response.status_code == 200
-    assert json_response['subject'] == 'Hello &lt;redacted&gt;'
+    assert json_response['subject'] == 'Hello <redacted>'

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -155,7 +155,7 @@ def test_get_notification_by_id_with_placeholders_and_recipient_identifiers_retu
         'template': expected_template_response,
         'created_at': notification.created_at.strftime(DATETIME_FORMAT),
         'created_by_name': None,
-        'body': 'Hello Bob\nThis is an email from va.gov',
+        'body': 'Hello <redacted>\nThis is an email from va.gov',
         'subject': 'Subject',
         'sent_at': notification.sent_at,
         'sent_by': None,
@@ -881,3 +881,30 @@ def test_get_notifications_renames_letter_statuses(client, sample_letter_templat
     json_response = json.loads(response.get_data(as_text=True))
     assert response.status_code == 200
     assert json_response['status'] == expected_status
+
+
+@pytest.mark.parametrize('template_type', [SMS_TYPE, EMAIL_TYPE])
+def test_get_notifications_removes_personalisation_from_content(
+    client,
+    sample_api_key,
+    sample_notification,
+    sample_template,
+    template_type,
+):
+    template = sample_template(
+        content='Hello ((name))\nThis is an email from VA Notify about some ((thing))',
+        template_type=template_type,
+    )
+    notification = sample_notification(
+        template=template,
+        personalisation={'name': 'Bob', 'thing': 'important stuff'},
+    )
+    auth_header = create_authorization_header(sample_api_key(service=template.service))
+    response = client.get(
+        path=url_for('v2_notifications.get_notification_by_id', notification_id=notification.id),
+        headers=[('Content-Type', 'application/json'), auth_header],
+    )
+
+    json_response = json.loads(response.get_data(as_text=True))
+    assert response.status_code == 200
+    assert json_response['body'] == 'Hello <redacted>\nThis is an email from VA Notify about some <redacted>'


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR redacts the `personalisation` field in the serialized Notification responses. A GET request to `v2/notifications/` will return the literal `<redacted>` in place of the personalization fields. 

issue #1357 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

This was [deployed](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/12318271329/job/34383134676) and tested in perf -

- sent a SMS using a template that had a personalization field, note the `((variable))`, in `content`.
<img width="1359" alt="Screenshot 2024-12-13 at 10 35 04 AM" src="https://github.com/user-attachments/assets/9b089412-132e-4c40-9c35-55476ec92ec2" />
<img width="1354" alt="Screenshot 2024-12-13 at 10 41 02 AM" src="https://github.com/user-attachments/assets/b0886ace-fd0b-436c-8e3f-e34b076e1fe9" />

- Issued a GET to v2/notifications/sms, note that `body` is `<redacted>`
<img width="1359" alt="Screenshot 2024-12-13 at 10 38 58 AM" src="https://github.com/user-attachments/assets/42b0767e-1b44-4a5d-b92f-bae8bcf0c4c4" />
- Verified on my phone that the SMS had the correct personalization (`dolore rebum`)

- Redeployed to dev and tested email subject redaction
![Screenshot 2024-12-13 at 4 05 10 PM](https://github.com/user-attachments/assets/4b278994-e04a-47d1-9ab8-0afecd55b8a9)

![Screenshot 2024-12-13 at 4 03 31 PM](https://github.com/user-attachments/assets/d5f3ca13-5d50-4ece-9d5c-31aa0f4cd4bc)

The unit tests cover emails, and have slightly more personalization fields.

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
