### PR TITLE
#1357 - Redact personalization in POST responses

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -129,7 +129,6 @@ def post_notification(notification_type):  # noqa: C901
                 current_app.logger.debug('Sending a notification without contact information is not implemented.')
                 return jsonify(result='error', message='Not Implemented'), 501
 
-        # template_with_content.values = notification.personalisation
         template_with_content.values = {k: '<redacted>' for k in notification.personalisation}
 
     if notification_type == SMS_TYPE:

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -1,4 +1,5 @@
 import functools
+import html
 
 import werkzeug
 from flask import request, jsonify, current_app, abort
@@ -128,13 +129,14 @@ def post_notification(notification_type):  # noqa: C901
                 current_app.logger.debug('Sending a notification without contact information is not implemented.')
                 return jsonify(result='error', message='Not Implemented'), 501
 
-        template_with_content.values = notification.personalisation
+        # template_with_content.values = notification.personalisation
+        template_with_content.values = {k: '<redacted>' for k in notification.personalisation}
 
     if notification_type == SMS_TYPE:
         create_resp_partial = functools.partial(create_post_sms_response_from_notification, from_number=reply_to)
     elif notification_type == EMAIL_TYPE:
         create_resp_partial = functools.partial(
-            create_post_email_response_from_notification, subject=template_with_content.subject
+            create_post_email_response_from_notification, subject=html.unescape(template_with_content.subject)
         )
     elif notification_type == LETTER_TYPE:
         create_resp_partial = functools.partial(

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -98,7 +98,7 @@ def test_post_sms_notification_returns_201(
     # endpoint checks
     assert resp_json['id'] == str(notifications[0].id)
     assert resp_json['reference'] == reference
-    assert resp_json['content']['body'] == template.content.replace('(( Name))', 'Jo')
+    assert resp_json['content']['body'] == template.content.replace('(( Name))', '<redacted>')
     assert resp_json['content']['from_number'] == current_app.config['FROM_NUMBER']
     assert f'v2/notifications/{notifications[0].id}' in resp_json['uri']
     assert resp_json['template']['id'] == str(template.id)
@@ -423,7 +423,7 @@ def test_post_sms_notification_without_callback_url(
     assert notification.callback_url is None
 
     assert resp_json['id'] == str(notification.id)
-    assert resp_json['content']['body'] == template.content.replace('(( Name))', 'Jo')
+    assert resp_json['content']['body'] == template.content.replace('(( Name))', '<redacted>')
     assert resp_json['callback_url'] is None
 
 
@@ -504,8 +504,8 @@ def test_post_email_notification_returns_201(
     assert resp_json['reference'] == reference
     assert notification.reference is None
     assert notification.reply_to_text is None
-    assert resp_json['content']['body'] == template.content.replace('((name))', 'Bob')
-    assert resp_json['content']['subject'] == template.subject.replace('((name))', 'Bob')
+    assert resp_json['content']['body'] == template.content.replace('((name))', '<redacted>')
+    assert resp_json['content']['subject'] == template.subject.replace('((name))', '<redacted>')
     assert 'v2/notifications/{}'.format(notification.id) in resp_json['uri']
     assert resp_json['template']['id'] == str(template.id)
     assert resp_json['template']['version'] == template.version
@@ -560,8 +560,8 @@ def test_post_email_notification_with_reply_to_returns_201(
     assert resp_json['id'] == str(notification.id)
     assert resp_json['billing_code'] == 'TESTCODE'
     assert resp_json['reference'] == reference
-    assert resp_json['content']['body'] == template.content.replace('((name))', 'Bob')
-    assert resp_json['content']['subject'] == template.subject.replace('((name))', 'Bob')
+    assert resp_json['content']['body'] == template.content.replace('((name))', '<redacted>')
+    assert resp_json['content']['subject'] == template.subject.replace('((name))', '<redacted>')
     assert 'v2/notifications/{}'.format(notification.id) in resp_json['uri']
     assert resp_json['template']['id'] == str(template.id)
     assert resp_json['template']['version'] == template.version
@@ -1337,7 +1337,7 @@ class TestPostNotificationWithAttachment:
         resp_json = response.get_json()
         assert validate(resp_json, post_email_response) == resp_json
 
-        assert resp_json['content']['body'] == 'Document: simulated-attachment-url'
+        assert resp_json['content']['body'] == 'Document: <redacted>'
 
     def test_without_document_upload_permission(
         self,


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR redacts personalization in POST responses to `/v2/notifications`, a follow up to [this PR](https://github.com/department-of-veterans-affairs/notification-api/pull/2180).

issue #1357 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- [Deployed to dev](https://github.com/department-of-veterans-affairs/notification-api/pull/2180)
- Sent an email, the POST response has been redacted:
<img width="1354" alt="Screenshot 2024-12-16 at 1 20 41 PM" src="https://github.com/user-attachments/assets/8f73b78c-3c19-47c7-bba3-6d8ed2e6e053" />

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
