### PR TITLE
TEAM #1177- Add script to cleanup task definitions in GHA workflow

### DIFF
--- a/.github/workflows/task-defnition-cleanup.yaml
+++ b/.github/workflows/task-defnition-cleanup.yaml
@@ -19,5 +19,136 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: echo hello
-        run: echo hello
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.VAEC_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.VAEC_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ secrets.VAEC_DEPLOY_ROLE }}
+          role-skip-session-tagging: true
+          role-duration-seconds: 1800
+
+      - name: Cleanup Old ECS Task Definitions
+        env:
+          AWS_REGION: "us-gov-west-1"
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          #!/bin/bash
+          set -e
+
+          MAX_REV=10
+          REGION="$AWS_REGION"
+          DRY_RUN="$DRY_RUN"
+
+          echo "Starting ECS Task Definitions cleanup in region: $REGION"
+          echo "Dry run mode: $DRY_RUN"
+
+          # -----------------------------------------------------------------------------
+          # 1. Function to deregister task definitions (or perform dry run).
+          # -----------------------------------------------------------------------------
+          deregister_task_definition() {
+            local task_def_arn="$1"
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[Dry Run] Would deregister task definition: $task_def_arn"
+            else
+              echo "Deregistering task definition: $task_def_arn"
+              aws ecs deregister-task-definition --task-definition "$task_def_arn" --region "$REGION"
+              echo "Deregistered $task_def_arn"
+            fi
+          }
+
+          # -----------------------------------------------------------------------------
+          # 2. Function to list all task definitions for a given family (with pagination).
+          #    We sort in descending order so that the newest revisions come first.
+          # -----------------------------------------------------------------------------
+          list_all_task_definitions() {
+            local family_filter="$1"
+            local next_token=""
+            local task_defs=()
+
+            while : ; do
+              if [ -z "$next_token" ]; then
+                response=$(aws ecs list-task-definitions \
+                  --region "$REGION" \
+                  --family-prefix "$family_filter" \
+                  --sort DESC \
+                  --max-items 1000 \
+                  --output json \
+                  --query '{taskDefinitionArns: taskDefinitionArns, nextToken: nextToken}')
+              else
+                response=$(aws ecs list-task-definitions \
+                  --region "$REGION" \
+                  --family-prefix "$family_filter" \
+                  --sort DESC \
+                  --max-items 1000 \
+                  --starting-token "$next_token" \
+                  --output json \
+                  --query '{taskDefinitionArns: taskDefinitionArns, nextToken: nextToken}')
+              fi
+
+              current_batch=$(echo "$response" | jq -r '.taskDefinitionArns[]')
+              if [ -n "$current_batch" ]; then
+                task_defs+=( $current_batch )
+              fi
+
+              next_token=$(echo "$response" | jq -r '.nextToken // empty')
+              if [ -z "$next_token" ]; then
+                break
+              fi
+            done
+
+            # Return all found ARNs
+            echo "${task_defs[@]}"
+          }
+
+          # -----------------------------------------------------------------------------
+          # 3. List of families to clean up, each keeping only the latest MAX_REV revisions.
+          # -----------------------------------------------------------------------------
+          TARGET_FAMILIES=(
+            "dev-notification-api-db-migrations-task"
+            "dev-notification-api-task"
+            "dev-va-enp-api-task"
+            "perf-notification-api-db-migrations-task"
+            "perf-notification-api-task"
+            "perf-va-enp-api-task"
+            "prod-notification-api-db-migrations-task"
+            "prod-notification-api-task"
+            "staging-notification-api-db-migrations-task"
+            "staging-notification-api-task"
+            "dev-notification-celery-beat-task"
+            "dev-notification-celery-task"
+            "perf-notification-celery-beat-task"
+            "perf-notification-celery-task"
+            "prod-notification-celery-beat-task"
+            "prod-notification-celery-task"
+            "staging-notification-celery-beat-task"
+            "staging-notification-celery-task"
+          )
+
+          # -----------------------------------------------------------------------------
+          # 4. Iterate over each family, keep the newest MAX_REV, and deregister older ones.
+          # -----------------------------------------------------------------------------
+          for FAMILY in "${TARGET_FAMILIES[@]}"; do
+            echo "--------------------------------------------------------------------------------"
+            echo "Processing Task Family: $FAMILY"
+            REVISIONS=$(list_all_task_definitions "$FAMILY")
+
+            if [ -z "$REVISIONS" ]; then
+              echo "No revisions found for family: $FAMILY"
+              continue
+            fi
+
+            REV_COUNT=0
+            for REV_ARN in $REVISIONS; do
+              REV_COUNT=$((REV_COUNT + 1))
+              if [ "$REV_COUNT" -le "$MAX_REV" ]; then
+                echo "Keeping revision $REV_COUNT: $REV_ARN"
+              else
+                deregister_task_definition "$REV_ARN"
+              fi
+            done
+          done
+
+          echo "ECS Task Definitions cleanup completed successfully."

--- a/.github/workflows/task-defnition-cleanup.yaml
+++ b/.github/workflows/task-defnition-cleanup.yaml
@@ -45,7 +45,7 @@ jobs:
           echo "Dry run mode: $DRY_RUN"
 
           # -----------------------------------------------------------------------------
-          # 1. Function to deregister task definitions (or perform dry run).
+          # 1. Function to deregister task definitions (with exponential backoff & jitter).
           # -----------------------------------------------------------------------------
           deregister_task_definition() {
             local task_def_arn="$1"
@@ -54,8 +54,22 @@ jobs:
               echo "[Dry Run] Would deregister task definition: $task_def_arn"
             else
               echo "Deregistering task definition: $task_def_arn"
-              aws ecs deregister-task-definition --task-definition "$task_def_arn" --region "$REGION"
-              echo "Deregistered $task_def_arn"
+              
+              # We'll attempt up to 5 times in case of rate limiting
+              for attempt in {1..5}; do
+                if aws ecs deregister-task-definition --task-definition "$task_def_arn" --region "$REGION"; then
+                  echo "Deregistered $task_def_arn"
+                  break
+                else
+                  echo "Attempt $attempt to deregister $task_def_arn failed. Sleeping before retry..."
+                  sleep $((attempt * 2))  # exponential backoff (2, 4, 6, 8, 10 seconds)
+                fi
+              done
+
+              # Introduce a small random jitter between deregistrations
+              sleep_time=$((1 + RANDOM % 3)) # 1–3 seconds
+              echo "Sleeping for $sleep_time second(s) to reduce rate-limit risk..."
+              sleep $sleep_time
             fi
           }
 


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR introduces a GHA workflow that deregisters all api and celery task definitions except the most recent 10 (for each family). The workflow runs on a cron, every Sunday at 00:00 UTC. There is also a workflow dispatch option that contains a dry run for testing purposes.

issue [TEAM 1177](https://github.com/department-of-veterans-affairs/vanotify-team/issues/1177)

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

As of right now, only dry run has been tested. I am going to test this now without dry run, and I am expecting it to fail on API limits being hit in AWS. Failed workflows on API limits are acceptable for now while we churn through the thousands of task definitions we have to deregister.

Once we churn through those, running this weekly should not trigger API limits.

Dry run: https://github.com/department-of-veterans-affairs/notification-api/actions/runs/12505543172/job/34889065650#step:4:130

Current workflow run deleting task definitions: https://github.com/department-of-veterans-affairs/notification-api/actions/runs/12505695741

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
