### PR TITLE
HOTFIX - Bumps memory of celery task in perf

### DIFF
--- a/cd/application-deployment/perf/vaec-celery-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-task-definition.json
@@ -204,7 +204,7 @@
   ],
   "cpu": "2048",
   "pidMode": "task",
-  "memory": "4096",
+  "memory": "5120",
   "tags": [
     {
       "key": "Stack",

--- a/cd/application-deployment/perf/vaec-celery-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-task-definition.json
@@ -204,7 +204,7 @@
   ],
   "cpu": "2048",
   "pidMode": "task",
-  "memory": "5120",
+  "memory": "6144",
   "tags": [
     {
       "key": "Stack",


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Celery task on Friday OOM'd, so we are going to bump this task from 4GB of memory to 5GB. I'm opting for a smaller jump because the average memory remained at around 50% utilization, but maximum jumped up and killed the task. If we need more we can always add more.

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

Config change, nothing to test.


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change
