### PR TITLE
#2219 - TwilioRestException Retry Logging

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -7,7 +7,7 @@ from app.celery.common import (
     log_and_update_permanent_failure,
     log_and_update_critical_failure,
 )
-from app.celery.exceptions import NonRetryableException, AutoRetryException
+from app.celery.exceptions import AutoRetryException, NonRetryableException, RetryableException
 from app.celery.service_callback_tasks import check_and_queue_callback_task
 from app.clients.email.aws_ses import AwsSesClientThrottlingSendRateException
 from app.config import QueueNames
@@ -240,7 +240,9 @@ def _handle_delivery_failure(
         raise NotificationTechnicalFailureException(f'Found {type(e).__name__}, NOT retrying...', e, e.args)
 
     else:
-        current_app.logger.exception('%s delivery failed for notification %s', notification_type, notification_id)
+        if not isinstance(e, RetryableException):
+            # Retryable should log where it happened, if it is here without RetryableException this is unexpected
+            current_app.logger.exception('%s delivery failed for notification %s', notification_type, notification_id)
 
         if can_retry(celery_task.request.retries, celery_task.max_retries, notification_id):
             current_app.logger.warning(

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -244,6 +244,8 @@ def _handle_delivery_failure(
             # Retryable should log where it happened, if it is here without RetryableException this is unexpected
             current_app.logger.exception('%s delivery failed for notification %s', notification_type, notification_id)
 
+        # We retry everything because it ensures missed exceptions do not prevent notifications from going out. Logs are
+        # checked daily and tickets opened for narrowing the not 'RetryableException's that make it this far.
         if can_retry(celery_task.request.retries, celery_task.max_retries, notification_id):
             current_app.logger.warning(
                 '%s unable to send for notification %s, retrying',

--- a/app/clients/sms/twilio.py
+++ b/app/clients/sms/twilio.py
@@ -263,7 +263,7 @@ class TwilioSMSClient(SmsClient):
                 raise NonRetryableException(status.status_reason) from e
             else:
                 self.logger.warning('Encountered a retryable error with sending an sms request to Twilio: %s', str(e))
-                raise RetryableException from e
+                raise RetryableException(str(e)) from e
         except:
             self.logger.exception('Twilio send SMS request for %s failed', reference)
             raise

--- a/app/clients/sms/twilio.py
+++ b/app/clients/sms/twilio.py
@@ -5,6 +5,7 @@ from logging import Logger
 from monotonic import monotonic
 from urllib.parse import parse_qs
 
+from requests.exceptions import ConnectionError, ReadTimeout
 from twilio.rest import Client
 from twilio.rest.api.v2010.account.message import MessageInstance
 from twilio.base.exceptions import TwilioRestException
@@ -250,6 +251,15 @@ class TwilioSMSClient(SmsClient):
             self.logger.info('Twilio send SMS request for %s succeeded: %s', reference, message.sid)
 
             return message.sid
+        except (ConnectionError, ReadTimeout) as e:
+            # Twilio uses requests under the hood and has thrown requests errors we have been retrying:
+            # ConnectionError (base for ConnectTimeout), ConnectTimeout, ReadTimeout
+            self.logger.warning(
+                'Notification: %s encountered a retryable error with sending an sms request to Twilio: %s',
+                reference,
+                str(e),
+            )
+            raise RetryableException(str(e)) from e
         except TwilioRestException as e:
             if e.status == 400 and 'phone number' in e.msg:
                 self.logger.exception('Twilio send SMS request for %s failed', reference)

--- a/app/clients/sms/twilio.py
+++ b/app/clients/sms/twilio.py
@@ -262,7 +262,11 @@ class TwilioSMSClient(SmsClient):
                 self.logger.debug('Twilio error details for %s - %s: %s', reference, e.code, e.msg)
                 raise NonRetryableException(status.status_reason) from e
             else:
-                self.logger.warning('Encountered a retryable error with sending an sms request to Twilio: %s', str(e))
+                self.logger.warning(
+                    'Notification: %s encountered a retryable error with sending an sms request to Twilio: %s',
+                    reference,
+                    str(e),
+                )
                 raise RetryableException(str(e)) from e
         except:
             self.logger.exception('Twilio send SMS request for %s failed', reference)

--- a/app/clients/sms/twilio.py
+++ b/app/clients/sms/twilio.py
@@ -9,7 +9,7 @@ from twilio.rest import Client
 from twilio.rest.api.v2010.account.message import MessageInstance
 from twilio.base.exceptions import TwilioRestException
 
-from app.celery.exceptions import NonRetryableException
+from app.celery.exceptions import NonRetryableException, RetryableException
 from app.clients.sms import SmsClient, SmsStatusRecord, UNABLE_TO_TRANSLATE
 from app.constants import (
     NOTIFICATION_CREATED,
@@ -262,7 +262,8 @@ class TwilioSMSClient(SmsClient):
                 self.logger.debug('Twilio error details for %s - %s: %s', reference, e.code, e.msg)
                 raise NonRetryableException(status.status_reason) from e
             else:
-                raise
+                self.logger.warning('Encountered a retryable error with sending an sms request to Twilio: %s', str(e))
+                raise RetryableException from e
         except:
             self.logger.exception('Twilio send SMS request for %s failed', reference)
             raise

--- a/tests/app/clients/test_twilio.py
+++ b/tests/app/clients/test_twilio.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 import pytest
 import requests_mock
-from requests.exceptions import ConnectionError, ReadTimeout
+from requests.exceptions import ConnectionError, ConnectTimeout, ReadTimeout
 from twilio.base.exceptions import TwilioRestException
 from urllib.parse import parse_qsl
 
@@ -483,7 +483,7 @@ def test_send_sms_sends_from_hardcoded_number(
     assert d['From'] == '+18194120710'
 
 
-@pytest.mark.parametrize('test_exception', (ConnectionError, ReadTimeout))
+@pytest.mark.parametrize('test_exception', (ConnectionError, ConnectTimeout, ReadTimeout))
 def test_send_sms_raises_if_twilio_requests_exception(
     notify_api,
     test_exception,

--- a/tests/app/clients/test_twilio.py
+++ b/tests/app/clients/test_twilio.py
@@ -492,8 +492,8 @@ def test_send_sms_raises_if_twilio_requests_exception(
     content = 'my message'
     reference = 'my reference'
     err_msg = 'it did not work'
-
     uri = f'https://api.twilio.com/2010-04-01/Accounts/{twilio_sms_client._account_sid}/Messages.json'
+
     with pytest.raises(RetryableException) as exc:
         with requests_mock.Mocker() as r_mock:
             r_mock.post(
@@ -512,8 +512,8 @@ def test_send_sms_raises_if_twilio_rejects(
     content = 'my message'
     reference = 'my reference'
     err_msg = 'it did not work'
-
     uri = f'https://api.twilio.com/2010-04-01/Accounts/{twilio_sms_client._account_sid}/Messages.json'
+
     with pytest.raises(RetryableException) as exc:
         with requests_mock.Mocker() as r_mock:
             r_mock.post(

--- a/tests/app/clients/test_twilio.py
+++ b/tests/app/clients/test_twilio.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 import pytest
 import requests_mock
+from requests.exceptions import ConnectionError, ReadTimeout
 from twilio.base.exceptions import TwilioRestException
 from urllib.parse import parse_qsl
 
@@ -482,26 +483,46 @@ def test_send_sms_sends_from_hardcoded_number(
     assert d['From'] == '+18194120710'
 
 
-def test_send_sms_raises_if_twilio_rejects(
+@pytest.mark.parametrize('test_exception', (ConnectionError, ReadTimeout))
+def test_send_sms_raises_if_twilio_requests_exception(
     notify_api,
-    mocker,
+    test_exception,
 ):
     to = '+61412345678'
     content = 'my message'
     reference = 'my reference'
-    response_dict = {'code': 60082, 'message': 'it did not work'}
+    err_msg = 'it did not work'
 
+    uri = f'https://api.twilio.com/2010-04-01/Accounts/{twilio_sms_client._account_sid}/Messages.json'
     with pytest.raises(RetryableException) as exc:
         with requests_mock.Mocker() as r_mock:
             r_mock.post(
-                f'https://api.twilio.com/2010-04-01/Accounts/{twilio_sms_client._account_sid}/Messages.json',
-                json=response_dict,
-                status_code=400,
+                uri,
+                exc=test_exception(err_msg),
             )
-
             twilio_sms_client.send_sms(to, content, reference)
 
-    assert response_dict['message'] in str(exc)
+    assert err_msg in str(exc)
+
+
+def test_send_sms_raises_if_twilio_rejects(
+    notify_api,
+):
+    to = '+61412345678'
+    content = 'my message'
+    reference = 'my reference'
+    err_msg = 'it did not work'
+
+    uri = f'https://api.twilio.com/2010-04-01/Accounts/{twilio_sms_client._account_sid}/Messages.json'
+    with pytest.raises(RetryableException) as exc:
+        with requests_mock.Mocker() as r_mock:
+            r_mock.post(
+                uri,
+                exc=TwilioRestException(status=400, uri=uri, msg=err_msg),
+            )
+            twilio_sms_client.send_sms(to, content, reference)
+
+    assert err_msg in str(exc)
 
 
 def test_send_sms_raises_if_twilio_fails_to_return_json(


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Updates the catch to raise a `RetryableException`, and upstream we catch avoid logging it as an exception because it is logged where the exception happened. 

Catches this [exception](https://vanotify.ddog-gov.com/logs?query=%40exc_info%3A%2ATwilioRestException%2A&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&context_event=AZRArEiOAAA2n_jCueMvJwAb&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&viz=&from_ts=1736011556047&to_ts=1736270756047&live=false) now:
![image](https://github.com/user-attachments/assets/633ac2db-7a05-4531-b7da-cfef806b8d7b)


Also put the `ConnectionError`, `ConnectTimeout`, and `ReadTimeout` that was falling into the [generic catch and retry](https://vanotify.ddog-gov.com/logs?query=%22Twilio%20send%20SMS%20request%20for%22%20%22failed%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1733678698084&to_ts=1736270698084&live=false) into this PR.
![image](https://github.com/user-attachments/assets/40af4e9b-3186-4392-8883-ed9ceb84cbaa)


issue #2219 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->
Unit tests were in a failing state with the change. Updated test to cover the different exception raised.
[Deployed](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/12654980907), regression passes.

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
