### PR TITLE
#1358 Redact personalization when in final state

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,4 +1,6 @@
 fileignoreconfig:
+- filename: app/celery/process_ses_receipts_tasks.py
+  checksum: 3e7ce740725d4c904663c34102a5bb3587ffec3991ffb1a6919b1b9cf8327267
 - filename: app/dao/api_key_dao.py
   checksum: c44cbd8ae02fb1d551a1f0941365c11977564a6444950ee2b0282ee4b5fd1314
 - filename: app/schema_validation/__init__.py

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -205,6 +205,9 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
             )
             return
 
+        if incoming_status in (NOTIFICATION_PERMANENT_FAILURE, NOTIFICATION_DELIVERED):
+            notification.personalisation = '<redacted>'
+
         # This is a test of the new status.  Is it a bounce?
         if incoming_status in (NOTIFICATION_TEMPORARY_FAILURE, NOTIFICATION_PERMANENT_FAILURE):
             # Add the failure status reason to the notification.

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -207,7 +207,8 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
             return
 
         if incoming_status in NOTIFICATION_STATUS_TYPES_COMPLETED:
-            notification.personalisation = {k: '<redacted>' for k in notification.personalisation}
+            for key in notification.personalisation:
+                notification.personalisation[key] = '<redacted>'
 
         # This is a test of the new status.  Is it a bounce?
         if incoming_status in (NOTIFICATION_TEMPORARY_FAILURE, NOTIFICATION_PERMANENT_FAILURE):

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -28,7 +28,6 @@ from app.constants import (
     NOTIFICATION_PENDING,
     NOTIFICATION_PERMANENT_FAILURE,
     NOTIFICATION_SENDING,
-    NOTIFICATION_STATUS_TYPES_COMPLETED,
     NOTIFICATION_TEMPORARY_FAILURE,
     STATUS_REASON_RETRYABLE,
     STATUS_REASON_UNREACHABLE,
@@ -206,7 +205,9 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
             )
             return
 
-        if incoming_status in NOTIFICATION_STATUS_TYPES_COMPLETED:
+        # Redact personalisation when an email is in a final state. An email may go from delivered to a bounce, but
+        # that will not affect the redaction, as the email will not be retried.
+        if incoming_status in (NOTIFICATION_DELIVERED, NOTIFICATION_PERMANENT_FAILURE):
             notification.personalisation = {k: '<redacted>' for k in notification.personalisation}
 
         # This is a test of the new status.  Is it a bounce?

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -207,8 +207,7 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
             return
 
         if incoming_status in NOTIFICATION_STATUS_TYPES_COMPLETED:
-            for key in notification.personalisation:
-                notification.personalisation[key] = '<redacted>'
+            notification.personalisation = {k: '<redacted>' for k in notification.personalisation}
 
         # This is a test of the new status.  Is it a bounce?
         if incoming_status in (NOTIFICATION_TEMPORARY_FAILURE, NOTIFICATION_PERMANENT_FAILURE):

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -206,7 +206,7 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
             return
 
         if incoming_status in (NOTIFICATION_PERMANENT_FAILURE, NOTIFICATION_DELIVERED):
-            notification.personalisation = '<redacted>'
+            notification.personalisation = {k: '<redacted>' for k in notification.personalisation}
 
         # This is a test of the new status.  Is it a bounce?
         if incoming_status in (NOTIFICATION_TEMPORARY_FAILURE, NOTIFICATION_PERMANENT_FAILURE):

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -25,9 +25,10 @@ from app.constants import (
     HTTP_TIMEOUT,
     KEY_TYPE_NORMAL,
     NOTIFICATION_DELIVERED,
-    NOTIFICATION_SENDING,
     NOTIFICATION_PENDING,
     NOTIFICATION_PERMANENT_FAILURE,
+    NOTIFICATION_SENDING,
+    NOTIFICATION_STATUS_TYPES_COMPLETED,
     NOTIFICATION_TEMPORARY_FAILURE,
     STATUS_REASON_RETRYABLE,
     STATUS_REASON_UNREACHABLE,
@@ -205,7 +206,7 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
             )
             return
 
-        if incoming_status in (NOTIFICATION_PERMANENT_FAILURE, NOTIFICATION_DELIVERED):
+        if incoming_status in NOTIFICATION_STATUS_TYPES_COMPLETED:
             notification.personalisation = {k: '<redacted>' for k in notification.personalisation}
 
         # This is a test of the new status.  Is it a bounce?

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -24,7 +24,7 @@ from sqlalchemy.sql.expression import case
 from sqlalchemy.dialects.postgresql import insert
 from werkzeug.datastructures import MultiDict
 
-from app import db
+from app import db, encryption
 from app.aws.s3 import remove_s3_object, get_s3_bucket_objects
 from app.constants import (
     EMAIL_TYPE,
@@ -360,8 +360,8 @@ def dao_update_sms_notification_delivery_status(
         'cost_in_millicents': cost_in_millicents,
     }
 
-    # if new_status in FINAL_STATUS_STATES:
-    #     stmt_values['personalisation'] = {'foo': 'bar'}
+    if new_status in FINAL_STATUS_STATES:
+        stmt_values['_personalisation'] = encryption.encrypt('<redacted>')
 
     if notification_type == SMS_TYPE:
         stmt = (

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -362,7 +362,6 @@ def dao_update_sms_notification_delivery_status(
         }
 
         if new_status in FINAL_STATUS_STATES:
-            # IDK how to do this without an additional query
             notification = db.session.get(Notification, notification_id)
             stmt_values['_personalisation'] = encryption.encrypt(
                 {k: '<redacted>' for k in notification.personalisation}

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -353,19 +353,25 @@ def dao_update_sms_notification_delivery_status(
         Notification: A Notification object
     """
 
+    stmt_values = {
+        'status': new_status,
+        'status_reason': new_status_reason,
+        'segments_count': segments_count,
+        'cost_in_millicents': cost_in_millicents,
+    }
+
+    # if new_status in FINAL_STATUS_STATES:
+    #     stmt_values['personalisation'] = {'foo': 'bar'}
+
     if notification_type == SMS_TYPE:
         stmt = (
             update(Notification)
             .where(Notification.id == notification_id)
             .where(sms_conditions(new_status))
-            .values(
-                status=new_status,
-                status_reason=new_status_reason,
-                segments_count=segments_count,
-                cost_in_millicents=cost_in_millicents,
-            )
+            .values(**stmt_values)
             .execution_options(synchronize_session='fetch')
         )
+
         current_app.logger.debug('sms delivery status statement: %s', stmt)
     else:
         raise NotImplementedError(

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -353,17 +353,21 @@ def dao_update_sms_notification_delivery_status(
         Notification: A Notification object
     """
 
-    stmt_values = {
-        'status': new_status,
-        'status_reason': new_status_reason,
-        'segments_count': segments_count,
-        'cost_in_millicents': cost_in_millicents,
-    }
-
-    if new_status in FINAL_STATUS_STATES:
-        stmt_values['_personalisation'] = encryption.encrypt('<redacted>')
-
     if notification_type == SMS_TYPE:
+        stmt_values = {
+            'status': new_status,
+            'status_reason': new_status_reason,
+            'segments_count': segments_count,
+            'cost_in_millicents': cost_in_millicents,
+        }
+
+        if new_status in FINAL_STATUS_STATES:
+            # IDK how to do this without an additional query
+            notification = db.session.get(Notification, notification_id)
+            stmt_values['_personalisation'] = encryption.encrypt(
+                {k: '<redacted>' for k in notification.personalisation}
+            )
+
         stmt = (
             update(Notification)
             .where(Notification.id == notification_id)

--- a/tests/app/celery/test_process_delivery_status_result_tasks.py
+++ b/tests/app/celery/test_process_delivery_status_result_tasks.py
@@ -560,4 +560,4 @@ def test_process_delivery_status_redacts_personalisation(
     process_delivery_status(event=sample_delivery_status_result_message)
 
     notification = dao_get_notification_by_reference('SMyyy')
-    assert notification.personalisation == '<redacted>'
+    assert notification.personalisation == {'foo': '<redacted>'}

--- a/tests/app/celery/test_process_delivery_status_result_tasks.py
+++ b/tests/app/celery/test_process_delivery_status_result_tasks.py
@@ -536,3 +536,28 @@ def test_get_include_payload_status_exception(notify_api, mocker, sample_notific
         'app.celery.process_delivery_status_result_tasks.dao_get_callback_include_payload_status', side_effect=exception
     )
     assert not _get_include_payload_status(sample_notification())
+
+
+@pytest.mark.serial
+def test_process_delivery_status_redacts_personalisation(
+    mocker,
+    sample_delivery_status_result_message,
+    sample_template,
+    sample_notification,
+):
+    """
+    Test that the Celery task will redact personalisation if the delivery status is in a final state.
+    """
+    sample_notification(
+        template=sample_template(content='Test ((foo))'),
+        reference='SMyyy',
+        sent_at=datetime.now(timezone.utc),
+        status=NOTIFICATION_SENDING,
+        personalisation={'foo': 'bar'},
+    )
+
+    mocker.patch('app.celery.process_delivery_status_result_tasks._get_include_payload_status', returns=True)
+    process_delivery_status(event=sample_delivery_status_result_message)
+
+    notification = dao_get_notification_by_reference('SMyyy')
+    assert notification.personalisation == '<redacted>'

--- a/tests/app/celery/test_process_delivery_status_result_tasks.py
+++ b/tests/app/celery/test_process_delivery_status_result_tasks.py
@@ -556,7 +556,7 @@ def test_process_delivery_status_redacts_personalisation(
         personalisation={'foo': 'bar'},
     )
 
-    mocker.patch('app.celery.process_delivery_status_result_tasks._get_include_payload_status', returns=True)
+    # mocker.patch('app.celery.process_delivery_status_result_tasks._get_include_payload_status', returns=True)
     process_delivery_status(event=sample_delivery_status_result_message)
 
     notification = dao_get_notification_by_reference('SMyyy')

--- a/tests/app/celery/test_process_delivery_status_result_tasks.py
+++ b/tests/app/celery/test_process_delivery_status_result_tasks.py
@@ -541,6 +541,7 @@ def test_get_include_payload_status_exception(notify_api, mocker, sample_notific
 @pytest.mark.serial
 def test_process_delivery_status_redacts_personalisation(
     mocker,
+    notify_db_session,
     sample_delivery_status_result_message,
     sample_template,
     sample_notification,
@@ -548,7 +549,7 @@ def test_process_delivery_status_redacts_personalisation(
     """
     Test that the Celery task will redact personalisation if the delivery status is in a final state.
     """
-    sample_notification(
+    notification = sample_notification(
         template=sample_template(content='Test ((foo))'),
         reference='SMyyy',
         sent_at=datetime.now(timezone.utc),
@@ -558,5 +559,5 @@ def test_process_delivery_status_redacts_personalisation(
 
     process_delivery_status(event=sample_delivery_status_result_message)
 
-    notification = dao_get_notification_by_reference('SMyyy')
+    notify_db_session.session.refresh(notification)
     assert notification.personalisation == {'foo': '<redacted>'}

--- a/tests/app/celery/test_process_delivery_status_result_tasks.py
+++ b/tests/app/celery/test_process_delivery_status_result_tasks.py
@@ -556,7 +556,6 @@ def test_process_delivery_status_redacts_personalisation(
         personalisation={'foo': 'bar'},
     )
 
-    # mocker.patch('app.celery.process_delivery_status_result_tasks._get_include_payload_status', returns=True)
     process_delivery_status(event=sample_delivery_status_result_message)
 
     notification = dao_get_notification_by_reference('SMyyy')

--- a/tests/app/celery/test_process_pinpoint_receipt_tasks.py
+++ b/tests/app/celery/test_process_pinpoint_receipt_tasks.py
@@ -376,5 +376,5 @@ def test_process_pinpoint_results_notification_final_status_personalisation(
         )
     )
     notification = notifications_dao.dao_get_notification_by_reference(test_reference)
-    assert notification.personalisation == '<redacted>'
+    assert notification.personalisation == {'name': '<redacted>'}
     mock_callback.assert_called_once()

--- a/tests/app/celery/test_process_pinpoint_receipt_tasks.py
+++ b/tests/app/celery/test_process_pinpoint_receipt_tasks.py
@@ -355,6 +355,7 @@ def test_process_pinpoint_callback_message_parse_exception(
 
 def test_process_pinpoint_results_notification_final_status_personalisation(
     mocker,
+    notify_db_session,
     sample_template,
     sample_notification,
 ):
@@ -362,7 +363,7 @@ def test_process_pinpoint_results_notification_final_status_personalisation(
 
     test_reference = str(uuid4())
     template = sample_template(content='Hello ((name))')
-    sample_notification(
+    notification = sample_notification(
         template=template,
         reference=test_reference,
         sent_at=datetime.now(timezone.utc),
@@ -375,6 +376,6 @@ def test_process_pinpoint_results_notification_final_status_personalisation(
             reference=test_reference, event_type='_SMS.SUCCESS', record_status='DELIVERED'
         )
     )
-    notification = notifications_dao.dao_get_notification_by_reference(test_reference)
+    notify_db_session.session.refresh(notification)
     assert notification.personalisation == {'name': '<redacted>'}
     mock_callback.assert_called_once()

--- a/tests/app/celery/test_process_pinpoint_receipt_tasks.py
+++ b/tests/app/celery/test_process_pinpoint_receipt_tasks.py
@@ -356,7 +356,6 @@ def test_process_pinpoint_callback_message_parse_exception(
 def test_process_pinpoint_results_notification_final_status_personalisation(
     mocker,
     sample_template,
-    event_type,
     sample_notification,
 ):
     mock_callback = mocker.patch('app.celery.process_delivery_status_result_tasks.check_and_queue_callback_task')
@@ -373,7 +372,7 @@ def test_process_pinpoint_results_notification_final_status_personalisation(
     )
     process_pinpoint_results(
         response=pinpoint_notification_callback_record(
-            reference=test_reference, event_type=event_type, record_status='DELIVERED'
+            reference=test_reference, event_type='_SMS.SUCCESS', record_status='DELIVERED'
         )
     )
     notification = notifications_dao.dao_get_notification_by_reference(test_reference)

--- a/tests/app/celery/test_process_pinpoint_receipt_tasks.py
+++ b/tests/app/celery/test_process_pinpoint_receipt_tasks.py
@@ -351,3 +351,31 @@ def test_process_pinpoint_callback_message_parse_exception(
     with pytest.raises(NonRetryableException) as exc_info:
         process_pinpoint_results(pinpoint_notification_callback_record(reference=str(uuid4())))
     assert UNABLE_TO_TRANSLATE in str(exc_info)
+
+
+def test_process_pinpoint_results_notification_final_status_personalisation(
+    mocker,
+    sample_template,
+    event_type,
+    sample_notification,
+):
+    mock_callback = mocker.patch('app.celery.process_delivery_status_result_tasks.check_and_queue_callback_task')
+
+    test_reference = str(uuid4())
+    template = sample_template(content='Hello ((name))')
+    sample_notification(
+        template=template,
+        reference=test_reference,
+        sent_at=datetime.now(timezone.utc),
+        status=NOTIFICATION_SENDING,
+        status_reason='just because',
+        personalisation={'name': 'Bob'},
+    )
+    process_pinpoint_results(
+        response=pinpoint_notification_callback_record(
+            reference=test_reference, event_type=event_type, record_status='DELIVERED'
+        )
+    )
+    notification = notifications_dao.dao_get_notification_by_reference(test_reference)
+    assert notification.personalisation == '<redacted>'
+    mock_callback.assert_called_once()

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -676,4 +676,4 @@ def test_process_ses_results_personalisation(notify_db_session, sample_template,
 
     notify_db_session.session.refresh(notification)
     assert notification.status == NOTIFICATION_DELIVERED
-    assert notification.personalisation == '<redacted>'
+    assert notification.personalisation == {'name': '<redacted>'}

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -653,3 +653,27 @@ def test_process_ses_results_no_bounce_regression(
     notify_db_session.session.refresh(notification)
     assert notification.status == status, 'The status should not have changed.'
     assert notification.status_reason == status_reason
+
+
+def test_process_ses_results_personalisation(notify_db_session, sample_template, sample_notification, mocker):
+    template = sample_template(template_type=EMAIL_TYPE, content='Hello ((name))')
+    ref = str(uuid4())
+
+    mock_send_email_status = mocker.patch(
+        'app.celery.send_va_profile_notification_status_tasks.send_notification_status_to_va_profile.apply_async'
+    )
+    mock_send_email_status.return_value = None
+
+    notification = sample_notification(
+        template=template,
+        reference=ref,
+        sent_at=datetime.utcnow(),
+        status=NOTIFICATION_SENDING,
+        status_reason='just because',
+        personalisation={'name': 'Jo'},
+    )
+    assert process_ses_receipts_tasks.process_ses_results(response=ses_notification_callback(reference=ref))
+
+    notify_db_session.session.refresh(notification)
+    assert notification.status == NOTIFICATION_DELIVERED
+    assert notification.personalisation == '<redacted>'


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR redacts personalization in the database when a notification is in a final state.

issue #1358 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- [Deployed to dev](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/13011771326), unit and regression tests pass.
- Sent an SMS with personalization
<img width="1066" alt="Screenshot 2025-01-28 at 8 03 51 AM" src="https://github.com/user-attachments/assets/054f0225-8b3b-411a-ab5e-601a978ce948" />

Verified:
- rendered correctly on phone. 
- field is encrypted and redacted in Postgres
<img width="810" alt="Screenshot 2025-01-28 at 8 02 54 AM" src="https://github.com/user-attachments/assets/19e956be-9306-4908-8a25-9a975a85409a" />

- Sent an email with personalization
<img width="1287" alt="Screenshot 2025-01-28 at 8 20 52 AM" src="https://github.com/user-attachments/assets/7ceeeedf-ffa8-488d-b841-79c196b49390" />

Verified:
- rendered correctly
![Screenshot 2025-01-28 at 8 12 42 AM](https://github.com/user-attachments/assets/fe042367-1393-4e8e-8cdd-cd3de56893f2)
- field is encrypted and redacted in Postgres
<img width="845" alt="Screenshot 2025-01-28 at 8 24 13 AM" src="https://github.com/user-attachments/assets/dbf68f67-4dc4-4d83-8eca-dff40d5b41d7" />

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
