### PR TITLE
#2286 missing e-mail subject personalisation errors

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -6,7 +6,7 @@ fileignoreconfig:
 - filename: app/schema_validation/__init__.py
   checksum: 9487ddbb105a20f5fd495eb4426b7c27ee3be1894b69a189363363ed616722c0
 - filename: poetry.lock
-  checksum: 1fb22a1a20ebe8084ccdd64b9a57f30fd0a9fbe35edfeaca4ea3cba8b9fb725b
+  checksum: 11c62ad0cde9cff96d0ebb5b77d7d170fec54b226a966aefe2b2098058b24281
 - filename: tests/app/dao/test_api_key_dao.py
   checksum: 5bab4eaddf8760c502111ae3e5f9f8bee59482d99f053f94598e8c77bd10b7b6
 - filename: tests/app/dao/test_ft_billing_dao.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -6,7 +6,7 @@ fileignoreconfig:
 - filename: app/schema_validation/__init__.py
   checksum: 9487ddbb105a20f5fd495eb4426b7c27ee3be1894b69a189363363ed616722c0
 - filename: poetry.lock
-  checksum: af5fb0c9dbbd760ad68c127b16337e6cdd4dbc4b25be6fce2e37d274a9ea96af
+  checksum: 5a38233437be4d758c89889492e0848616c7d7394e1148e85398a4ba9ee00962
 - filename: tests/app/dao/test_api_key_dao.py
   checksum: 5bab4eaddf8760c502111ae3e5f9f8bee59482d99f053f94598e8c77bd10b7b6
 - filename: tests/app/dao/test_ft_billing_dao.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -6,7 +6,7 @@ fileignoreconfig:
 - filename: app/schema_validation/__init__.py
   checksum: 9487ddbb105a20f5fd495eb4426b7c27ee3be1894b69a189363363ed616722c0
 - filename: poetry.lock
-  checksum: 11c62ad0cde9cff96d0ebb5b77d7d170fec54b226a966aefe2b2098058b24281
+  checksum: af5fb0c9dbbd760ad68c127b16337e6cdd4dbc4b25be6fce2e37d274a9ea96af
 - filename: tests/app/dao/test_api_key_dao.py
   checksum: 5bab4eaddf8760c502111ae3e5f9f8bee59482d99f053f94598e8c77bd10b7b6
 - filename: tests/app/dao/test_ft_billing_dao.py

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -34,12 +34,7 @@ from app.dao.service_sms_sender_dao import (
     dao_get_service_sms_sender_by_service_id_and_number,
 )
 from app.feature_flags import accept_recipient_identifiers_enabled, is_feature_enabled, FeatureFlag
-from app.models import (
-    Notification,
-    ScheduledNotification,
-    RecipientIdentifier,
-    Template
-)
+from app.models import Notification, ScheduledNotification, RecipientIdentifier, Template
 from app.dao.notifications_dao import (
     dao_create_notification,
     dao_delete_notification_by_id,

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -38,6 +38,7 @@ from app.models import (
     Notification,
     ScheduledNotification,
     RecipientIdentifier,
+    Template
 )
 from app.dao.notifications_dao import (
     dao_create_notification,
@@ -50,18 +51,23 @@ from app.va.identifier import IdentifierType
 
 
 def create_content_for_notification(
-    template,
-    personalisation,
+    template: Template,
+    personalisation: dict,
 ):
-    template_object = get_template_instance(template.__dict__, personalisation)
-    check_placeholders(template_object)
+    """
+    Return an appropriate template instance from the notifications-utils repository,
+    or raise BadRequestError.
+    """
 
-    return template_object
+    utils_template_instance = get_template_instance(template.__dict__, personalisation)
+    check_placeholders(utils_template_instance)
+
+    return utils_template_instance
 
 
-def check_placeholders(template_object):
-    if template_object.missing_data:
-        message = 'Missing personalisation: {}'.format(', '.join(template_object.missing_data))
+def check_placeholders(utils_template_instance):
+    if utils_template_instance.missing_data:
+        message = 'Missing personalisation: {}'.format(', '.join(utils_template_instance.missing_data))
         raise BadRequestError(fields=[{'template': message}], message=message)
 
 

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -215,7 +215,7 @@ def preview_template_by_id_and_service_id(
 ):
     fetched_template = dao_get_template_by_id_and_service_id(template_id=template_id, service_id=service_id)
     data = template_schema.dump(fetched_template)
-    template_object = get_template_instance(data, values=request.args.to_dict())
+    template_object = get_template_instance(data, request.args.to_dict())
 
     if template_object.missing_data:
         raise InvalidRequest(

--- a/app/utils.py
+++ b/app/utils.py
@@ -48,7 +48,7 @@ def get_template_instance(
     Return an appropriate template instance from the notifications-utils repository.  This happens here
     in order to validate that POST data for sending a notification has the correct personalisation values.
     Note that the same process inefficiently happens again later, in Celery, when the message is sending.
-    
+
     template - A dictionary of the attributes and values of a Template instance
     personalisation - personalization for a template instance
     """

--- a/app/utils.py
+++ b/app/utils.py
@@ -41,12 +41,21 @@ def url_with_token(
 
 
 def get_template_instance(
-    template,
-    values,
+    template: dict,
+    personalisation: dict,
 ):
+    """
+    Return an appropriate template instance from the notifications-utils repository.  This happens here
+    in order to validate that POST data for sending a notification has the correct personalisation values.
+    Note that the same process inefficiently happens again later, in Celery, when the message is sending.
+    
+    template - A dictionary of the attributes and values of a Template instance
+    personalisation - personalization for a template instance
+    """
+
     return {SMS_TYPE: SMSMessageTemplate, EMAIL_TYPE: WithSubjectTemplate, LETTER_TYPE: WithSubjectTemplate}[
         template['template_type']
-    ](template, values)
+    ](template, personalisation)
 
 
 def get_html_email_body_from_template(template_instance):

--- a/app/v2/template/post_template.py
+++ b/app/v2/template/post_template.py
@@ -21,7 +21,7 @@ def post_template_preview(template_id):
 
     template = templates_dao.dao_get_template_by_id_and_service_id(template_id, authenticated_service.id)
 
-    template_object = get_template_instance(template.__dict__, values=data.get('personalisation'))
+    template_object = get_template_instance(template.__dict__, data.get('personalisation'))
 
     check_placeholders(template_object)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2250,8 +2250,8 @@ statsd = ">=4.0.1"
 [package.source]
 type = "git"
 url = "https://github.com/department-of-veterans-affairs/notification-utils.git"
-reference = "HEAD"
-resolved_reference = "5b67537a6ed604f267076df6a640d75608701b89"
+reference = "API-2286-subject-placeholders"
+resolved_reference = "825dcd4fe198afc841b8bd0746673a799f0cd462"
 
 [[package]]
 name = "notifications-python-client"
@@ -3818,4 +3818,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10"
-content-hash = "f3a69b3a5bcd7c5ec5d6df87152a7fab8471696caa488bd4015a2d2a54a3c8fe"
+content-hash = "af22daa764c3fc2d87f1409d4f3bd05991d2d9632412b6585beaca50991cd36b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2250,8 +2250,8 @@ statsd = ">=4.0.1"
 [package.source]
 type = "git"
 url = "https://github.com/department-of-veterans-affairs/notification-utils.git"
-reference = "API-2286-subject-placeholders"
-resolved_reference = "a5bc579ad038e65bfb65b67055ce17e3c3a6f376"
+reference = "HEAD"
+resolved_reference = "c9392a6b282d021994673fa21c93013b09f1791b"
 
 [[package]]
 name = "notifications-python-client"
@@ -3818,4 +3818,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10"
-content-hash = "af22daa764c3fc2d87f1409d4f3bd05991d2d9632412b6585beaca50991cd36b"
+content-hash = "f3a69b3a5bcd7c5ec5d6df87152a7fab8471696caa488bd4015a2d2a54a3c8fe"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2221,7 +2221,7 @@ files = [
 
 [[package]]
 name = "notification-utils"
-version = "2.3.1"
+version = "2.3.2"
 description = "Shared python code for VA Notify. Forked from https://github.com/cds-snc/notification-utils"
 optional = false
 python-versions = "*"
@@ -2251,7 +2251,7 @@ statsd = ">=4.0.1"
 type = "git"
 url = "https://github.com/department-of-veterans-affairs/notification-utils.git"
 reference = "API-2286-subject-placeholders"
-resolved_reference = "825dcd4fe198afc841b8bd0746673a799f0cd462"
+resolved_reference = "a5bc579ad038e65bfb65b67055ce17e3c3a6f376"
 
 [[package]]
 name = "notifications-python-client"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ twilio = "*"
 Unidecode = "*"
 validatesns = "*"
 Werkzeug = "*"
-notification-utils = {git = "https://github.com/department-of-veterans-affairs/notification-utils.git"}
+notification-utils = {git = "https://github.com/department-of-veterans-affairs/notification-utils.git", branch = 'API-2286-subject-placeholders'}
 
 [tool.poetry.group.test]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ twilio = "*"
 Unidecode = "*"
 validatesns = "*"
 Werkzeug = "*"
-notification-utils = {git = "https://github.com/department-of-veterans-affairs/notification-utils.git", branch = 'API-2286-subject-placeholders'}
+notification-utils = {git = "https://github.com/department-of-veterans-affairs/notification-utils.git"}
 
 [tool.poetry.group.test]
 optional = true

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -544,11 +544,8 @@ def test_should_save_sms_if_restricted_service_and_valid_number(
 
     # Cleaned by sample_template
     notification = _notification_json(template, '+16502532222')
-
-    mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
-
-    notification_id = uuid4()
     encrypt_notification = encryption.encrypt(notification)
+    notification_id = uuid4()
 
     save_sms(
         service.id,
@@ -568,6 +565,9 @@ def test_should_save_sms_if_restricted_service_and_valid_number(
     assert not persisted_notification.job_id
     assert not persisted_notification.personalisation
     assert persisted_notification.notification_type == SMS_TYPE
+
+    mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
+
     provider_tasks.deliver_sms.apply_async.assert_called_once_with(
         args=(),
         kwargs={'notification_id': str(persisted_notification.id)},

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -531,6 +531,7 @@ def test_should_put_save_sms_task_in_research_mode_queue_if_research_mode_servic
     assert mocked_deliver_sms.called
 
 
+@pytest.mark.serial
 def test_should_save_sms_if_restricted_service_and_valid_number(
     notify_db_session,
     mocker,
@@ -546,6 +547,8 @@ def test_should_save_sms_if_restricted_service_and_valid_number(
     notification = _notification_json(template, '+16502532222')
     encrypt_notification = encryption.encrypt(notification)
     notification_id = uuid4()
+
+    mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
     save_sms(
         service.id,
@@ -565,8 +568,6 @@ def test_should_save_sms_if_restricted_service_and_valid_number(
     assert not persisted_notification.job_id
     assert not persisted_notification.personalisation
     assert persisted_notification.notification_type == SMS_TYPE
-
-    mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
     provider_tasks.deliver_sms.apply_async.assert_called_once_with(
         args=(),

--- a/tests/app/notifications/test_process_notifications.py
+++ b/tests/app/notifications/test_process_notifications.py
@@ -1239,7 +1239,7 @@ def test_send_notification_to_queue_delayed_throws_exception_when_send_message_f
         ('subject', 'hello ((name))', {'name': 'name'}),
         ('subject ((name))', 'hello', {'name': 'name'}),
         ('subject ((subject_name))', 'hello ((content_name))', {'subject_name': 'name', 'content_name': 'name'}),
-    ]
+    ],
 )
 def test_check_placeholders_email(sample_template, subject, content, personalisation):
     """
@@ -1259,7 +1259,7 @@ def test_check_placeholders_email(sample_template, subject, content, personalisa
         ('subject ((name))', 'hello', {}),
         ('subject', 'hello ((name))', {'other': 'other'}),
         ('subject ((name))', 'hello', {'other': 'other'}),
-    ]
+    ],
 )
 def test_check_placeholders_email_missing_personalisation(sample_template, subject, content, personalisation):
     template = sample_template(template_type=EMAIL_TYPE, subject=subject, content=content)

--- a/tests/app/notifications/test_process_notifications.py
+++ b/tests/app/notifications/test_process_notifications.py
@@ -33,6 +33,7 @@ from app.models import (
     RecipientIdentifier,
 )
 from app.notifications.process_notifications import (
+    check_placeholders,
     create_content_for_notification,
     persist_notification,
     persist_scheduled_notification,
@@ -42,6 +43,8 @@ from app.notifications.process_notifications import (
     simulated_recipient,
 )
 from notifications_utils.recipients import validate_and_format_phone_number, validate_and_format_email_address
+from notifications_utils.template import WithSubjectTemplate
+from app.utils import get_template_instance
 from app.v2.errors import BadRequestError
 from app.va.identifier import IdentifierType
 
@@ -1225,3 +1228,45 @@ def test_send_notification_to_queue_delayed_throws_exception_when_send_message_f
     assert 'test exception' in str(e)
 
     logger.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ('subject', 'content', 'personalisation'),
+    [
+        ('subject', 'content', {}),
+        # Unused placeholder values should be ignored and not cause problems.
+        ('subject', 'content', {'test': 'test'}),
+        ('subject', 'hello ((name))', {'name': 'name'}),
+        ('subject ((name))', 'hello', {'name': 'name'}),
+        ('subject ((subject_name))', 'hello ((content_name))', {'subject_name': 'name', 'content_name': 'name'}),
+    ]
+)
+def test_check_placeholders_email(sample_template, subject, content, personalisation):
+    """
+    Test the happy path.  No exception should get raised.
+    """
+
+    template = sample_template(template_type=EMAIL_TYPE, subject=subject, content=content)
+    utils_template_instance = get_template_instance(template.__dict__, personalisation)
+    assert isinstance(utils_template_instance, WithSubjectTemplate)
+    assert check_placeholders(utils_template_instance) is None
+
+
+@pytest.mark.parametrize(
+    ('subject', 'content', 'personalisation'),
+    [
+        ('subject', 'hello ((name))', {}),
+        ('subject ((name))', 'hello', {}),
+        ('subject', 'hello ((name))', {'other': 'other'}),
+        ('subject ((name))', 'hello', {'other': 'other'}),
+    ]
+)
+def test_check_placeholders_email_missing_personalisation(sample_template, subject, content, personalisation):
+    template = sample_template(template_type=EMAIL_TYPE, subject=subject, content=content)
+    utils_template_instance = get_template_instance(template.__dict__, personalisation)
+    assert isinstance(utils_template_instance, WithSubjectTemplate)
+
+    print(utils_template_instance.missing_data)  # TODO - delete
+
+    with pytest.raises(BadRequestError):
+        check_placeholders(utils_template_instance)

--- a/tests/app/notifications/test_process_notifications.py
+++ b/tests/app/notifications/test_process_notifications.py
@@ -1266,7 +1266,5 @@ def test_check_placeholders_email_missing_personalisation(sample_template, subje
     utils_template_instance = get_template_instance(template.__dict__, personalisation)
     assert isinstance(utils_template_instance, WithSubjectTemplate)
 
-    print(utils_template_instance.missing_data)  # TODO - delete
-
     with pytest.raises(BadRequestError):
         check_placeholders(utils_template_instance)


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

These changes add unit tests and pull in an updated version of Utils.  (See the Utils PR.)  The goal is that requests to send e-mail using a template with a placeholder in the subject return 400 if the POST data doesn't contain an associated value.  The problem was that Utils was only checking for missing values in the content body.

- issue #2286
- Associated [Utils PR](https://github.com/department-of-veterans-affairs/notification-utils/pull/205).

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

I repeated that steps in the ticket to reproduce the problem and observed that it's no longer a problem.

Happy path with template `b2c9ff49-b37b-4352-ab0c-3d3d0710fe4c`:
![image](https://github.com/user-attachments/assets/e6c1019d-9fba-4e25-bf8d-766c1a617753)

Missing subject data:
![image](https://github.com/user-attachments/assets/a01c997c-79fb-445f-93b2-57eca0a76dd9)

Missing content data:
![image](https://github.com/user-attachments/assets/8012c412-12bc-458d-8bb6-4bcdb049998d)

Missing subject data with template `64b0953c-b7ea-4b48-b70f-d242ce5b17d2`, which only has a placeholder in the subject:
![image](https://github.com/user-attachments/assets/956bf76c-6436-4296-9fa2-f7132fa43c28)

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
