### PR TITLE
#Team-1455 ICN redaction

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -22,7 +22,7 @@ fileignoreconfig:
 - filename: tests/app/dao/test_services_dao.py
   checksum: 572fb3a52e89ae19c5a94be881bcbfe0247bae112bce58d4ae1e9eff5a5c91b7
 - filename: tests/app/v2/notifications/test_get_notifications.py
-  checksum: 167aa80c8aac01566b3cf627cdaa839feac9dc77f0b13b6d0a008035aa8e15f1
+  checksum: c849183c2714c9674b5fcbf7b8b78cd728124aceb4a64af06ed3401837eeaa88
 - filename: tests/app/v2/notifications/test_push_broadcast_notifications.py
   checksum: 430fb5f087b3d9995af9cff700fe0fc0152b5582901cfc46db7d0ec884367d12
 - filename: tests/app/v2/notifications/test_push_notifications.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -22,7 +22,7 @@ fileignoreconfig:
 - filename: tests/app/dao/test_services_dao.py
   checksum: 572fb3a52e89ae19c5a94be881bcbfe0247bae112bce58d4ae1e9eff5a5c91b7
 - filename: tests/app/v2/notifications/test_get_notifications.py
-  checksum: c849183c2714c9674b5fcbf7b8b78cd728124aceb4a64af06ed3401837eeaa88
+  checksum: b20c4b5e1e1e1204dea37b7cb37fec94f6720b7bb58d216af3b94d0520e09a69
 - filename: tests/app/v2/notifications/test_push_broadcast_notifications.py
   checksum: 430fb5f087b3d9995af9cff700fe0fc0152b5582901cfc46db7d0ec884367d12
 - filename: tests/app/v2/notifications/test_push_notifications.py

--- a/app/models.py
+++ b/app/models.py
@@ -1461,7 +1461,14 @@ class Notification(db.Model):
             ),
             'postage': self.postage,
             'recipient_identifiers': [
-                {'id_type': recipient_identifier.id_type, 'id_value': recipient_identifier.id_value}
+                {
+                    'id_type': recipient_identifier.id_type,
+                    'id_value': (
+                        '<redacted>'
+                        if (recipient_identifier.id_type == IdentifierType.ICN.value)
+                        else recipient_identifier.id_value
+                    )
+                }
                 for recipient_identifier in self.recipient_identifiers.values()
             ],
             'billing_code': self.billing_code,

--- a/app/models.py
+++ b/app/models.py
@@ -1467,7 +1467,7 @@ class Notification(db.Model):
                         '<redacted>'
                         if (recipient_identifier.id_type == IdentifierType.ICN.value)
                         else recipient_identifier.id_value
-                    )
+                    ),
                 }
                 for recipient_identifier in self.recipient_identifiers.values()
             ],

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -197,10 +197,14 @@ def test_email_notification_serializes_with_recipient_identifiers(
         {'id_type': IdentifierType.VA_PROFILE_ID.value, 'id_value': 'some vaprofileid'},
         {'id_type': IdentifierType.ICN.value, 'id_value': 'some icn'},
     ]
+
     template = sample_template(template_type=EMAIL_TYPE)
-    noti = sample_notification(template=template, recipient_identifiers=recipient_identifiers)
-    response = noti.serialize()
-    assert response['recipient_identifiers'] == recipient_identifiers
+    notification = sample_notification(template=template, recipient_identifiers=recipient_identifiers)
+
+    serialized_recipient_identifiers = notification.serialize()['recipient_identifiers']
+
+    recipient_identifiers[1]['id_value'] = '<redacted>'
+    assert serialized_recipient_identifiers == recipient_identifiers
 
 
 def test_email_notification_serializes_with_empty_recipient_identifiers(

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -1,7 +1,10 @@
+"""
+TODO - Delete instances of create_notification; replace with sample_notification
+"""
 import datetime
 
 import pytest
-from flask import json, url_for
+from flask import url_for
 from sqlalchemy import select
 
 from app.constants import (
@@ -50,7 +53,7 @@ def test_get_notification_by_id_returns_200(
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     expected_template_response = {
         'id': '{}'.format(first_notification.serialize()['template']['id']),
@@ -134,7 +137,7 @@ def test_get_notification_by_id_with_placeholders_and_recipient_identifiers_retu
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     expected_template_response = {
         'id': '{}'.format(notification.serialize()['template']['id']),
@@ -202,7 +205,7 @@ def test_get_notification_by_reference_returns_200(
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
     assert len(json_response['notifications']) == 1
 
     assert json_response['notifications'][0]['id'] == str(sample_notification_with_reference.id)
@@ -258,7 +261,7 @@ def test_get_notifications_returns_scheduled_for(
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
     assert len(json_response['notifications']) == 1
 
     assert json_response['notifications'][0]['id'] == str(notification_with_ref.id)
@@ -283,7 +286,7 @@ def test_get_notification_by_reference_nonexistent_reference_returns_no_notifica
         headers=[('Content-Type', 'application/json'), auth_header],
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
@@ -306,7 +309,7 @@ def test_get_notification_by_id_nonexistent_id(
     assert response.status_code == 404
     assert response.headers['Content-type'] == 'application/json'
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
     assert json_response == {'errors': [{'error': 'NoResultFound', 'message': 'No result found'}], 'status_code': 404}
 
 
@@ -326,7 +329,7 @@ def test_get_notification_by_id_invalid_id(
     assert response.status_code == 400
     assert response.headers['Content-type'] == 'application/json'
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
     assert json_response == {
         'errors': [{'error': 'ValidationError', 'message': 'notification_id is not a valid UUID'}],
         'status_code': 400,
@@ -360,7 +363,7 @@ def test_get_notification_adds_delivery_estimate_for_letters(
         headers=[('Content-Type', 'application/json'), auth_header],
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
     assert response.status_code == 200
     assert json_response['postage'] == postage
     assert json_response['estimated_delivery'] == estimated_delivery
@@ -383,7 +386,7 @@ def test_get_notification_doesnt_have_delivery_estimate_for_non_letters(
         headers=[('Content-Type', 'application/json'), auth_header],
     )
     assert response.status_code == 200
-    assert 'estimated_delivery' not in json.loads(response.get_data(as_text=True))
+    assert 'estimated_delivery' not in response.get_json()
 
     # Teardown
     notify_db_session.session.delete(mocked_notification)
@@ -405,7 +408,7 @@ def test_get_all_notifications_except_job_notifications_returns_200(
     auth_header = create_authorization_header(sample_api_key(service=template.service))
     response = client.get(path='/v2/notifications', headers=[('Content-Type', 'application/json'), auth_header])
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
@@ -442,7 +445,7 @@ def test_get_all_notifications_with_include_jobs_arg_returns_200(
         path='/v2/notifications?include_jobs=true', headers=[('Content-Type', 'application/json'), auth_header]
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert response.status_code == 200
     assert json_response['links']['current'].endswith('/v2/notifications?include_jobs=true')
@@ -463,7 +466,7 @@ def test_get_all_notifications_no_notifications_if_no_notifications(
     auth_header = create_authorization_header(sample_api_key())
     response = client.get(path='/v2/notifications', headers=[('Content-Type', 'application/json'), auth_header])
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
@@ -491,7 +494,7 @@ def test_get_all_notifications_filter_by_template_type(
         path='/v2/notifications?template_type=email', headers=[('Content-Type', 'application/json'), auth_header]
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
@@ -524,7 +527,7 @@ def test_get_all_notifications_filter_by_template_type_invalid_template_type(
         path='/v2/notifications?template_type=orange', headers=[('Content-Type', 'application/json'), auth_header]
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert response.status_code == 400
     assert response.headers['Content-type'] == 'application/json'
@@ -549,7 +552,7 @@ def test_get_all_notifications_filter_by_single_status(
         path='/v2/notifications?status=pending', headers=[('Content-Type', 'application/json'), auth_header]
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
@@ -582,7 +585,7 @@ def test_get_all_notifications_filter_by_status_invalid_status(
         path=f'/v2/notifications?status={fake_status}', headers=[('Content-Type', 'application/json'), auth_header]
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert response.status_code == 400
     assert response.headers['Content-type'] == 'application/json'
@@ -614,7 +617,7 @@ def test_get_all_notifications_filter_by_multiple_statuses(
         headers=[('Content-Type', 'application/json'), auth_header],
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
@@ -653,7 +656,7 @@ def test_get_all_notifications_filter_by_failed_status(
         path='/v2/notifications?status=failed', headers=[('Content-Type', 'application/json'), auth_header]
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
@@ -690,7 +693,7 @@ def test_get_all_notifications_filter_by_id(
         headers=[('Content-Type', 'application/json'), auth_header],
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
@@ -716,7 +719,7 @@ def test_get_all_notifications_filter_by_id_invalid_id(
         headers=[('Content-Type', 'application/json'), auth_header],
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert json_response['status_code'] == 400
     assert len(json_response['errors']) == 1
@@ -738,7 +741,7 @@ def test_get_all_notifications_filter_by_id_no_notifications_if_nonexistent_id(
         headers=[('Content-Type', 'application/json'), auth_header],
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
@@ -768,7 +771,7 @@ def test_get_all_notifications_filter_by_id_no_notifications_if_last_notificatio
         headers=[('Content-Type', 'application/json'), auth_header],
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
@@ -810,7 +813,7 @@ def test_get_all_notifications_filter_multiple_query_parameters(
         headers=[('Content-Type', 'application/json'), auth_header],
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
 
     assert response.status_code == 200
     assert response.headers['Content-type'] == 'application/json'
@@ -845,7 +848,7 @@ def test_get_all_notifications_renames_letter_statuses(client, sample_letter_not
         path=url_for('v2_notifications.get_notifications'), headers=[('Content-Type', 'application/json'), auth_header]
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
     assert response.status_code == 200
 
     for noti in json_response['notifications']:
@@ -879,7 +882,7 @@ def test_get_notifications_renames_letter_statuses(client, sample_letter_templat
         headers=[('Content-Type', 'application/json'), auth_header],
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
     assert response.status_code == 200
     assert json_response['status'] == expected_status
 
@@ -906,7 +909,7 @@ def test_get_notifications_removes_personalisation_from_content(
         headers=[('Content-Type', 'application/json'), auth_header],
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
     assert response.status_code == 200
     assert json_response['body'] == 'Hello <redacted>\nThis is an email from VA Notify about some <redacted>'
 
@@ -932,6 +935,27 @@ def test_get_notifications_removes_personalisation_from_subject(
         headers=[('Content-Type', 'application/json'), auth_header],
     )
 
-    json_response = json.loads(response.get_data(as_text=True))
+    json_response = response.get_json()
     assert response.status_code == 200
     assert json_response['subject'] == 'Hello <redacted>'
+
+
+def test_get_notification_redacts_icn(
+    client,
+    sample_api_key,
+    sample_template,
+    sample_notification
+):
+    notification = create_notification(
+        template=sample_template(),
+        recipient_identifiers=[{'id_type': IdentifierType.ICN.value, 'id_value': 'icn'}]
+    )
+    assert notification.recipient_identifiers['ICN'].id_value == 'icn'
+    auth_header = create_authorization_header(sample_api_key(service=notification.template.service))
+
+    response = client.get(
+        path=url_for('v2_notifications.get_notification_by_id', notification_id=notification.id),
+        headers=[('Content-Type', 'application/json'), auth_header]
+    )
+
+    assert response.get_json()['recipient_identifiers'][0]['id_value'] == '<redacted>'

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -113,7 +113,7 @@ def test_get_notification_by_id_with_placeholders_and_recipient_identifiers_retu
     auth_header = create_authorization_header(sample_api_key(service=template.service))
     response = client.get(
         path=url_for('v2_notifications.get_notification_by_id', notification_id=notification.id),
-        headers=[('Content-Type', 'application/json'), auth_header]
+        headers=[('Content-Type', 'application/json'), auth_header],
     )
 
     assert response.status_code == 200
@@ -851,22 +851,16 @@ def test_get_notifications_removes_personalisation_from_subject(
     assert json_response['subject'] == 'Hello <redacted>'
 
 
-def test_get_notification_by_id_redacts_icn(
-    client,
-    sample_api_key,
-    sample_template,
-    sample_notification
-):
+def test_get_notification_by_id_redacts_icn(client, sample_api_key, sample_template, sample_notification):
     notification = sample_notification(
-        template=sample_template(),
-        recipient_identifiers=[{'id_type': IdentifierType.ICN.value, 'id_value': 'icn'}]
+        template=sample_template(), recipient_identifiers=[{'id_type': IdentifierType.ICN.value, 'id_value': 'icn'}]
     )
     assert notification.recipient_identifiers['ICN'].id_value == 'icn'
     auth_header = create_authorization_header(sample_api_key(service=notification.template.service))
 
     response = client.get(
         path=url_for('v2_notifications.get_notification_by_id', notification_id=notification.id),
-        headers=[('Content-Type', 'application/json'), auth_header]
+        headers=[('Content-Type', 'application/json'), auth_header],
     ).get_json()
 
     assert response['recipient_identifiers'][0]['id_type'] == 'ICN'
@@ -874,22 +868,15 @@ def test_get_notification_by_id_redacts_icn(
 
 
 @pytest.mark.serial
-def test_get_notifications_redacts_icn(
-    client,
-    sample_api_key,
-    sample_template,
-    sample_notification
-):
+def test_get_notifications_redacts_icn(client, sample_api_key, sample_template, sample_notification):
     notification = sample_notification(
-        template=sample_template(),
-        recipient_identifiers=[{'id_type': IdentifierType.ICN.value, 'id_value': 'icn'}]
+        template=sample_template(), recipient_identifiers=[{'id_type': IdentifierType.ICN.value, 'id_value': 'icn'}]
     )
     assert notification.recipient_identifiers['ICN'].id_value == 'icn'
     auth_header = create_authorization_header(sample_api_key(service=notification.template.service))
 
     response = client.get(
-        path=url_for('v2_notifications.get_notifications'),
-        headers=[('Content-Type', 'application/json'), auth_header]
+        path=url_for('v2_notifications.get_notifications'), headers=[('Content-Type', 'application/json'), auth_header]
     ).get_json()
 
     assert response['notifications'][0]['recipient_identifiers'][0]['id_type'] == 'ICN'


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

These changes:
- Modify the Notification.serialize method to use the value "\<redacted\>" for ICNs
- Replace the use of "create_notification" with "sample_notification" in the test file tests/app/v2/notifications/test_get_notifications.py (tech debt removal)

issue [team-1455](https://github.com/department-of-veterans-affairs/vanotify-team/issues/1455)

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

Notification `ef037299-52c4-424c-acbb-96beb02ef065` has an associated VA Profile ID and ICN.  Without these changes, the GET response includes:
```
"recipient_identifiers": [
        {
            "id_type": "VAPROFILEID",
            "id_value": "43627"
        },
        {
            "id_type": "ICN",
            "id_value": "...(THIS WAS NOT REDACTED)..."
        }
    ],
```
I manually redacted id_value above.  With these changes for redaction:
```
 "recipient_identifiers": [
        {
            "id_type": "VAPROFILEID",
            "id_value": "43627"
        },
        {
            "id_type": "ICN",
            "id_value": "<redacted>"
        }
    ],
```
I did not manually redact anything in the above output.

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
