### PR TITLE
#1112 - Drop the ServiceEmailReplyTo table (part 2 of 2)

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -15,4 +15,6 @@ fileignoreconfig:
   checksum: 572fb3a52e89ae19c5a94be881bcbfe0247bae112bce58d4ae1e9eff5a5c91b7
 - filename: tests/app/v2/notifications/test_get_notifications.py
   checksum: 167aa80c8aac01566b3cf627cdaa839feac9dc77f0b13b6d0a008035aa8e15f1
+- filename: migrations/versions/0376_drop_reply_to.py
+  checksum: 975bc9274cead1a9f9dd7cb67634e706d7b1656a0ce90264cfcd245669f42efd
 version: "1.0"

--- a/app/models.py
+++ b/app/models.py
@@ -419,6 +419,7 @@ class Service(db.Model, Versioned):
         return {'id': str(self.id), 'name': self.name, 'research_mode': self.research_mode}
 
 
+# Portal uses this table.  Do not drop it without consulting the front-end team.
 class ReplyToInbox(db.Model):
     __tablename__ = 'reply_to_inbox'
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -1731,32 +1732,6 @@ class LetterRate(db.Model):
     rate = db.Column(db.Numeric(), nullable=False)
     crown = db.Column(db.Boolean, nullable=False)
     post_class = db.Column(db.String, nullable=False)
-
-
-class ServiceEmailReplyTo(db.Model):
-    __tablename__ = 'service_email_reply_to'
-
-    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-
-    service_id = db.Column(UUID(as_uuid=True), db.ForeignKey('services.id'), unique=False, index=True, nullable=False)
-    service = db.relationship(Service, backref=db.backref('reply_to_email_addresses'))
-
-    email_address = db.Column(db.Text, nullable=False, index=False, unique=False)
-    is_default = db.Column(db.Boolean, nullable=False, default=True)
-    archived = db.Column(db.Boolean, nullable=False, default=False)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
-
-    def serialize(self):
-        return {
-            'id': str(self.id),
-            'service_id': str(self.service_id),
-            'email_address': self.email_address,
-            'is_default': self.is_default,
-            'archived': self.archived,
-            'created_at': self.created_at.strftime(DATETIME_FORMAT),
-            'updated_at': self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None,
-        }
 
 
 class ServiceLetterContact(db.Model):

--- a/migrations/versions/0376_drop_reply_to.py
+++ b/migrations/versions/0376_drop_reply_to.py
@@ -1,0 +1,32 @@
+"""
+Revision ID: 0376_drop_reply_to
+Revises: 0375_add_key_revoked
+Create Date: 2025-01-31 19:25:59.411624
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0376_drop_reply_to'
+down_revision = '0375_add_key_revoked'
+
+
+def upgrade():
+    op.drop_index('ix_service_email_reply_to_service_id', table_name='service_email_reply_to')
+    op.drop_table('service_email_reply_to')
+
+
+def downgrade():
+    op.create_table('service_email_reply_to',
+        sa.Column('id', postgresql.UUID(), autoincrement=False, nullable=False),
+        sa.Column('service_id', postgresql.UUID(), autoincrement=False, nullable=False),
+        sa.Column('email_address', sa.TEXT(), autoincrement=False, nullable=False),
+        sa.Column('is_default', sa.BOOLEAN(), autoincrement=False, nullable=False),
+        sa.Column('created_at', postgresql.TIMESTAMP(), autoincrement=False, nullable=False),
+        sa.Column('updated_at', postgresql.TIMESTAMP(), autoincrement=False, nullable=True),
+        sa.Column('archived', sa.BOOLEAN(), server_default=sa.text('false'), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(['service_id'], ['services.id'], name='service_email_reply_to_service_id_fkey'),
+        sa.PrimaryKeyConstraint('id', name='service_email_reply_to_pkey')
+    )
+    op.create_index('ix_service_email_reply_to_service_id', 'service_email_reply_to', ['service_id'], unique=False)

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -30,7 +30,6 @@ from app.models import (
     Permission,
     Rate,
     Service,
-    ServiceEmailReplyTo,
     ServiceCallback,
     ServiceLetterContact,
     ScheduledNotification,
@@ -624,21 +623,6 @@ def create_inbound_number(
     db.session.add(inbound_number)
     db.session.commit()
     return inbound_number
-
-
-def create_reply_to_email(service, email_address, is_default=True, archived=False):
-    data = {
-        'service': service,
-        'email_address': email_address,
-        'is_default': is_default,
-        'archived': archived,
-    }
-    reply_to = ServiceEmailReplyTo(**data)
-
-    db.session.add(reply_to)
-    db.session.commit()
-
-    return reply_to
 
 
 def create_service_sms_sender(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,9 +205,6 @@ def database_prep():
     C = meta_data.tables['communication_items']
     db.session.execute(delete(C))
 
-    SERT = meta_data.tables['service_email_reply_to']
-    db.session.execute(delete(SERT).where(SERT.c.service_id == notify_service_id))
-
     SP = meta_data.tables['service_permissions']
     db.session.execute(delete(SP).where(SP.c.service_id == notify_service_id))
 


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

These changes:
- Remove the table ServiceEmailReplyTo, which is unused in production. (Do not remove the table ReplyToInbox, which Portal uses.) There is an associated migration.
- Remove or modify associated test fixtures.

issue #1112

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

Note that this PR is "part 2 of 2."  I tested the migration downgrade before I split work for this ticket into two PRs, and I don't think it's necessary to retest this.  It's the exact same migration as before.

- [x] Migration [downgrade works](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/13334473127), and [Main redeployed](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/13334501500)

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
