### PR TITLE
HOTFIX - Gunicorn Timeout

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -7,6 +7,7 @@ worker_connections = 256
 bind = '0.0.0.0:{}'.format(os.getenv('PORT'))
 accesslog = '-'
 keepalive = 70
+timeout = 90  # Celery delay/apply_async can take 60s, worst case
 
 
 def on_starting(server):


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
We are seeing [gunicorn timing out](https://vanotify.ddog-gov.com/logs?query=host%3Aprod-notification-api-log-group%20service%3Acloudwatch%20%40aws.awslogs.logGroup%3Aprod-notification-api-log-group&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&context_event=AZUgzCJnAAAYv9VGdHArDQEV&event=&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&to_event=AwAAAZUgzBDweEivJwAAABhBWlVnekNKbkFBQVl2OVZHZEhBckRRQ28AAAAkMDE5NTIwZDAtYTZkMS00NmIyLTlhZWQtY2QzYWVmYjZjZjc0AADHwQ&viz=&from_ts=1740011699472&to_ts=1740011999473&live=false). This appears to be related to Celery apply_async/delay. In the short-term we will extend the timeout, long term we need to identify why this is happening.

[Default is 30 seconds](https://docs.gunicorn.org/en/stable/settings.html#timeout). Configured to allow 90 seconds.

issue N/A

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->
Deployed, passed regression.


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change
