### PR TITLE
#2278 Add HTML and plain text fields to TemplateBase

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -802,6 +802,8 @@ class TemplateBase(db.Model):
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, onupdate=datetime.datetime.utcnow)
     content = db.Column(db.Text, nullable=False)
+    content_as_html = db.Column(db.Text, nullable=True)
+    content_as_plain_text = db.Column(db.Text, nullable=True)
     archived = db.Column(db.Boolean, nullable=False, default=False)
     hidden = db.Column(db.Boolean, nullable=False, default=False)
     onsite_notification = db.Column(db.Boolean, nullable=False, default=False)
@@ -925,6 +927,8 @@ class TemplateBase(db.Model):
             'created_by': self.created_by.email_address,
             'version': self.version,
             'body': self.content,
+            'html': self.content_as_html,
+            'plain_text': self.content_as_plain_text,
             'subject': self.subject if self.template_type != SMS_TYPE else None,
             'name': self.name,
             'personalisation': {

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -2506,6 +2506,12 @@ components:
           format: date-time
         version:
           type: number
+        content_as_html:
+          type: string
+          nullable: true
+        content_as_plain_text:
+          type: string
+          nullable: true
     CreateHTMLPreviewRequest:
       type: object
       properties:

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: VA Notify API Documentation
-  version: 1.1.3
+  version: 1.2.3
   description: |
     <p>This documents the API schemas for consumption by internal VA developers.</p>
     <h1>Authorization header</h1>

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: VA Notify API Documentation
-  version: 1.2.3
+  version: 1.2.0
   description: |
     <p>This documents the API schemas for consumption by internal VA developers.</p>
     <h1>Authorization header</h1>

--- a/migrations/versions/0377_template_content.py
+++ b/migrations/versions/0377_template_content.py
@@ -1,0 +1,26 @@
+"""
+Revision ID: 0377_template_content
+Revises: 0376_drop_reply_to
+Create Date: 2025-02-25 15:12:25.067224
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0377_template_content'
+down_revision = '0376_drop_reply_to'
+
+
+def upgrade():
+    op.add_column('templates', sa.Column('content_as_html', sa.Text(), nullable=True))
+    op.add_column('templates', sa.Column('content_as_plain_text', sa.Text(), nullable=True))
+    op.add_column('templates_history', sa.Column('content_as_html', sa.Text(), nullable=True))
+    op.add_column('templates_history', sa.Column('content_as_plain_text', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('templates_history', 'content_as_plain_text')
+    op.drop_column('templates_history', 'content_as_html')
+    op.drop_column('templates', 'content_as_plain_text')
+    op.drop_column('templates', 'content_as_html')

--- a/tests/app/v2/template/test_get_template.py
+++ b/tests/app/v2/template/test_get_template.py
@@ -45,6 +45,8 @@ def test_get_template_by_id_returns_200(
         'version': template.version,
         'created_by': template.created_by.email_address,
         'body': template.content,
+        'html': None,
+        'plain_text': None,
         'subject': template.subject,
         'name': template.name,
         'personalisation': {},


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

These changes:
- Add the "content_as_html" and "content_as_plain_text" fields to the TemplateBase model class, which adds those fields in the database to the "templates" and "templates_history" tables
- As a consequence, the template serializers automatically add these new fields in the responses of the routes identified in the ticket's "acceptance criteria" section.  I updated the Swagger spec to reflect this.

This is to support future work.  Currently, when sending a notification with a given template, we always convert the template's markdown to HTML or plain text, but this output is constant unless users change the markdown.  We shouldn't need to perform the computation for every notification.

issue #2278

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- [x] Branch [deployed](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/13525508254), [rolled back](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/13526585094), and Main deployed
- [x] I inspected a local database container with psql:
```sh
notification_api=# \d templates
                                 Table "public.templates"
          Column           |            Type             | Collation | Nullable | Default 
---------------------------+-----------------------------+-----------+----------+---------
 ...
 content                   | text                        |           | not null | 
 ...
 content_as_html           | text                        |           |          | 
 content_as_plain_text     | text                        |           |          | 
```
```sh
notification_api=# \d templates_history
                             Table "public.templates_history"
          Column           |            Type             | Collation | Nullable | Default 
---------------------------+-----------------------------+-----------+----------+---------
 ...
 content                   | text                        |           | not null | 
 ...
 content_as_html           | text                        |           |          | 
 content_as_plain_text     | text                        |           |          | 
```
- [x] Same inspection above performed in Dev using EC2 console
- [x] New fields present in a response from GET /v2/service/<service_id>/templates/<template_id> (irrelevant fields removed):
```json
{
    "data": {
        "content": "This body has no personalization.",
        "content_as_html": null,
        "content_as_plain_text": null,
    }
}
```
- [x] New fields present, when expected, in responses for the other routes identified in the ticket's acceptance criteria

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
