### PR TITLE
#2311 - API Key Revoked Filter 

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,10 +1,10 @@
 fileignoreconfig:
 - filename: app/dao/api_key_dao.py
-  checksum: b705ce0649864c851c93ad648f4b6a6ea508770803fd91dbd4c4138610f02ae5
+  checksum: dae75b4691d745e1ec93bd7e87adad225bce77869cb8ec2f8acac50e7a091f09
 - filename: app/schema_validation/__init__.py
   checksum: 9487ddbb105a20f5fd495eb4426b7c27ee3be1894b69a189363363ed616722c0
 - filename: app/service/rest.py
-  checksum: 64ad0715bf30255b4a530f262faffb6a3a95e4b28967f6b9f48ca3ef8b4b969a
+  checksum: 4a0bca683668148a5fe6b7b36543f5950d207aa1655d8c1ab64eeb738b812495
 - filename: cd/application-deployment/prod/prod.env
   checksum: b2170727ac8f76eb7595f88fa16a34ee786a3e6743e2cd3690eef27f670e296f
 - filename: cd/application-deployment/staging/staging.env

--- a/.talismanrc
+++ b/.talismanrc
@@ -22,7 +22,7 @@ fileignoreconfig:
 - filename: tests/app/service/test_api_key_endpoints.py
   checksum: 5eb0442e5ad525c7a3e33c43db8eeb8c52d40c91ca9a1b770dbd4a95de6975a8
 - filename: tests/app/service/test_rest.py
-  checksum: 611819598937e48d076ae863b40e37bc8e136ea13ed6cb8699f79e2ead2880a7
+  checksum: 9e04718d4fedf36691047babbd7df74335813f126acb4953b0d16105a4653c82
 - filename: tests/app/v2/notifications/test_get_notifications.py
   checksum: 167aa80c8aac01566b3cf627cdaa839feac9dc77f0b13b6d0a008035aa8e15f1
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,6 @@
 fileignoreconfig:
 - filename: app/dao/api_key_dao.py
-  checksum: 5174cd06957432ba71ce08b681fa406fa7927b8b78acef480a50d677d94d341a
+  checksum: 13ec626fa8347a5732fd219f2a0c05188d0601ef5e9b14604e47c39142f0f7cd
 - filename: app/schema_validation/__init__.py
   checksum: 9487ddbb105a20f5fd495eb4426b7c27ee3be1894b69a189363363ed616722c0
 - filename: app/service/rest.py
@@ -20,7 +20,7 @@ fileignoreconfig:
 - filename: tests/app/dao/test_services_dao.py
   checksum: 572fb3a52e89ae19c5a94be881bcbfe0247bae112bce58d4ae1e9eff5a5c91b7
 - filename: tests/app/service/test_api_key_endpoints.py
-  checksum: 5eb0442e5ad525c7a3e33c43db8eeb8c52d40c91ca9a1b770dbd4a95de6975a8
+  checksum: a53d1342a998f3889fe8ce9352d8d02b468110dd7483893bfd65f5b61ef4606d
 - filename: tests/app/service/test_rest.py
   checksum: 9e04718d4fedf36691047babbd7df74335813f126acb4953b0d16105a4653c82
 - filename: tests/app/v2/notifications/test_get_notifications.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -20,7 +20,7 @@ fileignoreconfig:
 - filename: tests/app/dao/test_services_dao.py
   checksum: 572fb3a52e89ae19c5a94be881bcbfe0247bae112bce58d4ae1e9eff5a5c91b7
 - filename: tests/app/service/test_api_key_endpoints.py
-  checksum: f362beef1b712d9e2c4aa9fd9b9bc75caa7b2625606569f06631140a5ac5e231
+  checksum: 9cdd892c6ea6b6e911e50f216ed64401f9106ee0dd364d8935ebe96988dd556c
 - filename: tests/app/service/test_rest.py
   checksum: 9e04718d4fedf36691047babbd7df74335813f126acb4953b0d16105a4653c82
 - filename: tests/app/v2/notifications/test_get_notifications.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,6 @@
 fileignoreconfig:
 - filename: app/dao/api_key_dao.py
-  checksum: 13ec626fa8347a5732fd219f2a0c05188d0601ef5e9b14604e47c39142f0f7cd
+  checksum: 6a531a6582b75f6d72874f2135c9644d77f1873931b3638cf9d4b9198d75d908
 - filename: app/schema_validation/__init__.py
   checksum: 9487ddbb105a20f5fd495eb4426b7c27ee3be1894b69a189363363ed616722c0
 - filename: app/service/rest.py
@@ -20,7 +20,7 @@ fileignoreconfig:
 - filename: tests/app/dao/test_services_dao.py
   checksum: 572fb3a52e89ae19c5a94be881bcbfe0247bae112bce58d4ae1e9eff5a5c91b7
 - filename: tests/app/service/test_api_key_endpoints.py
-  checksum: a53d1342a998f3889fe8ce9352d8d02b468110dd7483893bfd65f5b61ef4606d
+  checksum: 572fd232dc5bb0835a5eaed004d22269449274f41db6ac7c0d124507903b9872
 - filename: tests/app/service/test_rest.py
   checksum: 9e04718d4fedf36691047babbd7df74335813f126acb4953b0d16105a4653c82
 - filename: tests/app/v2/notifications/test_get_notifications.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,10 +1,10 @@
 fileignoreconfig:
 - filename: app/dao/api_key_dao.py
-  checksum: 2ac9ca21efee5736e341161801fecdb2d0afb4616f693362ce0cd9b15ba6b526
+  checksum: b705ce0649864c851c93ad648f4b6a6ea508770803fd91dbd4c4138610f02ae5
 - filename: app/schema_validation/__init__.py
   checksum: 9487ddbb105a20f5fd495eb4426b7c27ee3be1894b69a189363363ed616722c0
 - filename: app/service/rest.py
-  checksum: f82b167237ae382d3ae351ed7892277b3ccae0df95cdf230f58c32b8eb288de1
+  checksum: 64ad0715bf30255b4a530f262faffb6a3a95e4b28967f6b9f48ca3ef8b4b969a
 - filename: cd/application-deployment/prod/prod.env
   checksum: b2170727ac8f76eb7595f88fa16a34ee786a3e6743e2cd3690eef27f670e296f
 - filename: cd/application-deployment/staging/staging.env
@@ -20,7 +20,7 @@ fileignoreconfig:
 - filename: tests/app/dao/test_services_dao.py
   checksum: 572fb3a52e89ae19c5a94be881bcbfe0247bae112bce58d4ae1e9eff5a5c91b7
 - filename: tests/app/service/test_api_key_endpoints.py
-  checksum: 572fd232dc5bb0835a5eaed004d22269449274f41db6ac7c0d124507903b9872
+  checksum: f362beef1b712d9e2c4aa9fd9b9bc75caa7b2625606569f06631140a5ac5e231
 - filename: tests/app/service/test_rest.py
   checksum: 9e04718d4fedf36691047babbd7df74335813f126acb4953b0d16105a4653c82
 - filename: tests/app/v2/notifications/test_get_notifications.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,6 @@
 fileignoreconfig:
 - filename: app/dao/api_key_dao.py
-  checksum: 6a531a6582b75f6d72874f2135c9644d77f1873931b3638cf9d4b9198d75d908
+  checksum: 2ac9ca21efee5736e341161801fecdb2d0afb4616f693362ce0cd9b15ba6b526
 - filename: app/schema_validation/__init__.py
   checksum: 9487ddbb105a20f5fd495eb4426b7c27ee3be1894b69a189363363ed616722c0
 - filename: app/service/rest.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -20,7 +20,7 @@ fileignoreconfig:
 - filename: tests/app/dao/test_services_dao.py
   checksum: 572fb3a52e89ae19c5a94be881bcbfe0247bae112bce58d4ae1e9eff5a5c91b7
 - filename: tests/app/service/test_api_key_endpoints.py
-  checksum: 9cdd892c6ea6b6e911e50f216ed64401f9106ee0dd364d8935ebe96988dd556c
+  checksum: fe5139b50049916613c201d8dc2cd16db4e281252327492f30b469d126213c14
 - filename: tests/app/service/test_rest.py
   checksum: 9e04718d4fedf36691047babbd7df74335813f126acb4953b0d16105a4653c82
 - filename: tests/app/v2/notifications/test_get_notifications.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,6 @@
 fileignoreconfig:
 - filename: app/dao/api_key_dao.py
-  checksum: dae75b4691d745e1ec93bd7e87adad225bce77869cb8ec2f8acac50e7a091f09
+  checksum: c1c17266b7ef13ac0f24d5296623fa871501d1cc8f5a8a04f0a51939a6537a39
 - filename: app/schema_validation/__init__.py
   checksum: 9487ddbb105a20f5fd495eb4426b7c27ee3be1894b69a189363363ed616722c0
 - filename: app/service/rest.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,10 +1,16 @@
 fileignoreconfig:
 - filename: app/dao/api_key_dao.py
-  checksum: ce13e50eb2989e73a04c5414dc7019505a815150831ebb1813196b4e222f72ba
-- filename: tests/app/service/test_api_key_endpoints.py
-  checksum: 5eb0442e5ad525c7a3e33c43db8eeb8c52d40c91ca9a1b770dbd4a95de6975a8
+  checksum: 5174cd06957432ba71ce08b681fa406fa7927b8b78acef480a50d677d94d341a
 - filename: app/schema_validation/__init__.py
   checksum: 9487ddbb105a20f5fd495eb4426b7c27ee3be1894b69a189363363ed616722c0
+- filename: app/service/rest.py
+  checksum: f82b167237ae382d3ae351ed7892277b3ccae0df95cdf230f58c32b8eb288de1
+- filename: cd/application-deployment/prod/prod.env
+  checksum: b2170727ac8f76eb7595f88fa16a34ee786a3e6743e2cd3690eef27f670e296f
+- filename: cd/application-deployment/staging/staging.env
+  checksum: 049c9132b0ffd7b484fefa1b589f4ee4e50150fd8c25756950ddb1b4b5256ce1
+- filename: migrations/versions/0376_drop_reply_to.py
+  checksum: 975bc9274cead1a9f9dd7cb67634e706d7b1656a0ce90264cfcd245669f42efd
 - filename: poetry.lock
   checksum: 64d78ee5ada60de197d40b3f8bb3a9d41125d43b8d70eb673eb6d5022ab6b3de
 - filename: tests/app/dao/test_api_key_dao.py
@@ -13,14 +19,10 @@ fileignoreconfig:
   checksum: dc425af859e49b9822259fad20d0ff99f3fde5c0237728fe73e5c9db2b78591b
 - filename: tests/app/dao/test_services_dao.py
   checksum: 572fb3a52e89ae19c5a94be881bcbfe0247bae112bce58d4ae1e9eff5a5c91b7
+- filename: tests/app/service/test_api_key_endpoints.py
+  checksum: 5eb0442e5ad525c7a3e33c43db8eeb8c52d40c91ca9a1b770dbd4a95de6975a8
+- filename: tests/app/service/test_rest.py
+  checksum: 611819598937e48d076ae863b40e37bc8e136ea13ed6cb8699f79e2ead2880a7
 - filename: tests/app/v2/notifications/test_get_notifications.py
   checksum: 167aa80c8aac01566b3cf627cdaa839feac9dc77f0b13b6d0a008035aa8e15f1
-- filename: tests/app/service/test_rest.py
-  checksum: ab6329f7ac1aaf437cad31bc085600b873ff076595c2de8be81a9ff64941b074
-- filename: migrations/versions/0376_drop_reply_to.py
-  checksum: 975bc9274cead1a9f9dd7cb67634e706d7b1656a0ce90264cfcd245669f42efd
-- filename: cd/application-deployment/prod/prod.env
-  checksum: b2170727ac8f76eb7595f88fa16a34ee786a3e6743e2cd3690eef27f670e296f
-- filename: cd/application-deployment/staging/staging.env
-  checksum: 049c9132b0ffd7b484fefa1b589f4ee4e50150fd8c25756950ddb1b4b5256ce1
 version: "1.0"

--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -67,13 +67,14 @@ def get_model_api_key(
 
 
 def get_model_api_keys(service_id: UUID) -> list[ApiKey]:
-    """Retrieves the API keys associated with the given service id.
+    """Retrieves the API keys associated with the given service id. Only returns keys that are not revoked and have not
+    expired.
 
     Args:
         service_id (UUID): The service id uuid to use when looking up API keys.
 
     Returns:
-        list[ApiKey]: The API keys associated with the given service id, if one is found.
+        list[ApiKey]: The API keys associated with the given service id, if any are found.
 
     Raises:
         NoResultFound: If there is no key associated with the given service, or the key has been revoked.

--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -51,7 +51,7 @@ def expire_api_key(
 def get_model_api_key(
     key_id: UUID,
 ) -> ApiKey:
-    """Retrieves the API key with the given id.
+    """Retrieves the API key with the given id, if it is not expired/revoked.
 
     Args:
         key_id (UUID): The API key uuid to lookup.
@@ -62,7 +62,7 @@ def get_model_api_key(
     Raises:
         NoResultFound: If there is no key with the given ID.
     """
-    stmt = select(ApiKey).where(ApiKey.id == key_id)
+    stmt = select(ApiKey).where(ApiKey.id == key_id, ApiKey.revoked.is_(False))
     return db.session.scalars(stmt).one()
 
 
@@ -78,7 +78,7 @@ def get_model_api_keys(service_id: UUID) -> list[ApiKey]:
     Raises:
         NoResultFound: If there is no key associated with the given service, or the key has been revoked.
     """
-    stmt = select(ApiKey).where(ApiKey.service_id == service_id)
+    stmt = select(ApiKey).where(ApiKey.service_id == service_id, ApiKey.revoked.is_(False))
     keys = db.session.scalars(stmt).all()
 
     if not keys:

--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -67,8 +67,7 @@ def get_model_api_key(
 
 
 def get_model_api_keys(service_id: UUID, include_revoked=False) -> list[ApiKey]:
-    """Retrieves the API keys associated with the given service id. Only returns keys that are not revoked and have not
-    expired.
+    """Retrieves the API keys associated with the given service id. By default, only active keys are returned.
 
     Args:
         service_id (UUID): The service id uuid to use when looking up API keys.

--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -78,7 +78,9 @@ def get_model_api_keys(service_id: UUID) -> list[ApiKey]:
     Raises:
         NoResultFound: If there is no key associated with the given service, or the key has been revoked.
     """
-    stmt = select(ApiKey).where(ApiKey.service_id == service_id, ApiKey.revoked.is_(False))
+    stmt = select(ApiKey).where(
+        ApiKey.service_id == service_id, ApiKey.revoked.is_(False), ApiKey.expiry_date > datetime.utcnow()
+    )
     keys = db.session.scalars(stmt).all()
 
     if not keys:

--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -66,7 +66,7 @@ def get_model_api_key(
     return db.session.scalars(stmt).one()
 
 
-def get_model_api_keys(service_id: UUID, include_revoked=False) -> list[ApiKey]:
+def get_model_api_keys(service_id: UUID, include_revoked: bool = False) -> list[ApiKey]:
     """Retrieves the API keys associated with the given service id. By default, only active keys are returned.
 
     Args:

--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -51,7 +51,7 @@ def expire_api_key(
 def get_model_api_key(
     key_id: UUID,
 ) -> ApiKey:
-    """Retrieves the API key with the given id, if it is not expired/revoked.
+    """Retrieves the API key with the given id.
 
     Args:
         key_id (UUID): The API key uuid to lookup.
@@ -62,7 +62,7 @@ def get_model_api_key(
     Raises:
         NoResultFound: If there is no key with the given ID.
     """
-    stmt = select(ApiKey).where(ApiKey.id == key_id, ApiKey.revoked.is_(False))
+    stmt = select(ApiKey).where(ApiKey.id == key_id)
     return db.session.scalars(stmt).one()
 
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -332,13 +332,13 @@ def get_api_keys(
         InvalidRequest: 404 NoResultsFound
         - If there are no valid API keys for the requested service, or the requested service id does not exist.
     """
-    dao_fetch_service_by_id(service_id=service_id)
-
     include_revoked = request.args.get('include_revoked', 'f')
     include_revoked = str(include_revoked).lower()
     if include_revoked not in ('true', 't', 'false', 'f'):
         raise InvalidRequest('Invalid value for include_revoked', status_code=400)
+
     include_revoked = include_revoked in ('true', 't')
+    dao_fetch_service_by_id(service_id=service_id)
 
     try:
         if key_id:

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -331,19 +331,19 @@ def get_api_keys(
     """
     dao_fetch_service_by_id(service_id=service_id)
 
-    min_expiry = request.args.get('min_expiry')
-    max_expiry = request.args.get('max_expiry')
+    min_expiry_days = request.args.get('min_expiry')
+    max_expiry_days = request.args.get('max_expiry')
 
     try:
         if key_id:
             api_keys = [get_model_api_key(key_id=key_id)]
         else:
             api_keys = get_model_api_keys(service_id=service_id)
-            if min_expiry:
-                min_expiry_date = datetime.strptime(min_expiry, '%Y-%m-%d')
+            if min_expiry_days:
+                min_expiry_date = datetime.utcnow() + timedelta(days=int(min_expiry_days))
                 api_keys = [key for key in api_keys if key.expiry_date >= min_expiry_date]
-            if max_expiry:
-                max_expiry_date = datetime.strptime(max_expiry, '%Y-%m-%d')
+            if max_expiry_days:
+                max_expiry_date = datetime.utcnow() + timedelta(days=int(max_expiry_days))
                 api_keys = [key for key in api_keys if key.expiry_date <= max_expiry_date]
     except NoResultFound:
         error = f'No valid API key found for service {service_id}'

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -336,8 +336,8 @@ def get_api_keys(
     include_revoked = str(include_revoked).lower()
     if include_revoked not in ('true', 't', 'false', 'f'):
         raise InvalidRequest('Invalid value for include_revoked', status_code=400)
-
     include_revoked = include_revoked in ('true', 't')
+
     dao_fetch_service_by_id(service_id=service_id)
 
     try:

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -356,7 +356,7 @@ def get_api_keys(
         raise InvalidRequest(error, status_code=400)
 
     # Ensure that min_expiry_days and max_expiry_days are greater than 0, if provided
-    if min_expiry_days and min_expiry_days < 0:
+    if min_expiry_days is not None and min_expiry_days <= 0:
         error = f"Minimum expiry days '{min_expiry_days}' must be greater than 0"
         raise InvalidRequest(error, status_code=400)
     if max_expiry_days and max_expiry_days < 0:

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -349,6 +349,13 @@ def get_api_keys(
         error = f"Minimum expiry days '{min_expiry_days}' must be less than maximum expiry days '{max_expiry_days}'"
         raise InvalidRequest(error, status_code=400)
 
+    # Ensure that the max and min are not negative
+    if min_expiry_days and min_expiry_days < 0:
+        error = f"Minimum expiry days '{min_expiry_days}' must be greater than 0"
+        raise InvalidRequest(error, status_code=400)
+    if max_expiry_days and max_expiry_days < 0:
+        error = f"Maximum expiry days '{max_expiry_days}' must be greater than 0"
+        raise InvalidRequest(error, status_code=400)
     try:
         if key_id:
             api_keys = [get_model_api_key(key_id=key_id)]

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -359,7 +359,7 @@ def get_api_keys(
     if min_expiry_days is not None and min_expiry_days <= 0:
         error = f"Minimum expiry days '{min_expiry_days}' must be greater than 0"
         raise InvalidRequest(error, status_code=400)
-    if max_expiry_days and max_expiry_days < 0:
+    if max_expiry_days is not None and max_expiry_days <= 0:
         error = f"Maximum expiry days '{max_expiry_days}' must be greater than 0"
         raise InvalidRequest(error, status_code=400)
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -336,7 +336,9 @@ def get_api_keys(
         if key_id:
             api_keys = [get_model_api_key(key_id=key_id)]
         else:
-            include_revoked = 'include_revoked' in request.args
+            include_revoked = request.args.get('include_revoked', False)
+            # Convert string to boolean
+            include_revoked = include_revoked in [True, 'true', 't', 'True', 'T']
             api_keys = get_model_api_keys(service_id=service_id, include_revoked=include_revoked)
     except NoResultFound:
         error = f'No valid API key found for service {service_id}'

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -1044,8 +1044,7 @@ paths:
   /service/{service_id}/api-keys:
     parameters:
       - $ref: "#/components/parameters/ServiceId"
-      - $ref: "#/components/parameters/MinExpiryDays"
-      - $ref: "#/components/parameters/MaxExpiryDays"
+      - $ref: "#/components/parameters/IncludeRevoked"
     get:
       tags:
         - api key
@@ -1790,22 +1789,13 @@ components:
       required: true
       description: CommunicationItem identifier
       example: e925b547-8195-4ed2-83c5-0633a74d780a
-    MinExpiryDays:
-      name: min_expiry_days
+    IncludeRevoked:
+      name: include_revoked
       in: query
       schema:
-        type: integer
+        type: boolean
       required: false
-      description: Results will include API keys that expire starting from this number of days
-      example: 7
-    MaxExpiryDays:
-      name: max_expiry_days
-      in: query
-      schema:
-        type: integer
-      required: false
-      description: Results will include API keys that expire within this number of days
-      example: 14
+      description: Setting this parameter to true will include revoked keys in the response
   responses:
     PushCreated:
       description: CREATED

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -1044,6 +1044,8 @@ paths:
   /service/{service_id}/api-keys:
     parameters:
       - $ref: "#/components/parameters/ServiceId"
+      - $ref: "#/components/parameters/MinExpiryDays"
+      - $ref: "#/components/parameters/MaxExpiryDays"
     get:
       tags:
         - api key
@@ -1788,6 +1790,22 @@ components:
       required: true
       description: CommunicationItem identifier
       example: e925b547-8195-4ed2-83c5-0633a74d780a
+    MinExpiryDays:
+      name: min_expiry_days
+      in: query
+      schema:
+        type: integer
+      required: false
+      description: Number of days from now
+      example: 7
+    MaxExpiryDays:
+      name: max_expiry_days
+      in: query
+      schema:
+        type: integer
+      required: false
+      description: Number of days from now
+      example: 14
   responses:
     PushCreated:
       description: CREATED

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -1796,7 +1796,7 @@ components:
       schema:
         type: integer
       required: false
-      description: Number of days from now
+      description: Results will include API keys that expire starting from this number of days
       example: 7
     MaxExpiryDays:
       name: max_expiry_days
@@ -1804,7 +1804,7 @@ components:
       schema:
         type: integer
       required: false
-      description: Number of days from now
+      description: Results will include API keys that expire within this number of days
       example: 14
   responses:
     PushCreated:

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -142,10 +142,10 @@ def test_save_api_key_can_create_keys_with_same_name(
 
     api_keys = get_model_api_keys(service.id)
 
-    # ensure there are 3 keys
-    assert len(api_keys) == 3
+    # ensure there are 2 keys
+    assert len(api_keys) == 2
     # ensure they have unique ids
-    assert len(set([key.id for key in api_keys])) == 3
+    assert len(set([key.id for key in api_keys])) == 2
     # ensure the names are the same
     assert len(set([key.name for key in api_keys])) == 1
 

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -315,6 +315,8 @@ def test_get_api_keys_with_query_params(
         ('?min_expiry=a', "Minimum expiry days must be an integer, received 'a'"),
         ('?max_expiry=a', "Maximum expiry days must be an integer, received 'a'"),
         ('?min_expiry=1&max_expiry=0', "Minimum expiry days '1' must be less than maximum expiry days '0'"),
+        ('?min_expiry=-5', "Minimum expiry days '-5' must be greater than or equal to 0"),
+        ('?max_expiry=-5', "Maximum expiry days '-5' must be greater than or equal to 0"),
     ),
     ids=(
         'min_expiry_invalid',

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -259,7 +259,7 @@ def test_get_api_keys_with_is_revoked(notify_api, notify_db_session, sample_serv
             expire_api_key(service_id=expired_key.service_id, api_key_id=expired_key.id)
             # Get request verification
             auth_header = create_admin_authorization_header()
-            # Generate a url, with the is_revoked query parameter present
+            # Generate a url, with the include_revoked query parameter present
             url = url_for('service.get_api_keys', service_id=service.id)
             url += '?include_revoked'
             response = client.get(

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -322,6 +322,8 @@ def test_get_api_keys_with_query_params(
         'min_expiry_invalid',
         'max_expiry_invalid',
         'min_max_expiry_invalid',
+        'min_expiry_negative',
+        'max_expiry_negative',
     ),
 )
 def test_get_api_keys_with_invalid_query_params(

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -217,7 +217,7 @@ def test_get_api_keys_should_return_all_keys_for_service(
             # Second bogus key to put data into the DB after adding to the correct service
             sample_api_key(service=bogus_service)
 
-            # Verify 2 keys are are in the table with the given service id
+            # Verify 2 keys are in the table with the given service id
             assert len(get_model_api_keys(service.id)) == 2
 
             # Get request verification

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -255,8 +255,8 @@ def test_get_api_keys_should_return_one_key_for_service(notify_api, notify_db_se
     ('query_params', 'num_keys'),
     (
         ('', 4),
-        ('?min_expiry=0', 4),
-        ('?max_expiry=0', 4),
+        ('?min_expiry=1', 4),
+        ('?max_expiry=1', 0),
         ('?min_expiry=4', 3),
         ('?max_expiry=4', 1),
         ('?min_expiry=4&max_expiry=16', 3),
@@ -264,8 +264,8 @@ def test_get_api_keys_should_return_one_key_for_service(notify_api, notify_db_se
     ),
     ids=(
         'no_params',
-        'min_expiry_0',
-        'max_expiry_0',
+        'min_expiry_1',
+        'max_expiry_1',
         'min_expiry_4',
         'max_expiry_4',
         'min_max_expiry_4_16',
@@ -315,8 +315,8 @@ def test_get_api_keys_with_query_params(
         ('?min_expiry=a', "Minimum expiry days must be an integer, received 'a'"),
         ('?max_expiry=a', "Maximum expiry days must be an integer, received 'a'"),
         ('?min_expiry=1&max_expiry=0', "Minimum expiry days '1' must be less than maximum expiry days '0'"),
-        ('?min_expiry=-5', "Minimum expiry days '-5' must be greater than or equal to 0"),
-        ('?max_expiry=-5', "Maximum expiry days '-5' must be greater than or equal to 0"),
+        ('?min_expiry=-5', "Minimum expiry days '-5' must be greater than 0"),
+        ('?max_expiry=-5', "Maximum expiry days '-5' must be greater than 0"),
     ),
     ids=(
         'min_expiry_invalid',

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -1,8 +1,6 @@
 import json
-from datetime import datetime, timedelta
 from uuid import uuid4
 
-import pytest
 from flask import url_for
 from sqlalchemy import delete, select, Table
 
@@ -251,90 +249,32 @@ def test_get_api_keys_should_return_one_key_for_service(notify_api, notify_db_se
             assert len(get_model_api_keys(service.id)) == 1
 
 
-@pytest.mark.parametrize(
-    ('query_params', 'num_keys'),
-    (
-        ('', 4),
-        ('?min_expiry=1', 4),
-        ('?max_expiry=1', 0),
-        ('?min_expiry=4', 3),
-        ('?max_expiry=4', 1),
-        ('?min_expiry=4&max_expiry=16', 3),
-        ('?max_expiry=16&min_expiry=4', 3),
-    ),
-    ids=(
-        'no_params',
-        'min_expiry_1',
-        'max_expiry_1',
-        'min_expiry_4',
-        'max_expiry_4',
-        'min_max_expiry_4_16',
-        'max_min_expiry_4_16',
-    ),
-)
-def test_get_api_keys_with_query_params(
-    notify_api, notify_db_session, sample_service, sample_api_key, query_params, num_keys
-):
-    service = sample_service()
-
-    # Create some keys
-    # Expired 7 days ago
-    expired_key = sample_api_key(key_name='expired key', service=service)
-    expired_key.expiry_date = datetime.utcnow() - timedelta(days=7)
-    notify_db_session.session.add(expired_key)
-    # Expires in 3 days
-    key_3 = sample_api_key(key_name='key 3', service=service)
-    key_3.expiry_date = datetime.utcnow() + timedelta(days=3)
-    notify_db_session.session.add(key_3)
-    # Expires in 7 days
-    key_7 = sample_api_key(key_name='key 7', service=service)
-    key_7.expiry_date = datetime.utcnow() + timedelta(days=7)
-    notify_db_session.session.add(key_7)
-    # Expires in 10 days
-    key_10 = sample_api_key(key_name='key 10', service=service)
-    key_10.expiry_date = datetime.utcnow() + timedelta(days=10)
-    notify_db_session.session.add(key_10)
-    # Expires in 14 days
-    key_14 = sample_api_key(key_name='key 14', service=service)
-    key_14.expiry_date = datetime.utcnow() + timedelta(days=14)
-    notify_db_session.session.add(key_14)
-
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            url = url_for('service.get_api_keys', service_id=service.id)
-            auth_header = create_admin_authorization_header()
-            response = client.get(url + query_params, headers=[('Content-Type', 'application/json'), auth_header])
-            assert response.status_code == 200
-            json_resp = json.loads(response.get_data(as_text=True))
-            assert len(json_resp['apiKeys']) == num_keys
-
-
-@pytest.mark.parametrize(
-    ('query_params', 'error_message'),
-    (
-        ('?min_expiry=a', "Minimum expiry days must be an integer, received 'a'"),
-        ('?max_expiry=a', "Maximum expiry days must be an integer, received 'a'"),
-        ('?min_expiry=1&max_expiry=0', "Minimum expiry days '1' must be less than maximum expiry days '0'"),
-        ('?min_expiry=-5', "Minimum expiry days '-5' must be greater than 0"),
-        ('?max_expiry=-5', "Maximum expiry days '-5' must be greater than 0"),
-    ),
-    ids=(
-        'min_expiry_invalid',
-        'max_expiry_invalid',
-        'min_max_expiry_invalid',
-        'min_expiry_negative',
-        'max_expiry_negative',
-    ),
-)
-def test_get_api_keys_with_invalid_query_params(
-    notify_api, notify_db_session, sample_service, query_params, error_message
-):
+def test_get_api_keys_with_is_revoked(notify_api, notify_db_session, sample_service, sample_api_key):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             service = sample_service()
-            url = url_for('service.get_api_keys', service_id=service.id)
+            sample_api_key(service=service, key_name='key1')
+            sample_api_key(service=service, key_name='key2')
+            expired_key = sample_api_key(service=service, key_name='expired_key')
+            expire_api_key(service_id=expired_key.service_id, api_key_id=expired_key.id)
+            # Get request verification
             auth_header = create_admin_authorization_header()
-            response = client.get(url + query_params, headers=[('Content-Type', 'application/json'), auth_header])
-            assert response.status_code == 400
+            # Generate a url, with the is_revoked query parameter present
+            url = url_for('service.get_api_keys', service_id=service.id)
+            url += '?include_revoked'
+            response = client.get(
+                url,
+                headers=[('Content-Type', 'application/json'), auth_header],
+            )
+            assert response.status_code == 200
             json_resp = json.loads(response.get_data(as_text=True))
-            assert json_resp['message'] == error_message
+            assert len(json_resp['apiKeys']) == 3
+
+            url = url_for('service.get_api_keys', service_id=service.id)
+            response = client.get(
+                url,
+                headers=[('Content-Type', 'application/json'), auth_header],
+            )
+            assert response.status_code == 200
+            json_resp = json.loads(response.get_data(as_text=True))
+            assert len(json_resp['apiKeys']) == 2

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -1,6 +1,7 @@
 import json
 from uuid import uuid4
 
+import pytest
 from flask import url_for
 from sqlalchemy import delete, select, Table
 
@@ -249,7 +250,30 @@ def test_get_api_keys_should_return_one_key_for_service(notify_api, notify_db_se
             assert len(get_model_api_keys(service.id)) == 1
 
 
-def test_get_api_keys_with_is_revoked(notify_api, notify_db_session, sample_service, sample_api_key):
+@pytest.mark.parametrize(
+    'include_revoked,num_keys',
+    [
+        (None, 2),
+        (False, 2),
+        (True, 3),
+        ('True', 3),
+        ('T', 3),
+        ('true', 3),
+        ('t', 3),
+    ],
+    ids=[
+        'include_revoked_none',
+        'include_revoked_false_bool',
+        'include_revoked_true_bool',
+        'include_revoked_true_cap_str',
+        'include_revoked_true_cap_char',
+        'include_revoked_true_str',
+        'include_revoked_true_char',
+    ],
+)
+def test_get_api_keys_with_is_revoked(
+    notify_api, notify_db_session, sample_service, sample_api_key, include_revoked, num_keys
+):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             service = sample_service()
@@ -257,24 +281,13 @@ def test_get_api_keys_with_is_revoked(notify_api, notify_db_session, sample_serv
             sample_api_key(service=service, key_name='key2')
             expired_key = sample_api_key(service=service, key_name='expired_key')
             expire_api_key(service_id=expired_key.service_id, api_key_id=expired_key.id)
-            # Get request verification
-            auth_header = create_admin_authorization_header()
-            # Generate a url, with the include_revoked query parameter present
-            url = url_for('service.get_api_keys', service_id=service.id)
-            url += '?include_revoked'
-            response = client.get(
-                url,
-                headers=[('Content-Type', 'application/json'), auth_header],
-            )
-            assert response.status_code == 200
-            json_resp = json.loads(response.get_data(as_text=True))
-            assert len(json_resp['apiKeys']) == 3
 
-            url = url_for('service.get_api_keys', service_id=service.id)
+            auth_header = create_admin_authorization_header()
+            url = url_for('service.get_api_keys', service_id=service.id, include_revoked=include_revoked)
             response = client.get(
                 url,
                 headers=[('Content-Type', 'application/json'), auth_header],
             )
             assert response.status_code == 200
             json_resp = json.loads(response.get_data(as_text=True))
-            assert len(json_resp['apiKeys']) == 2
+            assert len(json_resp['apiKeys']) == num_keys

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2030,47 +2030,20 @@ def test_delete_smtp_relay_for_service_returns_201_if_success(
 
 
 # Tests for the min_expiry/max_expiry filters in GET api keys
-def test_get_api_keys_returns_all_keys_when_no_expiry_filter(client, sample_api_key):
+@pytest.mark.parametrize(('min_expiry', 'max_expiry'), ((None, None),))
+def test_get_api_keys_returns_all_keys_when_no_expiry_filter(client, sample_api_key, min_expiry, max_expiry):
     sample_api_key()
     sample_api_key()
     sample_api_key()
 
-    response = client.get('/api_key', headers=[create_admin_authorization_header()])
+    url = '/api_key'
+    if min_expiry:
+        url += f'?min_expiry={min_expiry}'
+    if max_expiry:
+        url += f'?max_expiry={max_expiry}'
+
+    response = client.get(url, headers=[create_admin_authorization_header()])
     api_keys = response.get_json()['apiKeys']
 
     assert response.status_code == 200
     assert len(api_keys) == 3
-
-
-def test_get_api_keys_returns_keys_with_expiry_date_within_range(client, sample_api_key):
-    sample_api_key()
-    sample_api_key()
-    sample_api_key()
-    sample_api_key(expiry_date=datetime.utcnow() + timedelta(days=5))
-    sample_api_key(expiry_date=datetime.utcnow() + timedelta(days=10))
-    sample_api_key(expiry_date=datetime.utcnow() + timedelta(days=15))
-
-    response = client.get(
-        '/api_key?min_expiry_date=5&max_expiry_date=10', headers=[create_admin_authorization_header()]
-    )
-    api_keys = response.get_json()['apiKeys']
-
-    assert response.status_code == 200
-    assert len(api_keys) == 1
-
-
-def test_get_api_keys_returns_keys_with_expiry_date_within_range_inclusive(client, sample_api_key):
-    sample_api_key()
-    sample_api_key()
-    sample_api_key()
-    sample_api_key(expiry_date=datetime.utcnow() + timedelta(days=5))
-    sample_api_key(expiry_date=datetime.utcnow() + timedelta(days=10))
-    sample_api_key(expiry_date=datetime.utcnow() + timedelta(days=15))
-
-    response = client.get(
-        '/api_key?min_expiry_date=5&max_expiry_date=10', headers=[create_admin_authorization_header()]
-    )
-    api_keys = response.get_json()['apiKeys']
-
-    assert response.status_code == 200
-    assert len(api_keys) == 1

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2027,3 +2027,50 @@ def test_delete_smtp_relay_for_service_returns_201_if_success(
 
     delete_mock.assert_called_once()
     assert resp.status_code == 201
+
+
+# Tests for the min_expiry/max_expiry filters in GET api keys
+def test_get_api_keys_returns_all_keys_when_no_expiry_filter(client, sample_api_key):
+    sample_api_key()
+    sample_api_key()
+    sample_api_key()
+
+    response = client.get('/api_key', headers=[create_admin_authorization_header()])
+    api_keys = response.get_json()['apiKeys']
+
+    assert response.status_code == 200
+    assert len(api_keys) == 3
+
+
+def test_get_api_keys_returns_keys_with_expiry_date_within_range(client, sample_api_key):
+    sample_api_key()
+    sample_api_key()
+    sample_api_key()
+    sample_api_key(expiry_date=datetime.utcnow() + timedelta(days=5))
+    sample_api_key(expiry_date=datetime.utcnow() + timedelta(days=10))
+    sample_api_key(expiry_date=datetime.utcnow() + timedelta(days=15))
+
+    response = client.get(
+        '/api_key?min_expiry_date=5&max_expiry_date=10', headers=[create_admin_authorization_header()]
+    )
+    api_keys = response.get_json()['apiKeys']
+
+    assert response.status_code == 200
+    assert len(api_keys) == 1
+
+
+def test_get_api_keys_returns_keys_with_expiry_date_within_range_inclusive(client, sample_api_key):
+    sample_api_key()
+    sample_api_key()
+    sample_api_key()
+    sample_api_key(expiry_date=datetime.utcnow() + timedelta(days=5))
+    sample_api_key(expiry_date=datetime.utcnow() + timedelta(days=10))
+    sample_api_key(expiry_date=datetime.utcnow() + timedelta(days=15))
+
+    response = client.get(
+        '/api_key?min_expiry_date=5&max_expiry_date=10', headers=[create_admin_authorization_header()]
+    )
+    api_keys = response.get_json()['apiKeys']
+
+    assert response.status_code == 200
+    assert len(api_keys) == 1

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2027,23 +2027,3 @@ def test_delete_smtp_relay_for_service_returns_201_if_success(
 
     delete_mock.assert_called_once()
     assert resp.status_code == 201
-
-
-# Tests for the min_expiry/max_expiry filters in GET api keys
-@pytest.mark.parametrize(('min_expiry', 'max_expiry'), ((None, None),))
-def test_get_api_keys_returns_all_keys_when_no_expiry_filter(client, sample_api_key, min_expiry, max_expiry):
-    sample_api_key()
-    sample_api_key()
-    sample_api_key()
-
-    url = '/api_key'
-    if min_expiry:
-        url += f'?min_expiry={min_expiry}'
-    if max_expiry:
-        url += f'?max_expiry={max_expiry}'
-
-    response = client.get(url, headers=[create_admin_authorization_header()])
-    api_keys = response.get_json()['apiKeys']
-
-    assert response.status_code == 200
-    assert len(api_keys) == 3


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->
This PR enhances API key retrieval by filtering keys based on their expiry date and revocation status. Key changes include:
- Updating the API endpoint in rest.py to parse a new query parameter, include_revoked, which controls whether revoked (and thus expired) keys are returned.
- Revising the DAO method get_model_api_keys to support the include_revoked flag while filtering out revoked API keys by default.
- Adjusting tests in both the service and DAO layers to reflect the updated expected key counts and behavior.

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

issue #2311

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- [Deployed to dev](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/13833195053)
- Tested with Postman against dev.
  - with no `include_revoked` param
  <img width="2133" alt="Screenshot 2025-03-13 at 9 49 30 AM" src="https://github.com/user-attachments/assets/521c4995-f977-4400-b7f8-ee870ec4c3a7" />
  - with `include_revoked=true`, there were too many results for the preview, had to use the visualizer.
  <img width="2112" alt="Screenshot 2025-03-13 at 9 51 27 AM" src="https://github.com/user-attachments/assets/55237e6a-cf99-4cd6-bcad-772035204ec0" />

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change
