### PR TITLE
#803 - Hotfix - resolve unbound variable and exception handling

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -9,7 +9,7 @@ from flask import (
 from json import JSONDecodeError
 
 from notifications_utils.statsd_decorators import statsd
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 
 from app import notify_celery
 from app.celery.common import log_notification_total_time
@@ -60,7 +60,7 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
 
         try:
             notification = notifications_dao.dao_get_notification_by_reference(reference)
-        except NoResultFound:
+        except (NoResultFound, MultipleResultsFound):
             message_time = iso8601.parse_date(ses_message['mail']['timestamp']).replace(tzinfo=None)
             if datetime.utcnow() - message_time < timedelta(minutes=5):
                 self.retry(queue=QueueNames.RETRY)

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -9,7 +9,6 @@ from flask import (
 from json import JSONDecodeError
 
 from notifications_utils.statsd_decorators import statsd
-from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 
 from app import notify_celery
 from app.celery.common import log_notification_total_time
@@ -43,24 +42,44 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
     current_app.logger.debug('Full SES result response: %s', response)
     try:
         ses_message = json.loads(response['Message'])
+
+        reference = ses_message['mail']['messageId']
+        if reference is None:
+            current_app.logger.warning(
+                'SES complaint: unable to lookup notification, messageId was None | ses_message: %s', ses_message
+            )
+            return
+
         notification_type = ses_message.get('eventType')
 
         if notification_type == 'Bounce':
             # Bounces have ran their course with AWS and should be considered done. Clients can retry soft bounces.
             notification_type = determine_notification_bounce_type(notification_type, ses_message)
         elif notification_type == 'Complaint':
-            complaint, notification, recipient_email = handle_ses_complaint(ses_message)
-            return publish_complaint(complaint, notification, recipient_email)
+            try:
+                notification = notifications_dao.dao_get_notification_history_by_reference(reference)
+            except Exception:
+                # we expect results or no results but it could be multiple results
+                message_time = iso8601.parse_date(ses_message['mail']['timestamp']).replace(tzinfo=None)
+                if datetime.utcnow() - message_time < timedelta(minutes=5):
+                    self.retry(queue=QueueNames.RETRY)
+                else:
+                    current_app.logger.warning('SES complaint: notification not found | reference: %s', reference)
+                return
+
+            complaint, recipient_email = handle_ses_complaint(ses_message, notification)
+            publish_complaint(complaint, notification, recipient_email)
+            return
 
         aws_response_dict = get_aws_responses(notification_type)
 
         # This is the prospective, updated status.
         incoming_status = aws_response_dict['notification_status']
-        reference = ses_message['mail']['messageId']
 
         try:
             notification = notifications_dao.dao_get_notification_by_reference(reference)
-        except (NoResultFound, MultipleResultsFound):
+        except Exception:
+            # we expect results or no results but it could be multiple results
             message_time = iso8601.parse_date(ses_message['mail']['timestamp']).replace(tzinfo=None)
             if datetime.utcnow() - message_time < timedelta(minutes=5):
                 self.retry(queue=QueueNames.RETRY)
@@ -151,6 +170,9 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
 
     except JSONDecodeError:
         current_app.logger.exception('Error decoding SES results: full response data: %s', response)
+
+    except KeyError:
+        current_app.logger.exception('AWS message malformed: full response data: %s', response)
 
     except Retry:
         raise

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -44,7 +44,7 @@ def process_ses_results(  # noqa: C901 (too complex 19 > 10)
         ses_message = json.loads(response['Message'])
 
         reference = ses_message['mail']['messageId']
-        if reference is None:
+        if not reference:
             current_app.logger.warning(
                 'SES complaint: unable to lookup notification, messageId (reference) was None | ses_message: %s',
                 ses_message,

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -35,7 +35,7 @@ from app.celery.service_callback_tasks import check_and_queue_callback_task
 
 @notify_celery.task(bind=True, name='process-ses-result', max_retries=5, default_retry_delay=300)
 @statsd(namespace='tasks')
-def process_ses_results(  # noqa: C901 (too complex 14 > 10)
+def process_ses_results(  # noqa: C901 (too complex 19 > 10)
     self,
     response,
 ):
@@ -46,7 +46,8 @@ def process_ses_results(  # noqa: C901 (too complex 14 > 10)
         reference = ses_message['mail']['messageId']
         if reference is None:
             current_app.logger.warning(
-                'SES complaint: unable to lookup notification, messageId was None | ses_message: %s', ses_message
+                'SES complaint: unable to lookup notification, messageId (reference) was None | ses_message: %s',
+                ses_message,
             )
             return
 

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -22,7 +22,7 @@ def handle_ses_complaint(ses_message: dict, notification: Notification) -> Tuple
         'Complaint from SES: \n{}'.format(json.dumps(ses_message).replace('{', '(').replace('}', ')'))
     )
 
-    ses_complaint = ses_message.get('complaint', None)
+    ses_complaint = ses_message.get('complaint')
     complaint_type = ses_complaint.get('complaintFeedbackType', None) if ses_complaint else None
 
     if not complaint_type:

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -16,19 +16,13 @@ def determine_notification_bounce_type(
     return 'Permanent' if ses_message['bounce']['bounceType'] == 'Permanent' else 'Temporary'
 
 
-def handle_ses_complaint(ses_message: dict) -> Tuple[Complaint, Notification, str]:
+def handle_ses_complaint(ses_message: dict, notification: Notification) -> Tuple[Complaint, str]:
     recipient_email = remove_emails_from_complaint(ses_message)[0]
     current_app.logger.info(
         'Complaint from SES: \n{}'.format(json.dumps(ses_message).replace('{', '(').replace('}', ')'))
     )
-    try:
-        reference = ses_message['mail']['messageId']
-    except KeyError:
-        current_app.logger.exception('Complaint from SES failed to get reference from message.')
-        return
-    notification = dao_get_notification_history_by_reference(reference)
-    ses_complaint = ses_message.get('complaint', None)
 
+    ses_complaint = ses_message.get('complaint', None)
     complaint_type = ses_complaint.get('complaintFeedbackType', None) if ses_complaint else None
 
     if not complaint_type:
@@ -42,7 +36,7 @@ def handle_ses_complaint(ses_message: dict) -> Tuple[Complaint, Notification, st
         complaint_date=ses_complaint.get('timestamp', None) if ses_complaint else None,
     )
     save_complaint(complaint)
-    return complaint, notification, recipient_email
+    return complaint, recipient_email
 
 
 def handle_smtp_complaint(ses_message):

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -185,7 +185,6 @@ def test_process_ses_results_call_to_publish_complaint(sample_template, sample_n
     process_ses_receipts_tasks.process_ses_results(
         response=ses_notification_complaint_callback(reference=notification.reference)
     )
-    # TODO: called_once_with(complaint, notification, email)
     publish_complaint.assert_called_once()
 
 

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -81,6 +81,20 @@ def test_process_ses_results_reference_none(mocker, notify_api):
     )
 
 
+def test_process_ses_results_event_type_none(mocker, notify_api):
+    """Test that status notifications are not attempted if event type is None"""
+    mock_logger = mocker.patch('app.celery.process_ses_receipts_tasks.current_app.logger')
+    response = ses_notification_callback(reference=None)
+    ses_message = json.loads(response['Message'])
+    ses_message.pop('eventType')
+
+    process_ses_receipts_tasks.process_ses_results(response={'Message': json.dumps(ses_message)})
+    mock_logger.warning.assert_called_with(
+        'SES complaint: unable to lookup notification, messageId (reference) was None | ses_message: %s',
+        ses_message,
+    )
+
+
 def test_process_ses_results_notification_delivery(notify_db_session, sample_template, sample_notification, mocker):
     template = sample_template(template_type=EMAIL_TYPE)
     ref = str(uuid4())

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1544,6 +1544,9 @@ def sample_notification_history(
         if api_key is None:
             api_key = sample_api_key(template.service, key_type=key_type)
 
+        if reference is None:
+            reference = str(uuid4())
+
         notification_history = NotificationHistory(
             id=uuid4(),
             service=template.service,
@@ -1555,7 +1558,7 @@ def sample_notification_history(
             key_type=key_type,
             api_key=api_key,
             api_key_id=api_key.id,
-            reference=reference or uuid4(),
+            reference=reference,
             sent_at=sent_at,
             sms_sender_id=sms_sender_id,
         )

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1555,7 +1555,7 @@ def sample_notification_history(
             key_type=key_type,
             api_key=api_key,
             api_key_id=api_key.id,
-            reference=reference,
+            reference=reference or uuid4(),
             sent_at=sent_at,
             sms_sender_id=sms_sender_id,
         )

--- a/tests/app/notifications/test_notifications_ses_callback.py
+++ b/tests/app/notifications/test_notifications_ses_callback.py
@@ -40,19 +40,6 @@ def test_process_ses_results_in_complaint(
     assert complaints[0].notification_id == notification.id
 
 
-# lookup moved out of function
-# def test_handle_complaint_does_not_raise_exception_if_reference_is_missing():
-#     response = json.loads(ses_complaint_callback_malformed_message_id()['Message'])
-#     handle_ses_complaint(response, 'ref1')
-
-
-# lookup moved out of function
-# def test_handle_complaint_does_raise_exception_if_notification_not_found():
-#     response = json.loads(ses_complaint_callback()['Message'])
-#     with pytest.raises(expected_exception=SQLAlchemyError):
-#         handle_ses_complaint(response)
-
-
 def test_process_ses_results_in_complaint_if_notification_history_does_not_exist(
     notify_db_session,
     sample_notification,

--- a/tests/app/notifications/test_notifications_ses_callback.py
+++ b/tests/app/notifications/test_notifications_ses_callback.py
@@ -5,7 +5,7 @@ from sqlalchemy import select
 from uuid import uuid4
 
 from app.dao.notifications_dao import get_notification_by_id
-from app.models import Complaint, EMAIL_TYPE, Notification, NotificationHistory, UNKNOWN_COMPLAINT_TYPE
+from app.models import Complaint, EMAIL_TYPE, NotificationHistory, UNKNOWN_COMPLAINT_TYPE
 from app.notifications.notifications_ses_callback import handle_ses_complaint, handle_smtp_complaint
 
 from tests.app.db import (
@@ -30,7 +30,7 @@ def test_process_ses_results_in_complaint(
     sample_notification,
 ):
     ref = str(uuid4())
-    notification: Notification = sample_notification(gen_type=EMAIL_TYPE, reference=ref)
+    notification = sample_notification(gen_type=EMAIL_TYPE, reference=ref)
     complaint = ses_complaint_callback()['Message'].replace('ref1', ref)
     handle_ses_complaint(json.loads(complaint), notification)
 


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Paired with Kyle to trace the error/exception paths.
Complexity metric increased.
Iterated the changes, updating failing unit tests.

1. Address errors resulting in exception handler throwing UnboundLocal
2. Ensure sample_notification_history has a valid reference, uuid4
3. Moved notification lookup out to main celery task to ensure notification available to exception handlers
4. Added KeyError handler to handle malformed payloads
5. Updated unittests for change function signatures
6. Added coverage for missing/None reference but update to sample_notification_history should fix this in tests.
7. Added test for notification not found (forcing no retry to catch error message)

issue #803 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

Unit testing and DEV deploy regression tests.

![image](https://github.com/user-attachments/assets/0beb40ac-2228-49ea-809e-4140cc4df815)

![image](https://github.com/user-attachments/assets/7dc01f79-112b-49f2-965f-b34db69a7f40)

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [ ] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
