### PR TITLE
TEAM-1487 - Code scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ Jinja templates are pulled in from the [notification-utils](https://github.com/d
 ## Generic Internal Endpoints
 
 There is an internal Flask route `/internal/<generic>` which can be used to mock external endpoints for integration testing.
-`GET` requests return a text response in the form `"GET request received for endpoint {request.full_path}"` where
+`GET` requests return a JSON response in the form `{<generic>: "GET request received for endpoint {request.full_path}"}` where
 `request.full_path` is the url + query string. `POST` requests return a JSON response in the form `{<generic>: <request.json>}`. Both methods return a 200 and log the following attributes:
 
 - headers

--- a/app/internal/rest.py
+++ b/app/internal/rest.py
@@ -53,7 +53,6 @@ def handler(generic):
     logs.append(f'HEADERS: {headers_string}')
     current_app.logger.info('Generic Internal Request: %s', ' | '.join(logs))
     if request.method == 'GET':
-        # response_body = f'GET request received for endpoint {request.full_path}'
         response_message = f'GET request received for endpoint {request.full_path}'
         response_body = {'message': response_message}
     else:

--- a/app/internal/rest.py
+++ b/app/internal/rest.py
@@ -18,6 +18,7 @@ import time
 from werkzeug.exceptions import UnsupportedMediaType
 from contextlib import suppress
 from flask import Blueprint, current_app, jsonify, request
+from markupsafe import escape
 
 
 internal_blueprint = Blueprint('internal', __name__, url_prefix='/internal')
@@ -53,7 +54,7 @@ def handler(generic):
     logs.append(f'HEADERS: {headers_string}')
     current_app.logger.info('Generic Internal Request: %s', ' | '.join(logs))
     if request.method == 'GET':
-        response_body = f'GET request received for endpoint {request.full_path}'
+        response_body = f'GET request received for endpoint {escape(request.full_path)}'
     else:
         response_body = {generic: request.json}
 

--- a/app/internal/rest.py
+++ b/app/internal/rest.py
@@ -53,13 +53,10 @@ def handler(generic):
     logs.append(f'HEADERS: {headers_string}')
     current_app.logger.info('Generic Internal Request: %s', ' | '.join(logs))
     if request.method == 'GET':
-        # response_message = f'GET request received for endpoint {request.full_path}'
-        # response_body = {'message': response_message}
-        response_body = jsonify(message=f'GET request received for endpoint {request.full_path}')
+        response_body = jsonify({generic: f'GET request received for endpoint {request.full_path}'})
     else:
         response_body = {generic: request.json}
 
-    # TODO - CodeQL issue with this line will be addressed in TEAM-1487
     return response_body, status_code
 
 

--- a/app/internal/rest.py
+++ b/app/internal/rest.py
@@ -53,8 +53,9 @@ def handler(generic):
     logs.append(f'HEADERS: {headers_string}')
     current_app.logger.info('Generic Internal Request: %s', ' | '.join(logs))
     if request.method == 'GET':
-        response_message = f'GET request received for endpoint {request.full_path}'
-        response_body = {'message': response_message}
+        # response_message = f'GET request received for endpoint {request.full_path}'
+        # response_body = {'message': response_message}
+        response_body = jsonify(message=f'GET request received for endpoint {request.full_path}')
     else:
         response_body = {generic: request.json}
 

--- a/app/internal/rest.py
+++ b/app/internal/rest.py
@@ -18,7 +18,6 @@ import time
 from werkzeug.exceptions import UnsupportedMediaType
 from contextlib import suppress
 from flask import Blueprint, current_app, jsonify, request
-from markupsafe import escape
 
 
 internal_blueprint = Blueprint('internal', __name__, url_prefix='/internal')
@@ -54,7 +53,9 @@ def handler(generic):
     logs.append(f'HEADERS: {headers_string}')
     current_app.logger.info('Generic Internal Request: %s', ' | '.join(logs))
     if request.method == 'GET':
-        response_body = f'GET request received for endpoint {escape(request.full_path)}'
+        # response_body = f'GET request received for endpoint {request.full_path}'
+        response_message = f'GET request received for endpoint {request.full_path}'
+        response_body = {'message': response_message}
     else:
         response_body = {generic: request.json}
 

--- a/tests/app/internal/test_rest.py
+++ b/tests/app/internal/test_rest.py
@@ -18,7 +18,7 @@ def test_ut_get_internal(client, mocker, query_string):
     response = client.get(url_for('internal.handler', generic='foo', **query_string[0]))
     assert response.status_code == 200
     response_json = json.loads(response.text)
-    assert response_json['message'] == f'GET request received for endpoint /internal/foo?{query_string[1]}'
+    assert response_json['foo'] == f'GET request received for endpoint /internal/foo?{query_string[1]}'
 
     actual = mock_logger.call_args_list[0].args[0]
     expected = 'Generic Internal Request: %s'

--- a/tests/app/internal/test_rest.py
+++ b/tests/app/internal/test_rest.py
@@ -7,9 +7,9 @@ from unittest.mock import patch
 @pytest.mark.parametrize(
     'query_string',
     [
-        ({'foo': 'bar'}, 'foo=bar'),
-        ({}, ''),
-        ({'foo': 'bar', 'baz': 'qux'}, 'foo=bar&baz=qux'),
+        ({'foo': 'bar'}, 'foo=bar', 'foo=bar'),
+        ({}, '', ''),
+        ({'foo': 'bar', 'baz': 'qux'}, 'foo=bar&amp;baz=qux', 'foo=bar&baz=qux'),
     ],
 )
 def test_ut_get_internal(client, mocker, query_string):
@@ -23,7 +23,7 @@ def test_ut_get_internal(client, mocker, query_string):
     assert actual == expected, 'The logger was not called with the expected message.'
 
     actual = mock_logger.call_args_list[0].args[1]
-    assert f"QUERY_STRING: b'{query_string[1]}'" in actual, 'The logged info did not contain the correct QUERY_STRING.'
+    assert f"QUERY_STRING: b'{query_string[2]}'" in actual, 'The logged info did not contain the correct QUERY_STRING.'
 
 
 @pytest.mark.parametrize('method', ['GET', 'POST'])


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Update GET response for internal testing endpoint to return JSON object containing response string.

POST route was not altered.

Logging messages have not been changed.

TEAM-1487 - Code Scan
https://github.com/department-of-veterans-affairs/vanotify-team/issues/1487

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

Updated unit testing to reflect new response structure

![image](https://github.com/user-attachments/assets/b68c3537-379a-4bc4-bc30-957d8e964648)

Tested locally with CURL

**Before**

`curl -X GET "http://127.0.0.1:6011/internal/test?param1=100&param2=\"bob\"" -w "\n"`

`GET request received for endpoint /internal/test?param1=100&param2="bob"`

**After**

`curl -X GET "http://127.0.0.1:6011/internal/test?param1=100&param2=\"bob\"" -w "\n"`

```
{
  "test": "GET request received for endpoint /internal/test?param1=100&param2=\"bob\""
}
```

### PR tested against updated regression on DEV and passed.
https://github.com/department-of-veterans-affairs/notification-api-qa/actions/runs/13843156264

### Code scans
See ticket comments
https://github.com/department-of-veterans-affairs/vanotify-team/issues/1487

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
