### PR TITLE
#2352 - Vetext incoming lambda duplicate message

### DIFF
--- a/lambda_functions/vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
+++ b/lambda_functions/vetext_incoming_forwarder_lambda/vetext_incoming_forwarder_lambda.py
@@ -408,7 +408,7 @@ def push_to_retry_sqs(event_body):
 
         queue_msg = json.dumps(event_body)
         queue_msg_attrs = {'source': {'DataType': 'String', 'StringValue': 'twilio'}}
-        sqs.send_message(QueueUrl=queue_url, DelayedSeconds=3, MessageAttributes=queue_msg_attrs, MessageBody=queue_msg)
+        sqs.send_message(QueueUrl=queue_url, DelaySeconds=3, MessageAttributes=queue_msg_attrs, MessageBody=queue_msg)
 
         logger.info('Completed enqueue of message to retry queue')
     except Exception:


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

issue #2352

This PR attempts to fix the issue of sending duplicate messages to Vetext by adding a delay to the retry SQS service. Before this fix,  the retry SQS service was called several times in a matter of a second, potentially causing the same message to be forwarded to Vetext. 

Using [DelaySeconds](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs/client/send_message.html#:~:text=DelaySeconds%20(integer)) to delay SQS processing event

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Deployed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->
- [Deploy to DEV OK ](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/14454599214)


In order to test, I updated the forwarding to Vetext lambda to randomly throw a timeout exception when calling Vetext.  I triggered the dev [Forward to Vetext Lambda](https://console.amazonaws-us-gov.com/lambda/home?region=us-gov-west-1#/functions/project-dev-vetext-incoming-forwarder-lambda?subtab=triggers&tab=testing) and reviewed the logs in [DataDog](https://vanotify.ddog-gov.com/logs?query=service%3Aproject-dev-vetext-incoming-forwarder-lambda&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1744657560170&to_ts=1744658460170&live=true)


Example of code to randomly throw Timeout. 90 percent chance of throwing Timeout
```
  try:
        if random.random() < 0.9:
            raise requests.exceptions.Timeout(f"Simulated requests timeout - before delay")

        response = requests.post(endpoint_uri, verify=False, json=body, timeout=HTTPTIMEOUT, headers=headers)  # nosec
        logger.info('VeText POST complete')
        response.raise_for_status()

        logger.info('VeText call complete with response: %d', response.status_code)
        logger.debug('VeText response: %s', response.content)
        return response.content
    except requests.HTTPError as e:
    ...
```

- [DataDog logs before implementing delay](https://vanotify.ddog-gov.com/logs?query=service%3Aproject-dev-vetext-incoming-forwarder-lambda&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1744658255446&to_ts=1744658286455&live=false). Note the lambda retries multiple times within the same second - See log "Preparing for Retry SQS"
<img width="1297" alt="Screenshot 2025-04-14 at 4 50 46 PM" src="https://github.com/user-attachments/assets/8accd072-609a-4194-a8ca-0562d834315b" />

- [DataDog logs after the delay](https://vanotify.ddog-gov.com/logs?query=service%3Aproject-dev-vetext-incoming-forwarder-lambda&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1744663682076&to_ts=1744663732557&live=false). See log "Preparing for Retry SQS" 3 seconds apart
<img width="1283" alt="Screenshot 2025-04-14 at 4 49 51 PM" src="https://github.com/user-attachments/assets/11a6e4b2-ae22-489f-b940-51d6baf14853" />


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
