### PR TITLE
#2357 - Implement docker build caching

### DIFF
--- a/.github/actions/build-push-artifacts/action.yml
+++ b/.github/actions/build-push-artifacts/action.yml
@@ -45,5 +45,3 @@ runs:
         context: .
         push: true
         tags: ${{ steps.login-ecr-vaec.outputs.registry }}/notification_api:${{ inputs.ref }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max

--- a/.github/actions/build-push-artifacts/action.yml
+++ b/.github/actions/build-push-artifacts/action.yml
@@ -45,3 +45,5 @@ runs:
         context: .
         push: true
         tags: ${{ steps.login-ecr-vaec.outputs.registry }}/notification_api:${{ inputs.ref }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/dev-tests.yml
+++ b/.github/workflows/dev-tests.yml
@@ -27,7 +27,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           install: true
-          driver-opts: image=moby/buildkit:latest
   
       - uses: crazy-max/ghaction-github-runtime@v3
 

--- a/.github/workflows/dev-tests.yml
+++ b/.github/workflows/dev-tests.yml
@@ -27,8 +27,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           install: true
-  
-      - uses: crazy-max/ghaction-github-runtime@v3
+          version: latest  # Ensure we get version >= 0.21.0 for new cache service
+          
+      - name: Set up GitHub Actions Runtime
+        uses: crazy-max/ghaction-github-runtime@v3
 
       - name: Compose build (with cache)
         run: |

--- a/.github/workflows/dev-tests.yml
+++ b/.github/workflows/dev-tests.yml
@@ -23,6 +23,20 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          driver-opts: image=moby/buildkit:latest
+  
+      - uses: crazy-max/ghaction-github-runtime@v3
+
+      - name: Compose build (with cache)
+        run: |
+          docker compose --builder "${BUILDX_BUILDER}" \
+            -f ci/docker-compose-ci.yml \
+            build
+
       - name: Run tests using docker-compose
         run: |
           # Start DB container

--- a/.github/workflows/dev-tests.yml
+++ b/.github/workflows/dev-tests.yml
@@ -33,9 +33,9 @@ jobs:
 
       - name: Compose build (with cache)
         run: |
-          docker compose --builder "${BUILDX_BUILDER}" \
+          docker compose \
             -f ci/docker-compose-ci.yml \
-            build
+            build --builder "${BUILDX_BUILDER}"
 
       - name: Run tests using docker-compose
         run: |

--- a/.github/workflows/dev-tests.yml
+++ b/.github/workflows/dev-tests.yml
@@ -23,15 +23,23 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      # Caching requires 3 steps here
+      # 1. Set up Docker Buildx - according to https://docs.docker.com/build/cache/backends/gha/,
+      #    the standard Docker driver is not supported for caching. Setting up buildx is necessary.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           install: true
           version: latest  # Ensure we get version >= 0.21.0 for new cache service
-          
+        
+      # 2. Set up GitHub Actions Runtime
+      #    This is required to set up the runtime and expose ${ACTIONS_RESULTS_URL}, which is used by buildx.
+      #    Referenced here: https://docs.docker.com/build/cache/backends/gha/#authentication
       - name: Set up GitHub Actions Runtime
-        uses: crazy-max/ghaction-github-runtime@v3
+        uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124 # v3.1.0 -- pinned to avoid breaking changes
 
+      # 3. Compose build (with cache)
+      #    This is the actual build step that uses the cache.
       - name: Compose build (with cache)
         run: |
           docker compose \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -15,10 +15,10 @@ ENV PATH="$POETRY_HOME/bin:$PATH"
 COPY certs/* /usr/local/share/ca-certificates/
 
 # Copy necessary files for dependency installation and build steps
-COPY .git Makefile scripts/import-va-certs.sh poetry.lock pyproject.toml /
+COPY Makefile scripts/import-va-certs.sh poetry.lock pyproject.toml /
 
 # Install system build dependencies and other packages
-RUN apk add --no-cache bash build-base git postgresql-dev g++ make libffi-dev libmagic libcurl python3-dev openssl-dev \
+RUN apk add --no-cache bash build-base postgresql-dev g++ make libffi-dev libmagic libcurl python3-dev openssl-dev \
     curl-dev wget openssl && \
     # Import extra VA certs and generate a version file
     bash import-va-certs.sh && make generate-version-file

--- a/ci/docker-compose-ci.yml
+++ b/ci/docker-compose-ci.yml
@@ -4,6 +4,10 @@ services:
       context: ..
       dockerfile: ci/Dockerfile
       target: ci
+      cache-from:
+        - type=gha
+      cache-to:
+        - type=gha,mode=max
       args:
         POETRY_ARGS: --with static_tools,test
         FLASK_DEBUG: 1

--- a/ci/docker-compose-ci.yml
+++ b/ci/docker-compose-ci.yml
@@ -5,9 +5,9 @@ services:
       dockerfile: ci/Dockerfile
       target: ci
       cache_from:
-        - type=gha
+        - type=gha,url_v2=${ACTIONS_RESULTS_URL}
       cache_to:
-        - type=gha,mode=max
+        - type=gha,mode=max,url_v2=${ACTIONS_RESULTS_URL}
       args:
         POETRY_ARGS: --with static_tools,test
         FLASK_DEBUG: 1

--- a/ci/docker-compose-ci.yml
+++ b/ci/docker-compose-ci.yml
@@ -4,9 +4,9 @@ services:
       context: ..
       dockerfile: ci/Dockerfile
       target: ci
-      cache-from:
+      cache_from:
         - type=gha
-      cache-to:
+      cache_to:
         - type=gha,mode=max
       args:
         POETRY_ARGS: --with static_tools,test


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR implements Docker caching during unit testing (CI). It does this by adapting https://docs.docker.com/build/cache/backends/gha/ a little bit, because we use docker-compose to run our tests in CI.

At a high level, this PR:
1. Sets up buildx (requirement) to allow us to use the GHA backend cache store
2. Sets up the GHA runtime on the host to allow us to use buildx
3. Performs the build and caching

**NOTE**: This feature is listed as experimental on GHA documentation, but it is also listed as the recommended approach to caching docker images between runs. According to [GHA cache usage limits](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy), it will delete unused caches after 7 days, and we will only be allowed a max of 10GB worth of storage.

The image below shows some of the larger cache sizes in this PR alone. Most of the sizes are 8-10 KB, and a couple are a few hundred MB.
<img width="1294" alt="image" src="https://github.com/user-attachments/assets/3cb71f99-63c9-4e78-af70-aa7451078831" />
 

issue #2357 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

The image pasted above shows that images are being cached.

This image shows the initial caching run coming in at a total of 9m:
<img width="1905" alt="image" src="https://github.com/user-attachments/assets/b5750bea-5195-4da2-b87e-8c77d5c4b5f9" />

These workflow runs show using the cache:
https://github.com/department-of-veterans-affairs/notification-api/actions/runs/14734966503/job/41358652180
https://github.com/department-of-veterans-affairs/notification-api/actions/runs/14735258480/job/41359632413
https://github.com/department-of-veterans-affairs/notification-api/actions/runs/14737519426/job/41367240152

Building and populating the cache takes just over 3 minutes. Pulling down using the cache takes ~50 seconds.


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
