### PR TITLE
#1575 bugfix-deactivating-nonexistent-inbound-number

### DIFF
--- a/app/dao/inbound_numbers_dao.py
+++ b/app/dao/inbound_numbers_dao.py
@@ -1,3 +1,4 @@
+from uuid import UUID
 from app import db
 from app.dao.dao_utils import transactional
 from app.models import InboundNumber
@@ -21,11 +22,11 @@ def dao_get_inbound_numbers_for_service(service_id: str) -> List[InboundNumber]:
 
 @transactional
 def dao_set_inbound_number_active_flag(
-    inbound_number_id: str,
+    inbound_number_id: UUID,
     active: bool,
 ) -> None:
     inbound_number = db.session.get(InboundNumber, inbound_number_id)
-    if not inbound_number:
+    if inbound_number is None:
         raise ValueError(f'Inbound number with id {inbound_number_id} does not exist')
     inbound_number.active = active
 

--- a/app/dao/inbound_numbers_dao.py
+++ b/app/dao/inbound_numbers_dao.py
@@ -25,6 +25,8 @@ def dao_set_inbound_number_active_flag(
     active: bool,
 ) -> None:
     inbound_number = db.session.get(InboundNumber, inbound_number_id)
+    if not inbound_number:
+        raise ValueError(f'Inbound number with id {inbound_number_id} does not exist.')
     inbound_number.active = active
 
     db.session.add(inbound_number)

--- a/app/dao/inbound_numbers_dao.py
+++ b/app/dao/inbound_numbers_dao.py
@@ -26,7 +26,7 @@ def dao_set_inbound_number_active_flag(
 ) -> None:
     inbound_number = db.session.get(InboundNumber, inbound_number_id)
     if not inbound_number:
-        raise ValueError(f'Inbound number with id {inbound_number_id} does not exist.')
+        raise ValueError(f'Inbound number with id {inbound_number_id} does not exist')
     inbound_number.active = active
 
     db.session.add(inbound_number)

--- a/app/inbound_number/rest.py
+++ b/app/inbound_number/rest.py
@@ -85,8 +85,8 @@ def get_inbound_numbers_for_service(service_id):
 def post_set_inbound_number_off(inbound_number_id: uuid.UUID):
     try:
         dao_set_inbound_number_active_flag(inbound_number_id, active=False)
-    except ValueError:
-        raise InvalidRequest(f'Inbound number with id {inbound_number_id} does not exist', 400)
+    except ValueError as e:
+        raise InvalidRequest(str(e), status_code=400)
     return jsonify(), 204
 
 

--- a/app/inbound_number/rest.py
+++ b/app/inbound_number/rest.py
@@ -97,10 +97,11 @@ def post_set_inbound_number_off(inbound_number_id):
         dao_set_inbound_number_active_flag(inbound_number_id, active=False)
         return jsonify(), 204
     except Exception as e:
+        current_app.logger.error("An unexpected error occurred", exc_info=e)
         error_data = [
             {
                 'error': 'InternalServerError',
-                'message': str(e),
+                'message': 'An internal error has occurred. Please contact support if the issue persists.',
             }
         ]
         return jsonify(errors=error_data), 500

--- a/app/inbound_number/rest.py
+++ b/app/inbound_number/rest.py
@@ -1,7 +1,6 @@
 from flask import Blueprint, jsonify, request
 from sqlalchemy.exc import IntegrityError
 
-from app import db
 from app.dao.inbound_numbers_dao import (
     dao_create_inbound_number,
     dao_get_inbound_numbers,
@@ -84,27 +83,16 @@ def get_inbound_numbers_for_service(service_id):
 @inbound_number_blueprint.route('/<uuid:inbound_number_id>/off', methods=['POST'])
 def post_set_inbound_number_off(inbound_number_id):
     try:
-        inbound_number = db.session.get(InboundNumber, inbound_number_id)
-        if not inbound_number:
-            error_data = [
-                {
-                    'error': 'BadRequestError',
-                    'message': f'Inbound number with id {inbound_number_id} does not exist',
-                }
-            ]
-            return jsonify(errors=error_data), 400
-
         dao_set_inbound_number_active_flag(inbound_number_id, active=False)
-        return jsonify(), 204
-    except Exception as e:
-        current_app.logger.error("An unexpected error occurred", exc_info=e)
+    except ValueError:
         error_data = [
             {
-                'error': 'InternalServerError',
-                'message': 'An internal error has occurred. Please contact support if the issue persists.',
+                'error': 'BadRequestError',
+                'message': f'Inbound number with id {inbound_number_id} does not exist',
             }
         ]
-        return jsonify(errors=error_data), 500
+        return jsonify(errors=error_data), 400
+    return jsonify(), 204
 
 
 @inbound_number_blueprint.route('/available', methods=['GET'])

--- a/app/inbound_number/rest.py
+++ b/app/inbound_number/rest.py
@@ -81,7 +81,7 @@ def get_inbound_numbers_for_service(service_id):
 
 
 @inbound_number_blueprint.route('/<uuid:inbound_number_id>/off', methods=['POST'])
-def post_set_inbound_number_off(inbound_number_id):
+def post_set_inbound_number_off(inbound_number_id: str):
     try:
         dao_set_inbound_number_active_flag(inbound_number_id, active=False)
     except ValueError:

--- a/app/inbound_number/rest.py
+++ b/app/inbound_number/rest.py
@@ -1,3 +1,4 @@
+import uuid
 from flask import Blueprint, jsonify, request
 from sqlalchemy.exc import IntegrityError
 

--- a/app/inbound_number/rest.py
+++ b/app/inbound_number/rest.py
@@ -81,7 +81,7 @@ def get_inbound_numbers_for_service(service_id):
 
 
 @inbound_number_blueprint.route('/<uuid:inbound_number_id>/off', methods=['POST'])
-def post_set_inbound_number_off(inbound_number_id: str):
+def post_set_inbound_number_off(inbound_number_id: uuid.UUID):
     try:
         dao_set_inbound_number_active_flag(inbound_number_id, active=False)
     except ValueError:

--- a/app/inbound_number/rest.py
+++ b/app/inbound_number/rest.py
@@ -10,7 +10,7 @@ from app.dao.inbound_numbers_dao import (
     dao_set_inbound_number_active_flag,
     dao_update_inbound_number,
 )
-from app.errors import register_errors
+from app.errors import register_errors, InvalidRequest
 from app.inbound_number.inbound_number_schema import (
     post_create_inbound_number_schema,
     post_update_inbound_number_schema,
@@ -86,13 +86,7 @@ def post_set_inbound_number_off(inbound_number_id: uuid.UUID):
     try:
         dao_set_inbound_number_active_flag(inbound_number_id, active=False)
     except ValueError:
-        error_data = [
-            {
-                'error': 'BadRequestError',
-                'message': f'Inbound number with id {inbound_number_id} does not exist',
-            }
-        ]
-        return jsonify(errors=error_data), 400
+        raise InvalidRequest(f'Inbound number with id {inbound_number_id} does not exist', 400)
     return jsonify(), 204
 
 

--- a/tests/app/dao/test_inbound_numbers_dao.py
+++ b/tests/app/dao/test_inbound_numbers_dao.py
@@ -65,7 +65,7 @@ class TestSetInboundNumberActiveFlag:
         non_existent_id = uuid4()
         with pytest.raises(ValueError) as e:
             dao_set_inbound_number_active_flag(non_existent_id, active=True)
-        assert str(e.value) == f'Inbound number with id {non_existent_id} does not exist.'
+        assert str(e.value) == f'Inbound number with id {non_existent_id} does not exist'
 
 
 def test_create_inbound_number(notify_db_session):

--- a/tests/app/dao/test_inbound_numbers_dao.py
+++ b/tests/app/dao/test_inbound_numbers_dao.py
@@ -1,3 +1,4 @@
+from uuid import uuid4
 import pytest
 
 from app.dao.inbound_numbers_dao import (
@@ -59,6 +60,12 @@ class TestSetInboundNumberActiveFlag:
         dao_set_inbound_number_active_flag(inbound_number.id, active=active)
         inbound_number_from_db = notify_db_session.session.get(InboundNumber, inbound_number.id)
         assert inbound_number_from_db.active is active
+
+    def test_set_inbound_number_active_flag_raises_error_when_inbound_number_does_not_exist(self):
+        non_existent_id = uuid4()
+        with pytest.raises(ValueError) as e:
+            dao_set_inbound_number_active_flag(non_existent_id, active=True)
+        assert str(e.value) == f'Inbound number with id {non_existent_id} does not exist.'
 
 
 def test_create_inbound_number(notify_db_session):

--- a/tests/app/inbound_number/test_rest.py
+++ b/tests/app/inbound_number/test_rest.py
@@ -46,20 +46,20 @@ class TestGetInboundNumbersForService:
 
 
 class TestSetInboundNumberOff:
-    def test_sets_inbound_number_active_flag_off(self, notify_db_session, admin_request, mocker, sample_inbound_number):
+    def test_sets_inbound_number_active_flag_off(self, notify_db_session, admin_request, sample_inbound_number):
         """
         Test that the endpoint sets the active flag of an inbound number to False.
         """
         inbound_number = sample_inbound_number()
+        assert inbound_number.active
+
         admin_request.post(
             'inbound_number.post_set_inbound_number_off', _expected_status=204, inbound_number_id=inbound_number.id
         )
-        inbound_number_from_db = notify_db_session.session.get(InboundNumber, inbound_number.id)
-        assert inbound_number_from_db.active is False
+        notify_db_session.session.refresh(inbound_number)
+        assert not inbound_number.active
 
-    def test_returns_400_when_inbound_number_does_not_exist(
-        self, notify_db_session, admin_request, mocker, sample_inbound_number
-    ):
+    def test_returns_400_when_inbound_number_does_not_exist(self, admin_request):
         """
         Test that the endpoint returns a 400 error when the inbound number does not exist.
         """

--- a/tests/app/inbound_number/test_rest.py
+++ b/tests/app/inbound_number/test_rest.py
@@ -46,19 +46,28 @@ class TestGetInboundNumbersForService:
 
 
 class TestSetInboundNumberOff:
-    def test_sets_inbound_number_active_flag_off(self, admin_request, mocker, sample_service, sample_inbound_number):
-        dao_set_inbound_number_active_flag = mocker.patch('app.inbound_number.rest.dao_set_inbound_number_active_flag')
-
-        service = sample_service()
-        inbound_number = sample_inbound_number(service_id=service.id)
-        admin_request.post(
-            'inbound_number.post_set_inbound_number_off', _expected_status=204, inbound_number_id=inbound_number.id
+    def test_sets_inbound_number_active_flag_off(self, admin_request, mocker):
+        """
+        Test that the endpoint sets the active flag of an inbound number to False.
+        """
+        dao_set_inbound_number_active_flag = mocker.patch(
+            'app.inbound_number.rest.dao_set_inbound_number_active_flag', return_value=None
         )
-        dao_set_inbound_number_active_flag.assert_called_with(inbound_number.id, active=False)
+
+        inbound_number_id = uuid.uuid4()
+        admin_request.post(
+            'inbound_number.post_set_inbound_number_off', _expected_status=204, inbound_number_id=inbound_number_id
+        )
+        dao_set_inbound_number_active_flag.assert_called_with(inbound_number_id, active=False)
 
     def test_returns_400_when_inbound_number_does_not_exist(self, admin_request, mocker):
-        # Mock db.session.get to return None, simulating non-existent inbound number
-        mocker.patch('app.db.session.get', return_value=None)
+        """
+        Test that the endpoint returns a 400 error when the inbound number does not exist.
+        """
+        error_message = 'Inbound number with id {} does not exist'
+        mocker.patch(
+            'app.inbound_number.rest.dao_set_inbound_number_active_flag', side_effect=ValueError(error_message)
+        )
 
         non_existent_id = uuid.uuid4()
         response = admin_request.post(


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR adds error handling when attempting to deactivate an inbound number that doesn't exist by updating the DAO to raise a ValueError and modifying the REST endpoint to catch that error and return a 400 response.


issue #1575 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- [Deployed to dev](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/15114806328)
- POST to the inbound number deactivate endpoint with an invalid uuid (I used the sms_template_id var).

``` http
POST /vanotify/inbound-number/463a744a-bfcb-4044-af27-e8d6c6f092bd/off HTTP/1.1
Content-Type: application/json
Accept: */*
 
HTTP/1.1 400 BAD REQUEST
Date: Mon, 19 May 2025 13:07:46 GMT
Content-Type: application/json
Content-Length: 162
 
{
   "errors": [
      {
         "error": "BadRequestError",
         "message": "Inbound number with id 463a744a-bfcb-4044-af27-e8d6c6f092bd does not exist"
      }
   ]
}

```

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
