### PR TITLE
Remove default permissions from DD and task def workflows

### DIFF
--- a/.github/workflows/task-defnition-cleanup.yaml
+++ b/.github/workflows/task-defnition-cleanup.yaml
@@ -1,5 +1,8 @@
 name: Cleanup AWS ECS Task Definitions
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 0 * * 0' # weekly -- Sunday at 00:00 UTC

--- a/.github/workflows/task-defnition-cleanup.yaml
+++ b/.github/workflows/task-defnition-cleanup.yaml
@@ -1,7 +1,6 @@
 name: Cleanup AWS ECS Task Definitions
 
-permissions:
-  contents: read
+permissions: {} # no permissions needed
 
 on:
   schedule:

--- a/.github/workflows/update-datadog-image.yaml
+++ b/.github/workflows/update-datadog-image.yaml
@@ -1,5 +1,8 @@
 name: Datadog image update
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/update-datadog-image.yaml
+++ b/.github/workflows/update-datadog-image.yaml
@@ -1,7 +1,6 @@
 name: Datadog image update
 
-permissions:
-  contents: read
+permissions: {} # no permissions needed
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR removes the default GHA permissions from two workflows: Datadog image updated and ECS task def cleanup. This is part of a larger initiative to scope down our GHA workflows.

TEAM-1633

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

Successfully tested the ECS task definition workflow.
<img width="1294" alt="image" src="https://github.com/user-attachments/assets/98c99de8-b3e3-4f5b-8415-d5f92b78ea07" />

Did not test the datadog image updater, but it does not perform any actions to Github resources. When we run the updater the next time we update our DD image, if it fails, I will fix it. 


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change
