### PR TITLE
#2261 - API Key generation allows uuid type

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -34,7 +34,7 @@ fileignoreconfig:
 - filename: tests/app/notifications/test_validators.py
   checksum: 9dab7e3890137b515bf84f9ea587d79dbd5e63568ff9a72c3a404f7738c0b329
 - filename: tests/app/service/test_api_key_endpoints.py
-  checksum: 14c7ada5fa1473205c11646f7f786e662d24543633b9966241401a68c98be312
+  checksum: c26fd96b52dd1cfdab043cb589aee797646cc3eaa26dfa82d75433066209e9dc
 - filename: tests/app/service/test_rest.py
   checksum: b2126023c505e04dc66e4cc2be876c49daad154acd0c2ac63f03961e2ea8bef2
 - filename: tests/lambda_functions/nightly_stats_bigquery_upload/test_nightly_lambda.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -28,7 +28,7 @@ fileignoreconfig:
 - filename: tests/app/authentication/test_authentication.py
   checksum: f7091cd49ae042cb1a189d81e905c7595a822e5a6742624ed37a0ed7e1e05bb5
 - filename: tests/app/dao/test_api_key_dao.py
-  checksum: b89de4dbd757eeafac99d19344e24451195257732a2435a3fcf107d8916271b5
+  checksum: fac529618d40d8db7895c8f721f8271edf3c20a076b04a11ed9490518c613667
 - filename: tests/app/delivery/test_send_to_providers.py
   checksum: 760da11876b82b4401f5b5ddec998f3b5756209984e49591c352c49cd7b83d27
 - filename: tests/app/notifications/test_validators.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -32,7 +32,7 @@ fileignoreconfig:
 - filename: tests/app/authentication/test_authentication.py
   checksum: f7091cd49ae042cb1a189d81e905c7595a822e5a6742624ed37a0ed7e1e05bb5
 - filename: tests/app/dao/test_api_key_dao.py
-  checksum: 79b310a740cb215cf9fb1d9153a19832d42d968ffb7c1531a2356538be2ec4ec
+  checksum: 0978fff8de5235e1d30630b0632727c9065a5c7cb38b0204ec546dfdc50eefe3
 - filename: tests/app/delivery/test_send_to_providers.py
   checksum: 760da11876b82b4401f5b5ddec998f3b5756209984e49591c352c49cd7b83d27
 - filename: tests/app/notifications/test_validators.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -12,7 +12,7 @@ fileignoreconfig:
 - filename: app/schemas.py
   checksum: 263db62e3a74db2cb8efa2a0088364950c790730abdb243ff206bc2988c246d8
 - filename: app/service/rest.py
-  checksum: 5e350e4556b9c78c11e06d98da61a238d5a4f6a8e04cee0c557995007dd2aeaf
+  checksum: c3a9cd974573609d05092e449ef86ae38b76ce4540cf8c22020424608316566e
 - filename: app/v2/notifications/post_notifications.py
   checksum: b52f923d90faa072095d5e4c2925bf588a3649846ac65e8ae36f285823b57965
 - filename: cd/application-deployment/dev/dev.env
@@ -41,6 +41,8 @@ fileignoreconfig:
   checksum: c26fd96b52dd1cfdab043cb589aee797646cc3eaa26dfa82d75433066209e9dc
 - filename: tests/app/service/test_rest.py
   checksum: b2126023c505e04dc66e4cc2be876c49daad154acd0c2ac63f03961e2ea8bef2
+- filename: tests/app/service/test_secret_generator.py
+  checksum: 1f84342c3a20bcfc0192a9bbe2c28fefd9decf01a7c9c3a2cba0286b6ad33caa
 - filename: tests/lambda_functions/nightly_stats_bigquery_upload/test_nightly_lambda.py
   checksum: db79656ed019ef873475215ad09a6c3cfedd6079bfafe6ab1e56754fcf50ebe4
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -28,7 +28,7 @@ fileignoreconfig:
 - filename: tests/app/authentication/test_authentication.py
   checksum: f7091cd49ae042cb1a189d81e905c7595a822e5a6742624ed37a0ed7e1e05bb5
 - filename: tests/app/dao/test_api_key_dao.py
-  checksum: fac529618d40d8db7895c8f721f8271edf3c20a076b04a11ed9490518c613667
+  checksum: 79b310a740cb215cf9fb1d9153a19832d42d968ffb7c1531a2356538be2ec4ec
 - filename: tests/app/delivery/test_send_to_providers.py
   checksum: 760da11876b82b4401f5b5ddec998f3b5756209984e49591c352c49cd7b83d27
 - filename: tests/app/notifications/test_validators.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,8 @@
 fileignoreconfig:
 - filename: app/celery/reporting_tasks.py
   checksum: 2374dafe0993f493addc7ea8276342371584cf98d1a60c152a419981f85ea05a
+- filename: app/constants.py
+  checksum: 0f9db062e443cdbddd1b9fdd68178d1b8574ad5c6f3dc57b1e7f08cce8d50777
 - filename: app/dao/api_key_dao.py
   checksum: 92d84387fd479ad053b0c9e452e48780e390b5f920393a226cc3104183d36325
 - filename: app/delivery/send_to_providers.py
@@ -12,7 +14,7 @@ fileignoreconfig:
 - filename: app/schemas.py
   checksum: a76644e96e2811991d6ede197de257eb2185eb0d0b7ef88569b311219f6e30ed
 - filename: app/service/rest.py
-  checksum: b88c1b117a4ea40d9f185b5fc38755b37da8ebb47cf2c386e78e49044dc3c801
+  checksum: 9356f75621f193fa7a57e35d9feb1e203ebc3d064436d5399e93dc12985d24c3
 - filename: app/v2/notifications/post_notifications.py
   checksum: b52f923d90faa072095d5e4c2925bf588a3649846ac65e8ae36f285823b57965
 - filename: cd/application-deployment/dev/dev.env
@@ -32,17 +34,17 @@ fileignoreconfig:
 - filename: tests/app/authentication/test_authentication.py
   checksum: f7091cd49ae042cb1a189d81e905c7595a822e5a6742624ed37a0ed7e1e05bb5
 - filename: tests/app/dao/test_api_key_dao.py
-  checksum: b9109a34c225f4fb50ac611e391a09206731c44f7481ffa0d7b74dbc5444c722
+  checksum: 9f417a5f8fdb915b1b187ea456c5e72dd3552b178a29b9b2581e8a2b1255fcbd
 - filename: tests/app/delivery/test_send_to_providers.py
   checksum: 760da11876b82b4401f5b5ddec998f3b5756209984e49591c352c49cd7b83d27
 - filename: tests/app/notifications/test_validators.py
   checksum: 9dab7e3890137b515bf84f9ea587d79dbd5e63568ff9a72c3a404f7738c0b329
 - filename: tests/app/service/test_api_key_endpoints.py
-  checksum: 6af8acef2b764e5ec6e024b3053ab78234513942e731c99ab26f82036a24e538
+  checksum: 9419b40ea50f171b2f230617f813158f9559c3c57d607e3da417d7857e9504a9
 - filename: tests/app/service/test_rest.py
   checksum: b2126023c505e04dc66e4cc2be876c49daad154acd0c2ac63f03961e2ea8bef2
 - filename: tests/app/service/test_secret_generator.py
-  checksum: 7c06519be12d61976d2ba077e08ae8dd196ed5c2f93e74e55d55380fb3e613da
+  checksum: e2ae9adcb65e9850f773f418c48eff6686ef945bc5606a5a7ecadb2212494419
 - filename: tests/lambda_functions/nightly_stats_bigquery_upload/test_nightly_lambda.py
   checksum: db79656ed019ef873475215ad09a6c3cfedd6079bfafe6ab1e56754fcf50ebe4
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -7,6 +7,8 @@ fileignoreconfig:
   checksum: e6ffbab28f29de186ece73eda6602376e221e42d5bbfd8f25d9958dd3594e9af
 - filename: app/notifications/validators.py
   checksum: 7c3f9574dd8096863b53927723fccc75f8c0a27c06a2da09b277fbc8af7ba9ef
+- filename: app/schemas.py
+  checksum: 263db62e3a74db2cb8efa2a0088364950c790730abdb243ff206bc2988c246d8
 - filename: app/service/rest.py
   checksum: 5e350e4556b9c78c11e06d98da61a238d5a4f6a8e04cee0c557995007dd2aeaf
 - filename: app/v2/notifications/post_notifications.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,8 @@
 fileignoreconfig:
 - filename: app/celery/reporting_tasks.py
   checksum: 2374dafe0993f493addc7ea8276342371584cf98d1a60c152a419981f85ea05a
+- filename: app/dao/api_key_dao.py
+  checksum: 92d84387fd479ad053b0c9e452e48780e390b5f920393a226cc3104183d36325
 - filename: app/delivery/send_to_providers.py
   checksum: 0d0602d29851e4b485e231a1c101fdf3c7845951efd82bd966885d80204504d5
 - filename: app/feature_flags.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -5,6 +5,8 @@ fileignoreconfig:
   checksum: 0d0602d29851e4b485e231a1c101fdf3c7845951efd82bd966885d80204504d5
 - filename: app/feature_flags.py
   checksum: e6ffbab28f29de186ece73eda6602376e221e42d5bbfd8f25d9958dd3594e9af
+- filename: app/notifications/validators.py
+  checksum: 7c3f9574dd8096863b53927723fccc75f8c0a27c06a2da09b277fbc8af7ba9ef
 - filename: app/service/rest.py
   checksum: 5e350e4556b9c78c11e06d98da61a238d5a4f6a8e04cee0c557995007dd2aeaf
 - filename: app/v2/notifications/post_notifications.py
@@ -23,14 +25,16 @@ fileignoreconfig:
   checksum: 4e6e2fabf9630e9e0d26028818f41f34c065e80c223db34d35a1d1068c37a782
 - filename: poetry.lock
   checksum: 12c7eba25edd93a17625bffdf468aea9c2d485599516e1ba5b9b34c2b17dc0c4
-- filename: app/notifications/validators.py
-  checksum: 7c3f9574dd8096863b53927723fccc75f8c0a27c06a2da09b277fbc8af7ba9ef
 - filename: tests/app/authentication/test_authentication.py
   checksum: f7091cd49ae042cb1a189d81e905c7595a822e5a6742624ed37a0ed7e1e05bb5
+- filename: tests/app/dao/test_api_key_dao.py
+  checksum: b89de4dbd757eeafac99d19344e24451195257732a2435a3fcf107d8916271b5
 - filename: tests/app/delivery/test_send_to_providers.py
   checksum: 760da11876b82b4401f5b5ddec998f3b5756209984e49591c352c49cd7b83d27
 - filename: tests/app/notifications/test_validators.py
   checksum: 9dab7e3890137b515bf84f9ea587d79dbd5e63568ff9a72c3a404f7738c0b329
+- filename: tests/app/service/test_api_key_endpoints.py
+  checksum: 14c7ada5fa1473205c11646f7f786e662d24543633b9966241401a68c98be312
 - filename: tests/app/service/test_rest.py
   checksum: b2126023c505e04dc66e4cc2be876c49daad154acd0c2ac63f03961e2ea8bef2
 - filename: tests/lambda_functions/nightly_stats_bigquery_upload/test_nightly_lambda.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -12,7 +12,7 @@ fileignoreconfig:
 - filename: app/notifications/validators.py
   checksum: 7c3f9574dd8096863b53927723fccc75f8c0a27c06a2da09b277fbc8af7ba9ef
 - filename: app/schemas.py
-  checksum: a76644e96e2811991d6ede197de257eb2185eb0d0b7ef88569b311219f6e30ed
+  checksum: 868535a708972460e9bf565404c81a582e4eecca33047a0e71b18a5d2e6d6ffa
 - filename: app/service/rest.py
   checksum: 9356f75621f193fa7a57e35d9feb1e203ebc3d064436d5399e93dc12985d24c3
 - filename: app/v2/notifications/post_notifications.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -10,9 +10,9 @@ fileignoreconfig:
 - filename: app/notifications/validators.py
   checksum: 7c3f9574dd8096863b53927723fccc75f8c0a27c06a2da09b277fbc8af7ba9ef
 - filename: app/schemas.py
-  checksum: 263db62e3a74db2cb8efa2a0088364950c790730abdb243ff206bc2988c246d8
+  checksum: a76644e96e2811991d6ede197de257eb2185eb0d0b7ef88569b311219f6e30ed
 - filename: app/service/rest.py
-  checksum: c3a9cd974573609d05092e449ef86ae38b76ce4540cf8c22020424608316566e
+  checksum: b88c1b117a4ea40d9f185b5fc38755b37da8ebb47cf2c386e78e49044dc3c801
 - filename: app/v2/notifications/post_notifications.py
   checksum: b52f923d90faa072095d5e4c2925bf588a3649846ac65e8ae36f285823b57965
 - filename: cd/application-deployment/dev/dev.env
@@ -32,17 +32,17 @@ fileignoreconfig:
 - filename: tests/app/authentication/test_authentication.py
   checksum: f7091cd49ae042cb1a189d81e905c7595a822e5a6742624ed37a0ed7e1e05bb5
 - filename: tests/app/dao/test_api_key_dao.py
-  checksum: 0978fff8de5235e1d30630b0632727c9065a5c7cb38b0204ec546dfdc50eefe3
+  checksum: b9109a34c225f4fb50ac611e391a09206731c44f7481ffa0d7b74dbc5444c722
 - filename: tests/app/delivery/test_send_to_providers.py
   checksum: 760da11876b82b4401f5b5ddec998f3b5756209984e49591c352c49cd7b83d27
 - filename: tests/app/notifications/test_validators.py
   checksum: 9dab7e3890137b515bf84f9ea587d79dbd5e63568ff9a72c3a404f7738c0b329
 - filename: tests/app/service/test_api_key_endpoints.py
-  checksum: c26fd96b52dd1cfdab043cb589aee797646cc3eaa26dfa82d75433066209e9dc
+  checksum: 6af8acef2b764e5ec6e024b3053ab78234513942e731c99ab26f82036a24e538
 - filename: tests/app/service/test_rest.py
   checksum: b2126023c505e04dc66e4cc2be876c49daad154acd0c2ac63f03961e2ea8bef2
 - filename: tests/app/service/test_secret_generator.py
-  checksum: 1f84342c3a20bcfc0192a9bbe2c28fefd9decf01a7c9c3a2cba0286b6ad33caa
+  checksum: 7c06519be12d61976d2ba077e08ae8dd196ed5c2f93e74e55d55380fb3e613da
 - filename: tests/lambda_functions/nightly_stats_bigquery_upload/test_nightly_lambda.py
   checksum: db79656ed019ef873475215ad09a6c3cfedd6079bfafe6ab1e56754fcf50ebe4
 version: "1.0"

--- a/app/constants.py
+++ b/app/constants.py
@@ -198,6 +198,10 @@ KEY_TYPE_NORMAL = 'normal'
 KEY_TYPE_TEAM = 'team'
 KEY_TYPE_TEST = 'test'
 
+# Bandit thinks these are hardcoded secrets, but they are not.
+SECRET_TYPE_DEFAULT = 'default'  # nosec B105
+SECRET_TYPE_UUID = 'uuid'  # nosec B105
+
 # User auth types
 SMS_AUTH_TYPE = 'sms_auth'
 EMAIL_AUTH_TYPE = 'email_auth'

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -12,6 +12,8 @@ from app.constants import (
     EMAIL_TYPE,
     LETTER_TYPE,
     NOTIFICATION_STATUS_TYPES_COMPLETED,
+    SECRET_TYPE_DEFAULT,
+    SECRET_TYPE_UUID,
     SERVICE_PERMISSION_TYPES,
     SMS_TYPE,
 )
@@ -625,8 +627,8 @@ class ApiKeySchema(BaseSchema):
 
     @validates('secret_type')
     def validate_secret_type(self, value, **kwargs):
-        if value is not None and value not in ('uuid', 'default'):
-            raise ValidationError("Invalid secret type: must be 'uuid' or 'default'")
+        if value is not None and value not in (SECRET_TYPE_UUID, SECRET_TYPE_DEFAULT):
+            raise ValidationError(f"Invalid secret type: must be '{SECRET_TYPE_UUID}' or '{SECRET_TYPE_DEFAULT}'")
         return value
 
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -615,12 +615,19 @@ class TemplateHistorySchema(BaseSchema):
 class ApiKeySchema(BaseSchema):
     created_by = field_for(models.ApiKey, 'created_by', required=True)
     key_type = field_for(models.ApiKey, 'key_type', required=True)
+    secret_type = fields.Str(required=False, allow_none=True)
 
     class Meta:
         model = models.ApiKey
         exclude = ('service', '_secret')
         strict = True
         load_instance = True
+
+    @validates('secret_type')
+    def validate_secret_type(self, value, **kwargs):
+        if value is not None and value != 'uuid':
+            raise ValidationError("Invalid secret type: must be 'uuid'")
+        return value
 
 
 class JobSchema(BaseSchema):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -625,8 +625,8 @@ class ApiKeySchema(BaseSchema):
 
     @validates('secret_type')
     def validate_secret_type(self, value, **kwargs):
-        if value is not None and value != 'uuid':
-            raise ValidationError("Invalid secret type: must be 'uuid'")
+        if value is not None and value not in ('uuid', 'default'):
+            raise ValidationError("Invalid secret type: must be 'uuid' or 'default'")
         return value
 
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1,7 +1,7 @@
 import itertools
 from datetime import datetime, timedelta
 from typing import Literal
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from flask import current_app, Blueprint, jsonify, request
 from flask.wrappers import Response
@@ -157,6 +157,25 @@ def update_service(service_id):
     return jsonify(data=service_schema.dump(fetched_service)), 200
 
 
+def get_secret_generator(secret_type: str | None):
+    """Get the appropriate secret generator function based on secret type.
+
+    Args:
+        secret_type (str | None): The type of secret to generate. Currently supports 'uuid' or None.
+
+    Returns:
+        Callable[[], str] | None: Secret generator function or None for default behavior.
+    """
+    if secret_type == 'uuid':  # nosec B105
+
+        def uuid_secret_generator():
+            return str(uuid4())
+
+        return uuid_secret_generator
+
+    return None
+
+
 @service_blueprint.route('/<uuid:service_id>/api-key', methods=['POST'])
 @requires_admin_auth()
 def create_api_key(service_id: UUID) -> tuple[Response, Literal[201, 400]]:
@@ -178,7 +197,8 @@ def create_api_key(service_id: UUID) -> tuple[Response, Literal[201, 400]]:
     fetched_service = dao_fetch_service_by_id(service_id=service_id)
 
     try:
-        valid_api_key = api_key_schema.load(request.get_json())
+        request_data = request.get_json()
+        valid_api_key = api_key_schema.load(request_data)
     except DataError:
         err_msg += ' DataError, ensure created_by user id is a valid uuid'
         current_app.logger.exception(err_msg)
@@ -187,8 +207,12 @@ def create_api_key(service_id: UUID) -> tuple[Response, Literal[201, 400]]:
     valid_api_key.service = fetched_service
     valid_api_key.expiry_date = datetime.utcnow() + timedelta(days=180)
 
+    # Determine the secret generator function based on secret_type
+    secret_type = request_data.get('secret_type') if request_data else None
+    secret_generator = get_secret_generator(secret_type)
+
     try:
-        save_model_api_key(valid_api_key)
+        save_model_api_key(valid_api_key, secret_generator=secret_generator)
     except IntegrityError:
         err_msg += ' DB IntegrityError, ensure created_by id is valid and key_type is one of [normal, team, test]'
         current_app.logger.exception(err_msg)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from app import db
 from app.authentication.auth import requires_admin_auth, requires_admin_auth_or_user_in_service
+from app.constants import SECRET_TYPE_DEFAULT, SECRET_TYPE_UUID
 from app.dao.api_key_dao import (
     get_model_api_key,
     save_model_api_key,
@@ -166,14 +167,14 @@ def get_secret_generator(secret_type: str | None):
     Returns:
         Callable[[], str] | None: Secret generator function or None for default behavior.
     """
-    if secret_type == 'uuid':  # nosec B105
+    if secret_type == SECRET_TYPE_UUID:  # nosec B105
 
         def uuid_secret_generator():
             return str(uuid4())
 
         return uuid_secret_generator
 
-    if secret_type == 'default':  # nosec B105
+    if secret_type == SECRET_TYPE_DEFAULT:  # nosec B105
 
         def default_secret_generator():
             import secrets

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -161,7 +161,7 @@ def get_secret_generator(secret_type: str | None):
     """Get the appropriate secret generator function based on secret type.
 
     Args:
-        secret_type (str | None): The type of secret to generate. Currently supports 'uuid' or None.
+        secret_type (str | None): The type of secret to generate. Currently supports 'uuid', 'default', or None.
 
     Returns:
         Callable[[], str] | None: Secret generator function or None for default behavior.
@@ -172,6 +172,15 @@ def get_secret_generator(secret_type: str | None):
             return str(uuid4())
 
         return uuid_secret_generator
+
+    if secret_type == 'default':  # nosec B105
+
+        def default_secret_generator():
+            import secrets
+
+            return secrets.token_urlsafe(64)
+
+        return default_secret_generator
 
     return None
 

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy import delete, func, select
 from sqlalchemy.orm.exc import NoResultFound
 
-from app.constants import KEY_TYPE_NORMAL
+from app.constants import KEY_TYPE_NORMAL, SECRET_TYPE_DEFAULT
 from app.dao.api_key_dao import (
     get_model_api_key,
     save_model_api_key,
@@ -267,7 +267,7 @@ def test_save_api_key_with_default_generator_function_generates_default_token(no
     # Create a default generator function from get_secret_generator
     from app.service.rest import get_secret_generator
 
-    default_generator = get_secret_generator('default')
+    default_generator = get_secret_generator(SECRET_TYPE_DEFAULT)
 
     save_model_api_key(api_key, secret_generator=default_generator)
 

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -314,113 +314,105 @@ def test_get_api_keys_with_invalid_is_revoked_param(notify_api, notify_db_sessio
             assert json_resp['message'] == 'Invalid value for include_revoked'
 
 
-def test_create_api_key_with_uuid_secret_type_returns_201(notify_api, notify_db_session, sample_service):
+def test_create_api_key_with_uuid_secret_type_returns_201(client, notify_db_session, sample_service):
     """Test end-to-end happy path for requesting UUID-style secret generation through the REST API."""
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            service = sample_service()
-            data = {
-                'secret_type': 'uuid',
-                'name': 'Integration Test Key',
-                'created_by': str(service.created_by.id),
-                'key_type': KEY_TYPE_NORMAL,
-            }
-            auth_header = create_admin_authorization_header()
-            response = client.post(
-                url_for('service.create_api_key', service_id=service.id),
-                data=json.dumps(data),
-                headers=[('Content-Type', 'application/json'), auth_header],
-            )
+    service = sample_service()
+    data = {
+        'secret_type': 'uuid',
+        'name': 'Integration Test Key',
+        'created_by': str(service.created_by.id),
+        'key_type': KEY_TYPE_NORMAL,
+    }
+    auth_header = create_admin_authorization_header()
+    response = client.post(
+        url_for('service.create_api_key', service_id=service.id),
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header],
+    )
 
-            # This should fail until we implement the feature
-            assert response.status_code == 201
-            json_resp = json.loads(response.get_data(as_text=True))
-            assert 'data' in json_resp
+    # This should fail until we implement the feature
+    assert response.status_code == 201
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert 'data' in json_resp
 
-            # Verify the returned secret is a valid UUID format
-            try:
-                generated_uuid = uuid.UUID(json_resp['data'])
-                assert str(generated_uuid) == json_resp['data']
-                assert len(json_resp['data']) == 36  # Standard UUID string length
-            except ValueError:
-                pytest.fail(f'Expected UUID format but got: {json_resp["data"]}')
+    # Verify the returned secret is a valid UUID format
+    try:
+        generated_uuid = uuid.UUID(json_resp['data'])
+        assert str(generated_uuid) == json_resp['data']
+        assert len(json_resp['data']) == 36  # Standard UUID string length
+    except ValueError:
+        pytest.fail(f'Expected UUID format but got: {json_resp["data"]}')
 
-            # Cleanup - UUID test specific
-            saved_api_keys = get_model_api_keys(service.id)
-            if saved_api_keys:
-                saved_api_key = saved_api_keys[0]
-                # Clean up using same pattern as other tests
-                try:
-                    notify_db_session.session.delete(saved_api_key)
-                    notify_db_session.session.commit()
-                except Exception:
-                    pass  # Cleanup will be handled by fixtures
+    # Cleanup - UUID test specific
+    saved_api_keys = get_model_api_keys(service.id)
+    if saved_api_keys:
+        saved_api_key = saved_api_keys[0]
+        # Clean up using same pattern as other tests
+        try:
+            notify_db_session.session.delete(saved_api_key)
+            notify_db_session.session.commit()
+        except Exception:
+            pass  # Cleanup will be handled by fixtures
 
 
-def test_create_api_key_with_invalid_secret_type_returns_400(notify_api, sample_service):
+def test_create_api_key_with_invalid_secret_type_returns_400(client, sample_service):
     """Test proper error handling when invalid secret type values are submitted via the API."""
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            service = sample_service()
-            data = {
-                'secret_type': 'invalid_type',
-                'name': 'Test Key',
-                'created_by': str(service.created_by.id),
-                'key_type': KEY_TYPE_NORMAL,
-            }
-            auth_header = create_admin_authorization_header()
-            response = client.post(
-                url_for('service.create_api_key', service_id=service.id),
-                data=json.dumps(data),
-                headers=[('Content-Type', 'application/json'), auth_header],
-            )
+    service = sample_service()
+    data = {
+        'secret_type': 'invalid_type',
+        'name': 'Test Key',
+        'created_by': str(service.created_by.id),
+        'key_type': KEY_TYPE_NORMAL,
+    }
+    auth_header = create_admin_authorization_header()
+    response = client.post(
+        url_for('service.create_api_key', service_id=service.id),
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header],
+    )
 
-            # This should fail until we implement the feature
-            assert response.status_code == 400
-            json_resp = json.loads(response.get_data(as_text=True))
-            assert json_resp['result'] == 'error'
-            assert 'Invalid secret type' in json_resp['message'] or 'secret_type' in str(json_resp['message'])
+    # This should fail until we implement the feature
+    assert response.status_code == 400
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert json_resp['result'] == 'error'
+    assert 'Invalid secret type' in json_resp['message'] or 'secret_type' in str(json_resp['message'])
 
 
-def test_create_api_key_without_secret_type_maintains_backward_compatibility(
-    notify_api, notify_db_session, sample_service
-):
+def test_create_api_key_without_secret_type_maintains_backward_compatibility(client, notify_db_session, sample_service):
     """Test that existing API behavior remains unchanged for current consumers."""
-    with notify_api.test_request_context():
-        with notify_api.test_client() as client:
-            service = sample_service()
-            data = {
-                'name': 'Backward Compatible Test Key',
-                'created_by': str(service.created_by.id),
-                'key_type': KEY_TYPE_NORMAL,
-            }
-            auth_header = create_admin_authorization_header()
-            response = client.post(
-                url_for('service.create_api_key', service_id=service.id),
-                data=json.dumps(data),
-                headers=[('Content-Type', 'application/json'), auth_header],
-            )
+    service = sample_service()
+    data = {
+        'name': 'Backward Compatible Test Key',
+        'created_by': str(service.created_by.id),
+        'key_type': KEY_TYPE_NORMAL,
+    }
+    auth_header = create_admin_authorization_header()
+    response = client.post(
+        url_for('service.create_api_key', service_id=service.id),
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header],
+    )
 
-            assert response.status_code == 201
-            json_resp = json.loads(response.get_data(as_text=True))
-            assert 'data' in json_resp
+    assert response.status_code == 201
+    json_resp = json.loads(response.get_data(as_text=True))
+    assert 'data' in json_resp
 
-            # Verify secret is auto-generated using current random token method
-            secret = json_resp['data']
-            assert secret is not None
-            assert len(secret) >= 86  # Current default generates ~86+ chars
+    # Verify secret is auto-generated using current random token method
+    secret = json_resp['data']
+    assert secret is not None
+    assert len(secret) >= 86  # Current default generates ~86+ chars
 
-            # Verify it's not a UUID format
-            with pytest.raises(ValueError):
-                uuid.UUID(secret)
+    # Verify it's not a UUID format
+    with pytest.raises(ValueError):
+        uuid.UUID(secret)
 
-            # Cleanup - backward compatibility test specific
-            saved_api_keys = get_model_api_keys(service.id)
-            if saved_api_keys:
-                saved_api_key = saved_api_keys[0]
-                # Clean up using same pattern as other tests
-                try:
-                    notify_db_session.session.delete(saved_api_key)
-                    notify_db_session.session.commit()
-                except Exception:
-                    pass  # Cleanup will be handled by fixtures
+    # Cleanup - backward compatibility test specific
+    saved_api_keys = get_model_api_keys(service.id)
+    if saved_api_keys:
+        saved_api_key = saved_api_keys[0]
+        # Clean up using same pattern as other tests
+        try:
+            notify_db_session.session.delete(saved_api_key)
+            notify_db_session.session.commit()
+        except Exception:
+            pass  # Cleanup will be handled by fixtures

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -7,7 +7,7 @@ from flask import url_for
 from sqlalchemy import delete, select, Table
 
 from app import db
-from app.constants import KEY_TYPE_NORMAL
+from app.constants import KEY_TYPE_NORMAL, SECRET_TYPE_DEFAULT, SECRET_TYPE_UUID
 from app.models import ApiKey
 from app.dao.api_key_dao import expire_api_key, get_model_api_keys
 from tests import create_admin_authorization_header
@@ -318,7 +318,7 @@ def test_create_api_key_with_uuid_secret_type_returns_201(client, notify_db_sess
     """Test end-to-end happy path for requesting UUID-style secret generation through the REST API."""
     service = sample_service()
     data = {
-        'secret_type': 'uuid',
+        'secret_type': SECRET_TYPE_UUID,
         'name': 'Integration Test Key',
         'created_by': str(service.created_by.id),
         'key_type': KEY_TYPE_NORMAL,
@@ -399,7 +399,7 @@ def test_create_api_key_with_default_secret_type_returns_201(client, notify_db_s
     """Test end-to-end happy path for requesting default-style secret generation through the REST API."""
     service = sample_service()
     data = {
-        'secret_type': 'default',
+        'secret_type': SECRET_TYPE_DEFAULT,
         'name': 'Default Test Key',
         'created_by': str(service.created_by.id),
         'key_type': KEY_TYPE_NORMAL,

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from uuid import uuid4
 
 import pytest
@@ -337,8 +338,6 @@ def test_create_api_key_with_uuid_secret_type_returns_201(notify_api, notify_db_
             assert 'data' in json_resp
 
             # Verify the returned secret is a valid UUID format
-            import uuid
-
             try:
                 generated_uuid = uuid.UUID(json_resp['data'])
                 assert str(generated_uuid) == json_resp['data']
@@ -412,8 +411,6 @@ def test_create_api_key_without_secret_type_maintains_backward_compatibility(
             assert len(secret) >= 86  # Current default generates ~86+ chars
 
             # Verify it's not a UUID format
-            import uuid
-
             with pytest.raises(ValueError):
                 uuid.UUID(secret)
 

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -342,17 +342,6 @@ def test_create_api_key_with_uuid_secret_type_returns_201(client, notify_db_sess
     except ValueError:
         pytest.fail(f'Expected UUID format but got: {json_resp["data"]}')
 
-    # Cleanup - UUID test specific
-    saved_api_keys = get_model_api_keys(service.id)
-    if saved_api_keys:
-        saved_api_key = saved_api_keys[0]
-        # Clean up using same pattern as other tests
-        try:
-            notify_db_session.session.delete(saved_api_key)
-            notify_db_session.session.commit()
-        except Exception:
-            pass  # Cleanup will be handled by fixtures
-
 
 def test_create_api_key_with_invalid_secret_type_returns_400(client, sample_service):
     """Test proper error handling when invalid secret type values are submitted via the API."""
@@ -404,14 +393,3 @@ def test_create_api_key_without_secret_type_maintains_backward_compatibility(cli
     # Verify it's not a UUID format
     with pytest.raises(ValueError):
         uuid.UUID(secret)
-
-    # Cleanup - backward compatibility test specific
-    saved_api_keys = get_model_api_keys(service.id)
-    if saved_api_keys:
-        saved_api_key = saved_api_keys[0]
-        # Clean up using same pattern as other tests
-        try:
-            notify_db_session.session.delete(saved_api_key)
-            notify_db_session.session.commit()
-        except Exception:
-            pass  # Cleanup will be handled by fixtures

--- a/tests/app/service/test_api_key_endpoints.py
+++ b/tests/app/service/test_api_key_endpoints.py
@@ -330,7 +330,6 @@ def test_create_api_key_with_uuid_secret_type_returns_201(client, notify_db_sess
         headers=[('Content-Type', 'application/json'), auth_header],
     )
 
-    # This should fail until we implement the feature
     assert response.status_code == 201
     json_resp = json.loads(response.get_data(as_text=True))
     assert 'data' in json_resp

--- a/tests/app/service/test_secret_generator.py
+++ b/tests/app/service/test_secret_generator.py
@@ -22,6 +22,26 @@ def test_get_secret_generator_with_uuid_returns_uuid_generator():
     assert str(parsed_uuid) == secret
 
 
+def test_get_secret_generator_with_default_returns_default_generator():
+    """Test that requesting 'default' secret type returns a function that generates default tokens."""
+    generator = get_secret_generator('default')
+
+    assert generator is not None
+    assert callable(generator)
+
+    # Test that the generator produces a string secret similar to the default behavior
+    secret = generator()
+    assert isinstance(secret, str)
+    assert len(secret) >= 86  # Default token_urlsafe(64) generates ~86+ chars
+
+    # Verify it's not a UUID format
+    try:
+        UUID(secret)
+        assert False, 'Default secret should not be a valid UUID'
+    except ValueError:
+        pass  # Expected - default secrets are not UUIDs
+
+
 def test_get_secret_generator_with_none_returns_none():
     """Test that requesting None secret type returns None."""
     generator = get_secret_generator(None)
@@ -51,3 +71,16 @@ def test_get_secret_generator_uuid_produces_unique_values():
     # Verify all are valid UUIDs
     for secret in secrets:
         UUID(secret)  # This will raise ValueError if invalid
+
+
+def test_get_secret_generator_default_produces_unique_values():
+    """Test that the default generator produces unique values on each call."""
+    generator = get_secret_generator('default')
+
+    # Generate multiple secrets and ensure they're all different
+    secrets = [generator() for _ in range(10)]
+    assert len(set(secrets)) == 10  # All should be unique
+
+    # Verify all have expected length
+    for secret in secrets:
+        assert len(secret) >= 86

--- a/tests/app/service/test_secret_generator.py
+++ b/tests/app/service/test_secret_generator.py
@@ -2,12 +2,13 @@
 
 from uuid import UUID
 
+from app.constants import SECRET_TYPE_DEFAULT, SECRET_TYPE_UUID
 from app.service.rest import get_secret_generator
 
 
 def test_get_secret_generator_with_uuid_returns_uuid_generator():
     """Test that requesting 'uuid' secret type returns a function that generates UUIDs."""
-    generator = get_secret_generator('uuid')
+    generator = get_secret_generator(SECRET_TYPE_UUID)
 
     assert generator is not None
     assert callable(generator)
@@ -24,7 +25,7 @@ def test_get_secret_generator_with_uuid_returns_uuid_generator():
 
 def test_get_secret_generator_with_default_returns_default_generator():
     """Test that requesting 'default' secret type returns a function that generates default tokens."""
-    generator = get_secret_generator('default')
+    generator = get_secret_generator(SECRET_TYPE_DEFAULT)
 
     assert generator is not None
     assert callable(generator)
@@ -62,7 +63,7 @@ def test_get_secret_generator_with_unknown_type_returns_none():
 
 def test_get_secret_generator_uuid_produces_unique_values():
     """Test that the UUID generator produces unique values on each call."""
-    generator = get_secret_generator('uuid')
+    generator = get_secret_generator(SECRET_TYPE_UUID)
 
     # Generate multiple UUIDs and ensure they're all different
     secrets = [generator() for _ in range(10)]
@@ -75,7 +76,7 @@ def test_get_secret_generator_uuid_produces_unique_values():
 
 def test_get_secret_generator_default_produces_unique_values():
     """Test that the default generator produces unique values on each call."""
-    generator = get_secret_generator('default')
+    generator = get_secret_generator(SECRET_TYPE_DEFAULT)
 
     # Generate multiple secrets and ensure they're all different
     secrets = [generator() for _ in range(10)]

--- a/tests/app/service/test_secret_generator.py
+++ b/tests/app/service/test_secret_generator.py
@@ -1,0 +1,53 @@
+"""Tests for the get_secret_generator helper function."""
+
+from uuid import UUID
+
+from app.service.rest import get_secret_generator
+
+
+def test_get_secret_generator_with_uuid_returns_uuid_generator():
+    """Test that requesting 'uuid' secret type returns a function that generates UUIDs."""
+    generator = get_secret_generator('uuid')
+
+    assert generator is not None
+    assert callable(generator)
+
+    # Test that the generator produces valid UUID strings
+    secret = generator()
+    assert isinstance(secret, str)
+    assert len(secret) == 36  # Standard UUID string length
+
+    # Verify it's a valid UUID by parsing it
+    parsed_uuid = UUID(secret)
+    assert str(parsed_uuid) == secret
+
+
+def test_get_secret_generator_with_none_returns_none():
+    """Test that requesting None secret type returns None."""
+    generator = get_secret_generator(None)
+    assert generator is None
+
+
+def test_get_secret_generator_with_empty_string_returns_none():
+    """Test that requesting empty string secret type returns None."""
+    generator = get_secret_generator('')
+    assert generator is None
+
+
+def test_get_secret_generator_with_unknown_type_returns_none():
+    """Test that requesting unknown secret type returns None."""
+    generator = get_secret_generator('unknown_type')
+    assert generator is None
+
+
+def test_get_secret_generator_uuid_produces_unique_values():
+    """Test that the UUID generator produces unique values on each call."""
+    generator = get_secret_generator('uuid')
+
+    # Generate multiple UUIDs and ensure they're all different
+    secrets = [generator() for _ in range(10)]
+    assert len(set(secrets)) == 10  # All should be unique
+
+    # Verify all are valid UUIDs
+    for secret in secrets:
+        UUID(secret)  # This will raise ValueError if invalid


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This PR adds support for generating API keys with a UUID-style secret while maintaining backward compatibility for existing secret-generation behavior. 

issue #2261 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- [Deployed to dev](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/15348118726)
- Fired off some Postman requests, they are all api secrets so I can't really post here. I did a backwards-compatibility test and tested the new payload.

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
