### PR TITLE
HOTFIX - SES Rate Limit

### DIFF
--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -191,6 +191,10 @@ class AwsSesClient(EmailClient):
         ):
             self.statsd_client.incr('clients.ses.error.throttling')
             raise AwsSesClientThrottlingSendRateException(str(e))
+        elif 'Throttling' in str(e):
+            # The elif above missed a throttle. AWS likely has two ways to throttle, or the one above is out of date
+            self.statsd_client.incr('clients.ses.error.throttling')
+            raise AwsSesClientThrottlingSendRateException(str(e))
         else:
             self.statsd_client.incr('clients.ses.error')
             raise AwsSesClientException(str(e))

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 from uuid import uuid4
 
+import botocore
 from requests import HTTPError, Response
 from requests.exceptions import ConnectTimeout, RequestException
 from app.mobile_app.mobile_app_types import MobileAppType
@@ -14,7 +15,7 @@ from app.celery.provider_tasks import (
     deliver_sms_with_rate_limiting,
     _handle_delivery_failure,
 )
-from app.clients.email.aws_ses import AwsSesClientThrottlingSendRateException
+from app.clients.email.aws_ses import AwsSesClient, AwsSesClientThrottlingSendRateException
 from app.constants import (
     EMAIL_TYPE,
     NOTIFICATION_CREATED,
@@ -360,6 +361,28 @@ def test_should_retry_and_log_exception(mocker, sample_template, sample_notifica
         deliver_email(notification.id)
 
     assert notification.status == 'created'
+
+
+def test_should_retry_on_throttle(mocker, sample_template, sample_notification):
+    client = AwsSesClient()
+    client.init_app('asdf', 'logger', mocker.Mock())
+    e = botocore.exceptions.ClientError({'Error': {'Code': 1234, 'Message': 'Throttling'}}, 'op name')
+    with pytest.raises(AwsSesClientThrottlingSendRateException):
+        client._check_error_code(e, '1234')
+    # mocker.patch('app.delivery.send_to_providers.statsd')
+    # mocker.patch(
+    #     'app.delivery.send_to_providers._check_error_code', side_effect=botocore.exceptions.ClientError({'Error': {'Message': 'Throttling'}}, 'op name')
+    # )
+
+    # template = sample_template()
+    # assert template.template_type == SMS_TYPE
+    # notification = sample_notification(template=template)
+
+    # with pytest.raises(AutoRetryException) as exc_info:
+    #     deliver_email(notification.id)
+    # assert 'Throttling' in str(exc_info)
+
+    # assert notification.status == 'created'
 
 
 def test_deliver_sms_with_rate_limiting_should_deliver_if_rate_limit_not_exceeded(


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
We started to see throttling come in from AWS. These were caught and retried, but are being logged as errors/exceptions and thus causing alerts unnecessarily. This PR adds a catch for SES responses involving "Throttling" and is intended to catch what is not caught by the catch above it.

Also refactored the PII base class slightly to allow for using the encrypted value to build a `PiiObject`. 

Removed the ability to create empty `PiiObjects`.



issue N/A

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->
Created tests for all cases. 


## Checklist

- [ ] I have assigned myself to this PR
- [ ] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [ ] PR has a detailed description, including links to specific documentation
- [ ] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [ ] I did not remove any parts of the template, such as checkboxes even if they are not used
- [ ] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [ ] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change
