### PR TITLE
#HOTFIX - Updated logging in twilio status update job

### DIFF
--- a/app/celery/twilio_tasks.py
+++ b/app/celery/twilio_tasks.py
@@ -47,9 +47,8 @@ def update_twilio_status():
             updated_count += 1
         except NonRetryableException as e:
             current_app.logger.error(
-                '[TWILIO_STATUS_TASK] Rate limit hit, stopping batch. Updated %s/%s notifications. Error: %s',
-                updated_count,
-                len(notifications),
+                '[TWILIO_STATUS_TASK] Failed to update notification %s: %s due to rate limit, aborting.',
+                str(notification.id),
                 str(e),
             )
             break

--- a/tests/app/celery/test_twilio_tasks.py
+++ b/tests/app/celery/test_twilio_tasks.py
@@ -117,6 +117,8 @@ def test_update_twilio_status_exception(mocker, sample_notification):
     update_twilio_status()
 
     mock_logger.assert_called_once_with(
-        'Failed to update notification %s: %s due to rate limit, aborting.', str(notification_one.id), 'Test exception'
+        '[TWILIO_STATUS_TASK] Failed to update notification %s: %s due to rate limit, aborting.',
+        str(notification_one.id),
+        'Test exception',
     )
     mock_twilio_status_override.assert_called_once_with(notification_one.reference)


### PR DESCRIPTION
# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR updates logging statements in the Twilio status update scheduled task to include a prefix tag [TWILIO_STATUS_TASK], making it easier to distinguish these logs from regular application traffic. The changes also improve the logging structure by adding a completion summary and removing some redundant log messages.

issue #

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- [Deployed to dev](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/16379096487)
- Logs after job ran -
<img width="1355" height="206" alt="Screenshot 2025-07-18 at 4 13 12 PM" src="https://github.com/user-attachments/assets/417c890c-5785-4f3a-aa5f-0a8b49b90292" />


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change