### PR TITLE
#2538 PII persistence and retrieval

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -67,4 +67,6 @@ fileignoreconfig:
   checksum: 38948b94d8fdcdf64d3da02ffb50d170838ce783f3a1e3350b7b7bcdcb7cb1ca
 - filename: tests/app/v2/notifications/test_pii_wrapping_at_entrypoint.py
   checksum: 4dcd257865daa286c737d6a76e141e8b9aee66c0642524447c394554643b7712
+- filename: tests/app/v2/notifications/test_post_notifications.py
+  checksum: a12eb5a735321d8eaa8e2ff6af4e2dbd570a11f861213fd448b11cc2ee4cd8f9
 version: "1.0"

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -26,17 +26,19 @@ from app.constants import (
     NOTIFICATION_CREATED,
 )
 
-from app.dao.service_sms_sender_dao import (
-    dao_get_service_sms_sender_by_id,
-    dao_get_service_sms_sender_by_service_id_and_number,
-)
-from app.dao.templates_dao import TemplateHistoryData, dao_get_template_history_by_id
-from app.models import Notification, ScheduledNotification, RecipientIdentifier, Template
 from app.dao.notifications_dao import (
     dao_create_notification,
     dao_delete_notification_by_id,
     dao_created_scheduled_notification,
 )
+from app.dao.service_sms_sender_dao import (
+    dao_get_service_sms_sender_by_id,
+    dao_get_service_sms_sender_by_service_id_and_number,
+)
+from app.dao.templates_dao import TemplateHistoryData, dao_get_template_history_by_id
+from app.feature_flags import is_feature_enabled, FeatureFlag
+from app.models import Notification, ScheduledNotification, RecipientIdentifier, Template
+from app.pii.pii_base import Pii
 from app.v2.errors import BadRequestError
 from app.utils import get_template_instance
 from app.va.identifier import IdentifierType
@@ -123,10 +125,15 @@ def persist_notification(
     )
 
     if recipient_identifier:
+        # id_value is a string or Pii subclass instance.
+        recipient_identifier_value = recipient_identifier['id_value']
+        if is_feature_enabled(FeatureFlag.PII_ENABLED) and isinstance(recipient_identifier_value, Pii):
+            recipient_identifier_value = recipient_identifier_value.get_encrypted_value()
+
         _recipient_identifier = RecipientIdentifier(
             notification_id=notification_id,
             id_type=recipient_identifier['id_type'],
-            id_value=recipient_identifier['id_value'],
+            id_value=recipient_identifier_value,
         )
 
         notification.recipient_identifiers.set(_recipient_identifier)

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -50,24 +50,17 @@ from app.v2.notifications.notification_schemas import (
 from app.utils import get_public_notify_type_text
 
 
-def wrap_recipient_identifier_in_pii(form: dict) -> dict:
+def wrap_recipient_identifier_in_pii(form: dict):
     """Wrap the recipient identifier id_value in the appropriate PII class.
 
     This function takes a form containing recipient identifier data and wraps
-    the id_value in the appropriate PII class based on the id_type. This provides
+    the id_value in the appropriate PII subclass based on the id_type. This provides
     encryption and controlled access to personally identifiable information.
 
     Args:
         form (dict): The validated form data containing recipient_identifier.
-                    This dictionary may be modified in-place if a valid
-                    recipient_identifier with id_type and id_value is present.
-
-    Returns:
-        dict: The same form dictionary, potentially with the
-              recipient_identifier['id_value'] wrapped in an appropriate
-              PII class (PiiIcn, PiiEdipi, PiiBirlsid, PiiPid, or PiiVaProfileID).
-              If wrapping fails or required fields are missing, the form
-              is returned unchanged.
+                     This dictionary may be modified in-place if a valid
+                     recipient_identifier with id_type and id_value is present.
 
     Note:
         - The form parameter is modified in-place when PII wrapping occurs
@@ -75,12 +68,11 @@ def wrap_recipient_identifier_in_pii(form: dict) -> dict:
         - PII instantiation errors are logged but don't prevent function completion
         - Only processes forms that contain recipient_identifier with both id_type and id_value
     """
+
     recipient_identifier = form.get('recipient_identifier')
-    if recipient_identifier is None:
-        return form
 
     if not isinstance(recipient_identifier, dict):
-        return form
+        return
 
     # Get values with .get() to avoid KeyError
     id_type: str = recipient_identifier['id_type']
@@ -96,6 +88,7 @@ def wrap_recipient_identifier_in_pii(form: dict) -> dict:
     }
 
     pii_class: type | None = pii_class_mapping.get(id_type)
+
     if pii_class is not None:
         try:
             # Wrap the id_value in the appropriate PII class
@@ -111,8 +104,6 @@ def wrap_recipient_identifier_in_pii(form: dict) -> dict:
             # Continue without wrapping if PII instantiation fails
     else:
         current_app.logger.warning('Unknown id_type %s - cannot wrap in PII class', id_type)
-
-    return form
 
 
 @v2_notification_blueprint.route('/<notification_type>', methods=['POST'])
@@ -150,9 +141,9 @@ def post_notification(notification_type):  # noqa: C901
             )
         )
 
-    # Wrap PII in recipient_identifier if feature flag is enabled
     if is_feature_enabled(FeatureFlag.PII_ENABLED):
-        form = wrap_recipient_identifier_in_pii(form)
+        # This might modify the form by converting form['recipient_identifier']['id_value'] to a Pii subclass.
+        wrap_recipient_identifier_in_pii(form)
 
     scheduled_for = form.get('scheduled_for')
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -26,6 +26,7 @@ from app.models import (
     RecipientIdentifier,
     ScheduledNotification,
 )
+from app.pii.pii_low import PiiVaProfileID
 from app.schema_validation import validate
 from app.v2.errors import RateLimitError
 from app.v2.notifications.notification_schemas import post_email_response, post_sms_response
@@ -1464,3 +1465,50 @@ def test_post_notification_returns_400_when_billing_code_length_exceeds_max(
 
     assert response.status_code == 400
     assert 'too long' in response.json['errors'][0]['message']
+
+
+@pytest.mark.parametrize('notification_type', [EMAIL_TYPE, SMS_TYPE])
+def test_post_notification_encrypts_recipient_identifiers(
+    client,
+    mocker,
+    notify_db_session,
+    sample_template,
+    sample_api_key,
+    notification_type,
+):
+    mocker.patch('app.celery.lookup_va_profile_id_task.lookup_va_profile_id.apply_async')
+    mocker.patch('app.celery.contact_information_tasks.lookup_contact_info.apply_async')
+    mocker.patch.dict('os.environ', {'PII_ENABLED': 'True'})
+
+    template = sample_template(template_type=notification_type)
+    api_key = sample_api_key(service=template.service)
+
+    data = {
+        'template_id': template.id,
+        'recipient_identifier': {
+            'id_type': IdentifierType.VA_PROFILE_ID.value,
+            'id_value': 'some va profile id',
+        },
+    }
+    auth_header = create_authorization_header(api_key)
+
+    response = client.post(
+        path=f'v2/notifications/{notification_type}',
+        data=json.dumps(data),
+        headers=[('Content-Type', 'application/json'), auth_header],
+    )
+
+    assert response.status_code == 201
+
+    notification_id = response.get_json()['id']
+    notification = notify_db_session.session.get(Notification, notification_id)
+    va_profile_id = notification.recipient_identifiers['VAPROFILEID'].id_value
+    pii_va_Profile_id = PiiVaProfileID(va_profile_id, True)
+
+    try:
+        assert va_profile_id != 'some va profile id', 'This value should be encrypted.'
+        assert pii_va_Profile_id.get_pii() == 'some va profile id'
+    finally:
+        stmt = delete(Notification).where(Notification.id == notification_id)
+        notify_db_session.session.execute(stmt)
+        notify_db_session.session.commit()


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

When the feature flag PII_ENABLED is True, encrypt recipient identifier values before persisting them in the database, and ensure they are decrypted when needed to send a notification.  The values should also be redacted in the response to requests to GET and notification.

issue #2538

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->



## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [ ] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [ ] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [ ] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change
