### PR TITLE
#1829 Handle Pinpoint v2 status update events

### DIFF
--- a/app/clients/sms/aws_pinpoint.py
+++ b/app/clients/sms/aws_pinpoint.py
@@ -303,7 +303,7 @@ class AwsPinpointClient(SmsClient):
 
             event_type = delivery_status_message['eventType']
             message_status = delivery_status_message['messageStatus']
-            is_final = delivery_status_message.get('isFinal', False)
+            is_final = delivery_status_message.get('isFinal', True)
             status, status_reason = self._get_aws_status(event_type, message_status, is_final)
 
             # Convert price from dollars to millicents for consistency


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

issue[ #1829](https://github.com/department-of-veterans-affairs/vanotify-team/issues/1829)

Verified that existing message status strings for PinpointV1 match PinpointV2.
Added (TEXT_QUEUED, QUEUED) event mapping to NOTIFICATION_SENDING. This is equivalent to the V1 BUFFERED status.
Updated AWS SMS delivery status event mapping for Pinpoint V2 to handle the new isFinal attribute.

https://docs.aws.amazon.com/sms-voice/latest/userguide/configuration-sets-event-format.html
isFinal | True if this is the final status for the message. There are intermediate message statuses and it can take up to 72 hours for the final message status to be received.

The incoming event is logged as-is in addition to the interpreted SENDING status for non-final events.

Conversation with AWS support indicates we should treat all non-final events (isFinal == False) as NOTIFICATION_SENDING to avoid premature notification status updates and callbacks.

The V2 event (TEXT_PROTECT_BLOCKED. PROTECT_BLOCKED) does not require handling at this time since we do not have that feature enabled in our EUM configs on any environment.

The following events will no need to be handled once we phase out V1 support since these events do not exist in V2
- MAX_PRICE_EXCEEDED
- OPTED_OUT

Unit tests updated to cover all supported eventTypes and messageStatus strings for both final and non-final event payloads.

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- Local unit testing (adding new tests and enabling previously skipped test)
- GHA unit testing
- DEV deployment regressions (feature disabled)
  - Sent test SMS, delivered to device, verified status update to delivered
- DEV deployment with feature enabled
  - Sent test SMS, delivered to device, verified status update to delivered
  - Sent test SMS with device in airplane mode, delayed delivery with non-final status update
  - Sent test SMS with device in airplane mode, delayed delivery with intermediate non-final failure update

### Delayed delivery (device in airplane mode)

- Sent SMS notification (V2 enabled)

```
PinpointV2 decoded PinpointV2 delivery-status record data: {'eventType': 'TEXT_SUCCESSFUL', 'eventVersion': '1.0', 'eventTimestamp': 1757507700647, 'isFinal': False, 'originationPhoneNumber': '+18337021549', 'destinationPhoneNumber': '+1978808xxxx', 'isoCountryCode': 'US', 'isInternationalSend': False, 'mcc': '310', 'mnc': '012', 'carrierName': 'Verizon Wireless', 'messageId': '08b191d4-81b9-4a99-beba-8113dcf7ae8c', 'messageRequestTimestamp': 1757507695811, 'messageEncoding': 'GSM', 'messageType': 'TRANSACTIONAL', 'messageStatus': 'SUCCESSFUL', 'messageStatusDescription': 'Message has been accepted by phone carrier', 'totalMessageParts': 1, 'totalMessagePrice': 0.00581, 'totalCarrierFee': 0.003}
```

```
Final pinpoint logic | reference: 08b191d4-81b9-4a99-beba-8113dcf7ae8c | notification_id: ddd7e8c3-f81e-4c00-8c35-711da740fb8a | status: sending | status_reason: None | cost_in_millicents: 0.0 | service_id: d6aa2c68-a2d9-4437-ab19-3ae8eb202553 | template_id: c62c286e-ef06-46b0-bd37-1163008c4054
```

TEXT_SUCCESSFUL/SUCCESSFUL would normally be processed as delivered but this is marked `'isFinal': False` so for V2 processing, it's instead processed as SENDING/PENDING

Get Notification
{{notification-api-url}}/v2/notifications/{{notification-id}}

```
{
	"id": "ddd7e8c3-f81e-4c00-8c35-711da740fb8a",
	"status": "sending",
	"status_reason": null
}
```

- Switched off airplane mode on device
- SMS delivered to device
- FINAL status update event processed `'isFinal': True`

```
PinpointV2 decoded PinpointV2 delivery-status record data: {'eventType': 'TEXT_DELIVERED', 'eventVersion': '1.0', 'eventTimestamp': 1757508996345, 'isFinal': True, 'originationPhoneNumber': '+18337021549', 'destinationPhoneNumber': '+1978808xxxx', 'isoCountryCode': 'US', 'isInternationalSend': False, 'mcc': '310', 'mnc': '012', 'carrierName': 'Verizon Wireless', 'messageId': '08b191d4-81b9-4a99-beba-8113dcf7ae8c', 'messageRequestTimestamp': 1757507695811, 'messageEncoding': 'GSM', 'messageType': 'TRANSACTIONAL', 'messageStatus': 'DELIVERED', 'messageStatusDescription': 'Message has been accepted by phone', 'totalMessageParts': 1, 'totalMessagePrice': 0.00581, 'totalCarrierFee': 0.003}
```

```
Final pinpoint logic | reference: 08b191d4-81b9-4a99-beba-8113dcf7ae8c | notification_id: ddd7e8c3-f81e-4c00-8c35-711da740fb8a | status: delivered | status_reason: None | cost_in_millicents: 5.0 | service_id: d6aa2c68-a2d9-4437-ab19-3ae8eb202553 | template_id: c62c286e-ef06-46b0-bd37-1163008c4054
```

Get Notification
{{notification-api-url}}/v2/notifications/{{notification-id}}

```
{
    "id": "ddd7e8c3-f81e-4c00-8c35-711da740fb8a",
    "status": "delivered",
    "status_reason": null,
}
```

### Simulated non-final failure update (device in airplane mode)

- Sent SMS notification (V2 enabled)

```
PinpointV2 decoded PinpointV2 delivery-status record data: {'eventType': 'TEXT_SUCCESSFUL', 'eventVersion': '1.0', 'eventTimestamp': 1757510149605, 'isFinal': False, 'originationPhoneNumber': '+18337021549', 'destinationPhoneNumber': '+1978808xxxx', 'isoCountryCode': 'US', 'isInternationalSend': False, 'mcc': '310', 'mnc': '012', 'carrierName': 'Verizon Wireless', 'messageId': 'f995a8b6-34aa-487d-8818-d6263b168f73', 'messageRequestTimestamp': 1757510146695, 'messageEncoding': 'GSM', 'messageType': 'TRANSACTIONAL', 'messageStatus': 'SUCCESSFUL', 'messageStatusDescription': 'Message has been accepted by phone carrier', 'totalMessageParts': 1, 'totalMessagePrice': 0.00581, 'totalCarrierFee': 0.003}
```

```
Final pinpoint logic | reference: f995a8b6-34aa-487d-8818-d6263b168f73 | notification_id: f26f2111-5ebf-4c62-8360-2764e5bb90a6 | status: sending | status_reason: None | cost_in_millicents: 0.0 | service_id: d6aa2c68-a2d9-4437-ab19-3ae8eb202553 | template_id: c62c286e-ef06-46b0-bd37-1163008c4054
```

- Notification is still 'sending' since the update was not final

#### Sent a simulated TEXT_INVALID_MESSAGE event (not final) to the V2 status update endpoint

- Note: Failures like this "should not" be sent as non-final according the AWS support but they might.
  - This test is just an additional validation of the final vs. non-final processing

```
PinpointV2 decoded PinpointV2 delivery-status record data: {'eventType': 'TEXT_INVALID_MESSAGE', 'eventVersion': '1.0', 'eventTimestamp': 1757510147391, 'isFinal': False, 'originationPhoneNumber': '+18337021549', 'destinationPhoneNumber': '+1978808xxxx', 'isoCountryCode': 'US', 'isInternationalSend': False, 'mcc': '310', 'mnc': '012', 'carrierName': 'Verizon Wireless', 'messageId': 'f995a8b6-34aa-487d-8818-d6263b168f73', 'messageRequestTimestamp': 1757510146695, 'messageEncoding': 'GSM', 'messageType': 'TRANSACTIONAL', 'messageStatus': 'INVALID_MESSAGE', 'messageStatusDescription': 'Message has been accepted by phone carrier', 'totalMessageParts': 1, 'totalMessagePrice': 0.00581, 'totalCarrierFee': 0.003}
```

- Non-final event correctly interpreted as SENDING/PENDING

```
Final pinpoint logic | reference: f995a8b6-34aa-487d-8818-d6263b168f73 | notification_id: f26f2111-5ebf-4c62-8360-2764e5bb90a6 | status: sending | status_reason: None | cost_in_millicents: 0.0 | service_id: d6aa2c68-a2d9-4437-ab19-3ae8eb202553 | template_id: c62c286e-ef06-46b0-bd37-1163008c4054
```

Get Notification
{{notification-api-url}}/v2/notifications/{{notification-id}}

```
{
    "id": "f26f2111-5ebf-4c62-8360-2764e5bb90a6",
    "status": "sending",
    "status_reason": null,
}
```

- Switched off airplane mode on device
- SMS delivered to device
- FINAL status update event processed `'isFinal': True`

```
PinpointV2 decoded PinpointV2 delivery-status record data: {'eventType': 'TEXT_DELIVERED', 'eventVersion': '1.0', 'eventTimestamp': 1757511557982, 'isFinal': True, 'originationPhoneNumber': '+18337021549', 'destinationPhoneNumber': '+1978808xxxx', 'isoCountryCode': 'US', 'isInternationalSend': False, 'mcc': '310', 'mnc': '012', 'carrierName': 'Verizon Wireless', 'messageId': 'f995a8b6-34aa-487d-8818-d6263b168f73', 'messageRequestTimestamp': 1757510146695, 'messageEncoding': 'GSM', 'messageType': 'TRANSACTIONAL', 'messageStatus': 'DELIVERED', 'messageStatusDescription': 'Message has been accepted by phone', 'totalMessageParts': 1, 'totalMessagePrice': 0.00581, 'totalCarrierFee': 0.003}
```

```
Final pinpoint logic | reference: f995a8b6-34aa-487d-8818-d6263b168f73 | notification_id: f26f2111-5ebf-4c62-8360-2764e5bb90a6 | status: delivered | status_reason: None | cost_in_millicents: 5.0 | service_id: d6aa2c68-a2d9-4437-ab19-3ae8eb202553 | template_id: c62c286e-ef06-46b0-bd37-1163008c4054
```

Get Notification
{{notification-api-url}}/v2/notifications/{{notification-id}}

```
{
    "id": "f26f2111-5ebf-4c62-8360-2764e5bb90a6",
    "status": "delivered",
    "status_reason": null,
}
```

### Pinpoint V2 feature disabled (existing SMS delivery not affected)

- Sent SMS via Pinpoint V1, delivered to device, delivery update processed

```
Returning provider: AWS Pinpoint, for notification b3c59373-3b64-4106-8f27-5c4333096c6c
```

```
Final pinpoint logic | reference: 4mhtlovsrpnao630hto9425dpcq3t7eltusi60g0 | notification_id: b3c59373-3b64-4106-8f27-5c4333096c6c | status: sending | status_reason: None | cost_in_millicents: 0.0 | service_id: d6aa2c68-a2d9-4437-ab19-3ae8eb202553 | template_id: c62c286e-ef06-46b0-bd37-1163008c4054
```

```
Final pinpoint logic | reference: 4mhtlovsrpnao630hto9425dpcq3t7eltusi60g0 | notification_id: b3c59373-3b64-4106-8f27-5c4333096c6c | status: delivered | status_reason: None | cost_in_millicents: 881.0 | service_id: d6aa2c68-a2d9-4437-ab19-3ae8eb202553 | template_id: c62c286e-ef06-46b0-bd37-1163008c4054
```

{
	"id": "b3c59373-3b64-4106-8f27-5c4333096c6c",
	"status": "delivered",
	"status_reason": null,
}


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
