### PR TITLE
#1099 - Allow VA Profile look up lambda to use old and new JWT certs

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -77,6 +77,8 @@ fileignoreconfig:
   checksum: f365a7336c5105df6c11a6f95e765fe5079d0c3c97907e059dea5556a62ff494
 - filename: app/va/va_profile/va_profile_client.py
   checksum: 5c867bf817283bf50f2d974697c1c08d80976f37b1a1a13d0ba2e029536e9b2c
+- filename: lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+  checksum: 9cdb7bf7610743d061cf653d4292be2a3966d428ae1234da56c8314e7699d096
 - filename: app/pii/pii_base.py
   checksum: 584cb03893d943c5f8504e5951128f17ce26cf9ffdfc51a29992d9e30e9a3d8b
 version: "1.0"

--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -71,17 +71,19 @@ if NOTIFY_ENVIRONMENT != 'test' and not os.path.isdir(CA_PATH):
     sys.exit('The VA CA certificate directory is missing.  Is the lambda layer in use?')
 
 if NOTIFY_ENVIRONMENT == 'test':
-    jwt_cert_path = 'tests/lambda_functions/va_profile/cert.pem'
+    jwt_cert_paths = ('tests/lambda_functions/va_profile/cert.pem',)
 elif NOTIFY_ENVIRONMENT == 'prod':
-    jwt_cert_path = '/opt/jwt/Profile_prod_public.pem'
+    jwt_cert_paths = ('/opt/jwt/Profile_prod_public.pem',)
 else:
-    jwt_cert_path = '/opt/jwt/Profile_2025_nonprod_public.pem'
+    jwt_cert_paths = ('/opt/jwt/Profile_nonprod_public.pem', '/opt/jwt/Profile_2025_nonprod_public.pem')
 
 # Load VA Profile's public certificate used to verify JWT signatures for POST requests.
 # In deployment environments, the certificate should be available via a lambda layer.
+va_profile_public_certs = []
 try:
-    with open(jwt_cert_path, 'rb') as f:
-        va_profile_public_cert = load_pem_x509_certificate(f.read()).public_key()
+    for cert_path in jwt_cert_paths:
+        with open(cert_path, 'rb') as f:
+            va_profile_public_certs.append(load_pem_x509_certificate(f.read()).public_key())
 except (OSError, ValueError) as e:
     logger.exception(e)
     sys.exit('The JWT public certificate is missing or invalid.  Cannot authenticate POST requests.')
@@ -225,7 +227,7 @@ def va_profile_opt_in_out_lambda_handler(  # noqa: C901
     logger.info('POST request received.')
     logger.debug('POST event: %s', event)
 
-    global va_profile_public_cert, integration_testing_public_cert
+    global integration_testing_public_cert
 
     headers = event.get('headers', {})
     is_integration_test = 'integration_test' in event.get('queryStringParameters', {})
@@ -241,7 +243,7 @@ def va_profile_opt_in_out_lambda_handler(  # noqa: C901
     # Authenticate the POST request by verifying the JWT signature.
     if not jwt_is_valid(
         headers.get('Authorization', headers.get('authorization', '')),
-        integration_testing_public_cert if is_integration_test else va_profile_public_cert,
+        [integration_testing_public_cert] if is_integration_test else va_profile_public_certs,
     ):
         logger.info('Authentication failed.  Returning 401.')
         return {'statusCode': 401}
@@ -444,13 +446,13 @@ def va_profile_opt_in_out_lambda_handler(  # noqa: C901
 
 def jwt_is_valid(
     auth_header_value: str,
-    public_key: Certificate,
+    public_keys: list[Certificate],
 ) -> bool:
     """
     The POST request should have sent an asymmetrically signed JWT.  Attempt to verify the signature.
     """
 
-    assert public_key
+    assert public_keys
     if not auth_header_value:
         return False
 
@@ -470,14 +472,17 @@ def jwt_is_valid(
         'require': ['exp', 'iat'],
         'verify_exp': 'verify_signature',
     }
-    try:
-        # This returns the claims as a dictionary, but we aren't using them.  Require the
-        # Issued at Time (iat) claim to ensure the JWT varies with each request.  Otherwise,
-        # an attacker could replay the static Bearer value.
-        jwt.decode(token, public_key, algorithms=['RS256'], options=options)
-        return True
-    except (jwt.exceptions.InvalidTokenError, TypeError):
-        logger.exception('Failed to validate key')
+    for i, public_key in enumerate(public_keys):
+        try:
+            # This returns the claims as a dictionary, but we aren't using them.  Require the
+            # Issued at Time (iat) claim to ensure the JWT varies with each request.  Otherwise,
+            # an attacker could replay the static Bearer value.
+            jwt.decode(token, public_key, algorithms=['RS256'], options=options)
+            # Blank if the key is less than 35 characters
+            logger.debug('Used key: %s', i)
+            return True
+        except (jwt.exceptions.InvalidTokenError, TypeError):
+            logger.exception('Failed to validate key: %s', i)
 
     return False
 

--- a/tests/lambda_functions/va_profile/test_va_profile_integration.py
+++ b/tests/lambda_functions/va_profile/test_va_profile_integration.py
@@ -286,7 +286,7 @@ def test_jwt_is_valid(jwt_encoded, public_key):
     Test the helper function used to determine if the JWT has a valid signature.
     """
 
-    assert jwt_is_valid(f'Bearer {jwt_encoded}', public_key)
+    assert jwt_is_valid(f'Bearer {jwt_encoded}', [public_key])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

issue [#1099 ](https://github.com/orgs/department-of-veterans-affairs/projects/1417/views/1?pane=issue&itemId=135025902&issue=department-of-veterans-affairs%7Cvanotify-infra%7C1099)

- Update JWT layer and VA_CA layer for va-profile-opt-in-out-lambda and bip-msg-mpi-lookup-lambda thru [Infra PR](https://github.com/department-of-veterans-affairs/vanotify-infra/pull/1102)
- Reverted changes from previous PR to support old and new JWT certs.

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

### Test `va-profile-opt-in-out-lambda` can use old cert
- Do not deploy new Infra changes
- [Notification-API deploy OK](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/18857152182)
- Confirm va-profile-opt-in-out-lambda working with old cert 
   <img width="995" height="299" alt="Screenshot 2025-10-27 at 4 12 57 PM" src="https://github.com/user-attachments/assets/ce08fb45-d23c-46c3-b452-9e9ce87b45f9" />

### Test `va-profile-opt-in-out-lambda` can use new cert 
- [Infra deploy OK](https://github.com/department-of-veterans-affairs/vanotify-infra/actions/runs/18865018099)
- [Notification-API deploy OK](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/18857152182)
- Confirm va-profile-opt-in-out-lambda working 
    <img width="928" height="335" alt="Screenshot 2025-10-27 at 10 56 13 PM" src="https://github.com/user-attachments/assets/c010a19a-bc0f-434e-a77e-13cf13206a4b" />

- Confirm lambda using newest lambda layers - JWT and VA_CAs
   <img width="655" height="199" alt="Screenshot 2025-10-27 at 11 31 35 PM" src="https://github.com/user-attachments/assets/abbfd255-0600-4626-b580-5233a1cf2607" />




### Test `big-msg-mpi-loopup-lambda` can use new cert
- [Infra deploy OK](https://github.com/department-of-veterans-affairs/vanotify-infra/actions/runs/18865018099)
- [Notification-API deploy OK](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/18857152182)
- Confirm bip-msg-mpi-lookup-lambda working 
     <img width="1007" height="179" alt="Screenshot 2025-10-27 at 10 57 11 PM" src="https://github.com/user-attachments/assets/dd0a9cfe-bca7-4b92-a42e-29f4d39f994d" />

- Confirm lambda using newest lambda layer 
    <img width="482" height="233" alt="Screenshot 2025-10-27 at 11 32 17 PM" src="https://github.com/user-attachments/assets/6c046475-4875-4d8b-83a2-6e5c2a1c6dd5" />



## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
