### PR TITLE
HOTFIX - Change Order of Cert Check to Remove False Errors

### DIFF
--- a/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
+++ b/lambda_functions/va_profile/va_profile_opt_in_out_lambda.py
@@ -74,8 +74,8 @@ if NOTIFY_ENVIRONMENT == 'test':
     jwt_cert_paths = ('tests/lambda_functions/va_profile/cert.pem',)
 elif NOTIFY_ENVIRONMENT == 'prod':
     jwt_cert_paths = (
-        '/opt/jwt/Profile_prod_public.pem',
         '/opt/jwt/Profile_prod_public_2026.pem',
+        '/opt/jwt/Profile_prod_public.pem',
     )
 else:
     jwt_cert_paths = (


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This pull request updates the order of the certificate paths used for JWT verification in the production environment of the `va_profile_opt_in_out_lambda.py` lambda function. The change ensures that the newer certificate (`Profile_prod_public_2026.pem`) is checked before the older one (`Profile_prod_public.pem`).

Certificate management:

* In the production environment block of `lambda_functions/va_profile/va_profile_opt_in_out_lambda.py`, the certificate path `/opt/jwt/Profile_prod_public_2026.pem` is now listed before `/opt/jwt/Profile_prod_public.pem` in the `jwt_cert_paths` tuple, ensuring the newer certificate is prioritized.

issue N/A

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- This change only affects prod and is simple changing the order in which the certificates are checked, so we no longer get an error when the lambda is called.


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change
