### PR TITLE
#2641 Re-enable Caching After VEText Number Migrations

### DIFF
--- a/app/dao/service_sms_sender_dao.py
+++ b/app/dao/service_sms_sender_dao.py
@@ -1,4 +1,4 @@
-from cachetools import TTLCache
+from cachetools import TTLCache, cached
 from datetime import datetime, timedelta
 from uuid import UUID
 
@@ -29,8 +29,7 @@ def insert_service_sms_sender(
     db.session.add(new_sms_sender)
 
 
-# TODO: 2641 Re-enable caching after phone number migration is complete
-# @cached(sms_sender_data_cache)
+@cached(sms_sender_data_cache)
 def dao_get_service_sms_sender_by_id(
     service_id: str,
     service_sms_sender_id: str,
@@ -59,8 +58,7 @@ def dao_get_service_sms_sender_by_id(
     )
 
 
-# TODO: 2641 Re-enable caching after phone number migration is complete
-# @cached(sms_sender_data_cache)
+@cached(sms_sender_data_cache)
 def dao_get_sms_senders_data_by_service_id(service_id: str) -> list[ServiceSmsSenderData]:
     """Return a cached list of ServiceSmsSenderData objects for a given service_id."""
     stmt = (
@@ -100,8 +98,7 @@ def dao_get_sms_senders_by_service_id(service_id: str) -> list[ServiceSmsSender]
     return db.session.scalars(stmt).all()
 
 
-# TODO: 2641 Re-enable caching after phone number migration is complete
-# @cached(sms_sender_data_cache)
+@cached(sms_sender_data_cache)
 def dao_get_service_sms_sender_by_service_id_and_number(
     service_id: str,
     number: str,
@@ -346,8 +343,7 @@ def _allocate_inbound_number_for_service(
     return db.session.get(InboundNumber, inbound_number_id)
 
 
-# TODO: 2641 Re-enable caching after phone number migration is complete
-# @cached(sms_sender_data_cache)
+@cached(sms_sender_data_cache)
 def dao_get_default_service_sms_sender_by_service_id(service_id: str) -> ServiceSmsSenderData | None:
     """Return the default ServiceSmsSenderData for a given service_id, or None if not found."""
     stmt = select(ServiceSmsSender).where(

--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -3,7 +3,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 
-from cachetools import TTLCache
+from cachetools import TTLCache, cached
 from sqlalchemy import asc, desc, func, select, update
 
 from app import db
@@ -255,8 +255,7 @@ def dao_get_template_by_id_and_service_id_without_cache(
     return db.session.scalars(stmt).one()
 
 
-# TODO: 2641 Re-enable caching after phone number migration is complete
-# @cached(cache=template_cache)
+@cached(cache=template_cache)
 def dao_get_template_data_by_id_and_service_id(
     template_id: uuid.UUID,
     service_id: uuid.UUID,
@@ -308,8 +307,7 @@ def dao_get_number_of_templates_by_service_id_and_name(
     return db.session.scalar(stmt)
 
 
-# TODO: 2641 Re-enable caching after phone number migration is complete
-# @cached(cache=TTLCache(maxsize=1024, ttl=600))
+@cached(cache=TTLCache(maxsize=1024, ttl=600))
 def dao_get_template_history_by_id(template_id: str, version: str) -> TemplateHistoryData | None:
     stmt = select(TemplateHistory).where(TemplateHistory.id == template_id, TemplateHistory.version == version)
     template_history_object = db.session.scalars(stmt).first()

--- a/tests/app/dao/test_service_sms_sender_dao.py
+++ b/tests/app/dao/test_service_sms_sender_dao.py
@@ -585,8 +585,6 @@ def test_validate_rate_limit(rate_limit, rate_limit_interval, raises_exception) 
         assert _validate_rate_limit(sms_sender, rate_limit, rate_limit_interval) is None
 
 
-# TODO: 2641 Re-enable caching after phone number migration is complete
-@pytest.mark.skip(reason='Caching temporarily disabled')
 class TestSmsSenderCache:
     def test_get_service_sms_sender_by_id_cache(self, mocker, notify_db_session, sample_service, sample_sms_sender):
         service = sample_service()

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -999,8 +999,6 @@ class TestDAOGetTemplateById:
 
         assert result is None
 
-    # TODO: 2641 Re-enable caching after phone number migration is complete
-    @pytest.mark.skip(reason='Caching temporarily disabled')
     def test_dao_get_template_by_id_caching_behavior(
         self,
         notify_db_session: SQLAlchemy,


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Caching was disabled to allow for smother transitions to the new phone numbers and number pools when making the changes necessary for migrating VEText numbers. This PR reverts these changes.

issue [#2641](https://github.com/department-of-veterans-affairs/notification-api/issues/2641)

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->
- [x] Ran test suite locally
- [x] Deployed to DEV, regressions passed ([here](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/20727294725))
- [x] Tested in DEV w/ and w/o caching, see screenshots below:

**Before (main deployed, no caching):**
see datadog [here](https://vanotify.ddog-gov.com/apm/resource/postgres/postgres.query/bbbbf23ffbabd6c?query=env%3Adev%20operation_name%3Apostgres.query%20resource_name%3A%22SELECT%20service_sms_senders.id%2C%20service_sms_senders.archived%2C%20service_sms_senders.created_at%2C%20service_sms_senders.description%2C%20service_sms_senders.inbound_number_id%2C%20service_sms_senders.is_default%2C%20service_sms_senders.provider_id%2C%20service_sms_senders.rate_limit%2C%20service_sms_senders.rate_limit_interval%2C%20service_sms_senders.service_id%2C%20service_sms_senders.sms_sender%2C%20service_sms_senders.sms_sender_specifics%2C%20service_sms_senders.updated_at%20FROM%20service_sms_senders%20WHERE%20service_sms_senders.id%20%3D%20%3F%20AND%20service_sms_senders.service_id%20%3D%20%3F%20AND%20service_sms_senders.archived%20IS%20%3F%22%20service%3Apostgres&env=dev&fromUser=false&primaryTags=task_version%3A%2A&start=1767647190036&end=1767648090036&paused=true)

<img width="2619" height="1024" alt="image" src="https://github.com/user-attachments/assets/467cb5c5-f5a6-453d-89e2-429e6f9d10c5" />



 **After (PR deployed, caching enabled):**
see datadog [here](https://vanotify.ddog-gov.com/apm/resource/postgres/postgres.query/bbbbf23ffbabd6c?query=env%3Adev%20operation_name%3Apostgres.query%20resource_name%3A%22SELECT%20service_sms_senders.id%2C%20service_sms_senders.archived%2C%20service_sms_senders.created_at%2C%20service_sms_senders.description%2C%20service_sms_senders.inbound_number_id%2C%20service_sms_senders.is_default%2C%20service_sms_senders.provider_id%2C%20service_sms_senders.rate_limit%2C%20service_sms_senders.rate_limit_interval%2C%20service_sms_senders.service_id%2C%20service_sms_senders.sms_sender%2C%20service_sms_senders.sms_sender_specifics%2C%20service_sms_senders.updated_at%20FROM%20service_sms_senders%20WHERE%20service_sms_senders.id%20%3D%20%3F%20AND%20service_sms_senders.service_id%20%3D%20%3F%20AND%20service_sms_senders.archived%20IS%20%3F%22%20service%3Apostgres&env=dev&fromUser=false&primaryTags=task_version%3A%2A&start=1767649440925&end=1767650340925&paused=true)

<img width="2792" height="1401" alt="image" src="https://github.com/user-attachments/assets/d0115e17-019c-476f-9624-0001aad292d7" />



## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
