### PR TITLE
#2549-V2: Tracking Notification Retries and Updates - DB Update

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1242,7 +1242,7 @@ class Notification(db.Model):
     sent_by = db.Column(db.String, nullable=True)
     updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)
     provider_updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
-    retry_count = db.Column(db.Integer, nullable=False, default=0)
+    retry_count = db.Column(db.Integer, nullable=True)
     status = db.Column(
         'notification_status',
         db.String,
@@ -1600,7 +1600,7 @@ class NotificationHistory(db.Model, HistoryModel):
     sent_by = db.Column(db.String, nullable=True)
     updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True, onupdate=datetime.datetime.utcnow)
     provider_updated_at = db.Column(db.DateTime, index=False, unique=False, nullable=True)
-    retry_count = db.Column(db.Integer, nullable=False, default=0)
+    retry_count = db.Column(db.Integer, nullable=True)
     status = db.Column(
         'notification_status',
         db.String,

--- a/migrations/versions/0381_add_retry_fields.py
+++ b/migrations/versions/0381_add_retry_fields.py
@@ -17,12 +17,6 @@ def upgrade():
     op.add_column('notification_history', sa.Column('retry_count', sa.Integer(), nullable=True))
     op.add_column('notification_history', sa.Column('provider_updated_at', sa.DateTime(), nullable=True))
 
-    op.execute('UPDATE notifications SET retry_count = 0')
-    op.execute('UPDATE notification_history SET retry_count = 0')
-
-    op.alter_column('notifications', 'retry_count', nullable=False, server_default='0')
-    op.alter_column('notification_history', 'retry_count', nullable=False, server_default='0')
-
 
 def downgrade():
     op.drop_column('notification_history', 'provider_updated_at')


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This is related to PR #2666. Originally I set the `retry_count` field non-null to restrict optionality and reduce complexity inside the app.. The problem with this was that there are hundreds of millions of records (at least) that needed to be updated in this table in prod, so the migration timed out.

This PR is to rollback this migration, and allow the `retry_count` field to be nullable.

TODOs
- [x] Check timing in perf migration (1m 13s) against timing from the failed [Continuous Deployment Pipeline](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/20827595146/job/59851910206) (4m 16s)
- [x] Double check that `napi` connects to the read prod db, and `napi-write` connects to the write prod db
- [x] Downgrade staging
- [x] Redeploy to dev, validate re-upgrade


issue #2549

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- [x] Local validation (up/down migration, confirm `retry_count` is nullable)
- [x] verify both the read and write prod db instances to check the status of the migration
  - The `provider_updated_at` and `retry_count` columns do not exist.
  - The current alembic version is `0380_add_service_allow_fallback`
- [x] testing in perf (downgrade migration, re-upgrade, check timings)
- [x] Validate downgrade in staging
- [x] Validate re-upgrade in dev

## Local validation

### Validated migration up/down (locally)
```
~/Projects/notification-api 2549-v2-Tracking-Notification-Retries-and-Updates* 20s
❯ docker compose -f ci/docker-compose-local.yml run --rm migrations flask db current
[+] Running 1/1
 ✔ Container ci-db-1  Started                                                                                                                    0.1s 
Writing SSL certificate and key to files
{"asctime": "2026-01-09T17:24:19", "application": "notification-api", "levelname": "INFO", "requestId": "no-request-id", "message": "Logging configured. The log level has been set to 10", "pathname": "/.venv/lib/python3.10/site-packages/notifications_utils/logging.py", "lineno": 102}
{"asctime": "2026-01-09T17:24:19", "application": "notification-api", "levelname": "INFO", "requestId": "no-request-id", "message": "Initializing MobileAppRegistry", "pathname": "/app/app/mobile_app/mobile_app_registry.py", "lineno": 10}
0381_add_retry_fields (head)

~/Projects/notification-api 2549-v2-Tracking-Notification-Retries-and-Updates*
❯ docker compose -f ci/docker-compose-local.yml run --rm migrations flask db downgrade -- -1
[+] Creating 1/1
 ✔ Container ci-db-1  Running                                                                                                                    0.0s 
Writing SSL certificate and key to files
{"asctime": "2026-01-09T17:24:33", "application": "notification-api", "levelname": "INFO", "requestId": "no-request-id", "message": "Logging configured. The log level has been set to 10", "pathname": "/.venv/lib/python3.10/site-packages/notifications_utils/logging.py", "lineno": 102}
{"asctime": "2026-01-09T17:24:33", "application": "notification-api", "levelname": "INFO", "requestId": "no-request-id", "message": "Initializing MobileAppRegistry", "pathname": "/app/app/mobile_app/mobile_app_registry.py", "lineno": 10}

~/Projects/notification-api 2549-v2-Tracking-Notification-Retries-and-Updates*
❯ docker compose -f ci/docker-compose-local.yml run --rm migrations flask db current
[+] Creating 1/1
 ✔ Container ci-db-1  Running                                                                                                                    0.0s 
Writing SSL certificate and key to files
{"asctime": "2026-01-09T17:24:52", "application": "notification-api", "levelname": "INFO", "requestId": "no-request-id", "message": "Logging configured. The log level has been set to 10", "pathname": "/.venv/lib/python3.10/site-packages/notifications_utils/logging.py", "lineno": 102}
{"asctime": "2026-01-09T17:24:52", "application": "notification-api", "levelname": "INFO", "requestId": "no-request-id", "message": "Initializing MobileAppRegistry", "pathname": "/app/app/mobile_app/mobile_app_registry.py", "lineno": 10}
0380_add_service_allow_fallback

~/Projects/notification-api 2549-v2-Tracking-Notification-Retries-and-Updates*
❯ docker compose -f ci/docker-compose-local.yml run --rm migrations flask db upgrade
[+] Creating 1/1
 ✔ Container ci-db-1  Running                                                                                                                    0.0s 
Writing SSL certificate and key to files
{"asctime": "2026-01-09T17:25:16", "application": "notification-api", "levelname": "INFO", "requestId": "no-request-id", "message": "Logging configured. The log level has been set to 10", "pathname": "/.venv/lib/python3.10/site-packages/notifications_utils/logging.py", "lineno": 102}
{"asctime": "2026-01-09T17:25:16", "application": "notification-api", "levelname": "INFO", "requestId": "no-request-id", "message": "Initializing MobileAppRegistry", "pathname": "/app/app/mobile_app/mobile_app_registry.py", "lineno": 10}

~/Projects/notification-api 2549-v2-Tracking-Notification-Retries-and-Updates*
❯ docker compose -f ci/docker-compose-local.yml run --rm migrations flask db current
[+] Creating 1/1
 ✔ Container ci-db-1  Running                                                                                                                    0.0s 
Writing SSL certificate and key to files
{"asctime": "2026-01-09T17:25:21", "application": "notification-api", "levelname": "INFO", "requestId": "no-request-id", "message": "Logging configured. The log level has been set to 10", "pathname": "/.venv/lib/python3.10/site-packages/notifications_utils/logging.py", "lineno": 102}
{"asctime": "2026-01-09T17:25:22", "application": "notification-api", "levelname": "INFO", "requestId": "no-request-id", "message": "Initializing MobileAppRegistry", "pathname": "/app/app/mobile_app/mobile_app_registry.py", "lineno": 10}
0381_add_retry_fields (head)
```

### Validate `retry_count` is now nullable on both tables (locally)
<img width="2136" height="465" alt="image" src="https://github.com/user-attachments/assets/d8e3584e-0a55-4a88-b67e-32ee6ba4b369" />
<img width="2367" height="458" alt="image" src="https://github.com/user-attachments/assets/5ea744c5-861d-456c-986b-29f846c2e394" />

## Prod inspection

### Prod - napi inspection
```
notification_api=> SELECT version_num FROM alembic_version;
           version_num
---------------------------------
 0380_add_service_allow_fallback
(1 row)

notification_api=> \d notifications
                                   Table "public.notifications"
       Column        |            Type             | Collation | Nullable |        Default
---------------------+-----------------------------+-----------+----------+-----------------------
 id                  | uuid                        |           | not null |
 to                  | character varying           |           |          |
 job_id              | uuid                        |           |          |
 service_id          | uuid                        |           |          |
 template_id         | uuid                        |           |          |
 created_at          | timestamp without time zone |           | not null |
 sent_at             | timestamp without time zone |           |          |
 sent_by             | character varying           |           |          |
 updated_at          | timestamp without time zone |           |          |
 reference           | character varying           |           |          |
 template_version    | integer                     |           | not null |
 job_row_number      | integer                     |           |          |
 _personalisation    | character varying           |           |          |
 api_key_id          | uuid                        |           |          |
 key_type            | character varying(255)      |           | not null |
 notification_type   | notification_type           |           | not null |
 billable_units      | integer                     |           | not null |
 client_reference    | character varying           |           |          |
 international       | boolean                     |           |          |
 phone_prefix        | character varying           |           |          |
 rate_multiplier     | numeric                     |           |          |
 notification_status | text                        |           |          |
 normalised_to       | character varying           |           |          |
 created_by_id       | uuid                        |           |          |
 reply_to_text       | character varying           |           |          |
 postage             | character varying           |           |          |
 status_reason       | character varying           |           |          |
 billing_code        | character varying(256)      |           |          |
 sms_sender_id       | uuid                        |           |          |
 segments_count      | integer                     |           | not null | 0
 cost_in_millicents  | double precision            |           | not null | '0'::double precision
 callback_url        | character varying(255)      |           |          |
 
 notification_api=> \d notification_history
                               Table "public.notification_history"
       Column        |            Type             | Collation | Nullable |        Default
---------------------+-----------------------------+-----------+----------+-----------------------
 id                  | uuid                        |           | not null |
 job_id              | uuid                        |           |          |
 job_row_number      | integer                     |           |          |
 service_id          | uuid                        |           |          |
 template_id         | uuid                        |           |          |
 template_version    | integer                     |           | not null |
 api_key_id          | uuid                        |           |          |
 key_type            | character varying           |           | not null |
 notification_type   | notification_type           |           | not null |
 created_at          | timestamp without time zone |           | not null |
 sent_at             | timestamp without time zone |           |          |
 sent_by             | character varying           |           |          |
 updated_at          | timestamp without time zone |           |          |
 reference           | character varying           |           |          |
 billable_units      | integer                     |           | not null |
 client_reference    | character varying           |           |          |
 international       | boolean                     |           |          |
 phone_prefix        | character varying           |           |          |
 rate_multiplier     | numeric                     |           |          |
 notification_status | text                        |           |          |
 created_by_id       | uuid                        |           |          |
 postage             | character varying           |           |          |
 status_reason       | character varying           |           |          |
 billing_code        | character varying(256)      |           |          |
 sms_sender_id       | uuid                        |           |          |
 segments_count      | integer                     |           | not null | 0
 cost_in_millicents  | double precision            |           | not null | '0'::double precision
```

### Prod - napi-write inspection

```
notification_api=> SELECT version_num FROM alembic_version;
           version_num
---------------------------------
 0380_add_service_allow_fallback
 
 notification_api=> \d notifications
                                   Table "public.notifications"
       Column        |            Type             | Collation | Nullable |        Default
---------------------+-----------------------------+-----------+----------+-----------------------
 id                  | uuid                        |           | not null |
 to                  | character varying           |           |          |
 job_id              | uuid                        |           |          |
 service_id          | uuid                        |           |          |
 template_id         | uuid                        |           |          |
 created_at          | timestamp without time zone |           | not null |
 sent_at             | timestamp without time zone |           |          |
 sent_by             | character varying           |           |          |
 updated_at          | timestamp without time zone |           |          |
 reference           | character varying           |           |          |
 template_version    | integer                     |           | not null |
 job_row_number      | integer                     |           |          |
 _personalisation    | character varying           |           |          |
 api_key_id          | uuid                        |           |          |
 key_type            | character varying(255)      |           | not null |
 notification_type   | notification_type           |           | not null |
 billable_units      | integer                     |           | not null |
 client_reference    | character varying           |           |          |
 international       | boolean                     |           |          |
 phone_prefix        | character varying           |           |          |
 rate_multiplier     | numeric                     |           |          |
 notification_status | text                        |           |          |
 normalised_to       | character varying           |           |          |
 created_by_id       | uuid                        |           |          |
 reply_to_text       | character varying           |           |          |
 postage             | character varying           |           |          |
 status_reason       | character varying           |           |          |
 billing_code        | character varying(256)      |           |          |
 sms_sender_id       | uuid                        |           |          |
 segments_count      | integer                     |           | not null | 0
 cost_in_millicents  | double precision            |           | not null | '0'::double precision
 callback_url        | character varying(255)      |           |          |
 
 notification_api=> \d notification_history
                               Table "public.notification_history"
       Column        |            Type             | Collation | Nullable |        Default
---------------------+-----------------------------+-----------+----------+-----------------------
 id                  | uuid                        |           | not null |
 job_id              | uuid                        |           |          |
 job_row_number      | integer                     |           |          |
 service_id          | uuid                        |           |          |
 template_id         | uuid                        |           |          |
 template_version    | integer                     |           | not null |
 api_key_id          | uuid                        |           |          |
 key_type            | character varying           |           | not null |
 notification_type   | notification_type           |           | not null |
 created_at          | timestamp without time zone |           | not null |
 sent_at             | timestamp without time zone |           |          |
 sent_by             | character varying           |           |          |
 updated_at          | timestamp without time zone |           |          |
 reference           | character varying           |           |          |
 billable_units      | integer                     |           | not null |
 client_reference    | character varying           |           |          |
 international       | boolean                     |           |          |
 phone_prefix        | character varying           |           |          |
 rate_multiplier     | numeric                     |           |          |
 notification_status | text                        |           |          |
 created_by_id       | uuid                        |           |          |
 postage             | character varying           |           |          |
 status_reason       | character varying           |           |          |
 billing_code        | character varying(256)      |           |          |
 sms_sender_id       | uuid                        |           |          |
 segments_count      | integer                     |           | not null | 0
 cost_in_millicents  | double precision            |           | not null | '0'::double precision
```

## Perf testing

### perf-napi inspection (before downgrade)

Fields exist and retry_count is non-nullable, as expected.

```
notification_api=> SELECT version_num FROM alembic_version;
      version_num
-----------------------
 0381_add_retry_fields
(1 row)

notification_api=> \d notifications
                                   Table "public.notifications"
       Column        |            Type             | Collation | Nullable |        Default
---------------------+-----------------------------+-----------+----------+-----------------------
 id                  | uuid                        |           | not null |
 ...
 retry_count         | integer                     |           | not null | 0
 provider_updated_at | timestamp without time zone |           |          |


notification_api=> \d notification_history
                               Table "public.notification_history"
       Column        |            Type             | Collation | Nullable |        Default
---------------------+-----------------------------+-----------+----------+-----------------------
 id                  | uuid                        |           | not null |
 ...
 retry_count         | integer                     |           | not null | 0
 provider_updated_at | timestamp without time zone |           |          |
```

### perf-napi inspection (after downgrade)

Fields no longer exist. We also counted the rows before and after this downgrade to confirm there were exactly 2 less rows.

```
notification_api=> SELECT version_num FROM alembic_version;
           version_num
---------------------------------
 0380_add_service_allow_fallback
(1 row)

notification_api=> \d notifications
                                   Table "public.notifications"
       Column        |            Type             | Collation | Nullable |        Default
---------------------+-----------------------------+-----------+----------+-----------------------
 id                  | uuid                        |           | not null |
 to                  | character varying           |           |          |
 job_id              | uuid                        |           |          |
 service_id          | uuid                        |           |          |
 template_id         | uuid                        |           |          |
 created_at          | timestamp without time zone |           | not null |
 sent_at             | timestamp without time zone |           |          |
 sent_by             | character varying           |           |          |
 updated_at          | timestamp without time zone |           |          |
 reference           | character varying           |           |          |
 template_version    | integer                     |           | not null |
 job_row_number      | integer                     |           |          |
 _personalisation    | character varying           |           |          |
 api_key_id          | uuid                        |           |          |
 key_type            | character varying(255)      |           | not null |
 notification_type   | notification_type           |           | not null |
 billable_units      | integer                     |           | not null |
 client_reference    | character varying           |           |          |
 international       | boolean                     |           |          |
 phone_prefix        | character varying           |           |          |
 rate_multiplier     | numeric                     |           |          |
 notification_status | text                        |           |          |
 normalised_to       | character varying           |           |          |
 created_by_id       | uuid                        |           |          |
 reply_to_text       | character varying           |           |          |
 postage             | character varying           |           |          |
 status_reason       | character varying           |           |          |
 billing_code        | character varying(256)      |           |          |
 sms_sender_id       | uuid                        |           |          |
 segments_count      | integer                     |           | not null | 0
 cost_in_millicents  | double precision            |           | not null | '0'::double precision
 callback_url        | character varying(255)      |           |          |
Indexes:
    "notifications_pkey" PRIMARY KEY, btree (id)
    "ix_notifications_api_key_id" btree (api_key_id)
    "ix_notifications_client_reference" btree (client_reference)
    "ix_notifications_created_at" btree (created_at)
    "ix_notifications_job_id" btree (job_id)
    "ix_notifications_key_type" btree (key_type)
    "ix_notifications_notification_status" btree (notification_status)
    "ix_notifications_notification_type" btree (notification_type)
    "ix_notifications_reference" btree (reference)
    "ix_notifications_service_created_at" btree (service_id, created_at)
notification_api=> \d notification_history
                               Table "public.notification_history"
       Column        |            Type             | Collation | Nullable |        Default
---------------------+-----------------------------+-----------+----------+-----------------------
 id                  | uuid                        |           | not null |
 job_id              | uuid                        |           |          |
 job_row_number      | integer                     |           |          |
 service_id          | uuid                        |           |          |
 template_id         | uuid                        |           |          |
 template_version    | integer                     |           | not null |
 api_key_id          | uuid                        |           |          |
 key_type            | character varying           |           | not null |
 notification_type   | notification_type           |           | not null |
 created_at          | timestamp without time zone |           | not null |
 sent_at             | timestamp without time zone |           |          |
 sent_by             | character varying           |           |          |
 updated_at          | timestamp without time zone |           |          |
 reference           | character varying           |           |          |
 billable_units      | integer                     |           | not null |
 client_reference    | character varying           |           |          |
 international       | boolean                     |           |          |
 phone_prefix        | character varying           |           |          |
 rate_multiplier     | numeric                     |           |          |
 notification_status | text                        |           |          |
 created_by_id       | uuid                        |           |          |
 postage             | character varying           |           |          |
 status_reason       | character varying           |           |          |
 billing_code        | character varying(256)      |           |          |
 sms_sender_id       | uuid                        |           |          |
 segments_count      | integer                     |           | not null | 0
 cost_in_millicents  | double precision            |           | not null | '0'::double precision
```

### perf-napi inspection (after upgrade)

See below, confirmed the new fields (1) exist, and (2) are nullable.

```
notification_api=> SELECT version_num FROM alembic_version;
      version_num
-----------------------
 0381_add_retry_fields
(1 row)

notification_api=> \d notifications
                                   Table "public.notifications"
       Column        |            Type             | Collation | Nullable |        Default
---------------------+-----------------------------+-----------+----------+-----------------------
 id                  | uuid                        |           | not null |
 ...
 retry_count         | integer                     |           |          |
 provider_updated_at | timestamp without time zone |           |          |

notification_api=> \d notification_history
                               Table "public.notification_history"
       Column        |            Type             | Collation | Nullable |        Default
---------------------+-----------------------------+-----------+----------+-----------------------
 id                  | uuid                        |           | not null |
 ...
 retry_count         | integer                     |           |          |
 provider_updated_at | timestamp without time zone |           |          |
```

### perf migration timing results
Perf migration timing in failed deployment run, before changes...
<img width="3222" height="1364" alt="image" src="https://github.com/user-attachments/assets/b66c6114-9dc6-4ee0-a8e0-b7262088ea9e" />

Vs.. Perf migration timing with changes..
<img width="3221" height="1429" alt="image" src="https://github.com/user-attachments/assets/36f96f94-c134-4598-8dfc-fb591ea5dfbc" />

## Staging Downgrade

### staging inspection (after downgrade)

Fields no longer exist

```
notification_api=> SELECT version_num FROM alembic_version;
           version_num
---------------------------------
 0380_add_service_allow_fallback
(1 row)

notification_api=> \d notifications
                                   Table "public.notifications"
       Column        |            Type             | Collation | Nullable |        Default
---------------------+-----------------------------+-----------+----------+-----------------------
 id                  | uuid                        |           | not null |
 to                  | character varying           |           |          |
 job_id              | uuid                        |           |          |
 service_id          | uuid                        |           |          |
 template_id         | uuid                        |           |          |
 created_at          | timestamp without time zone |           | not null |
 sent_at             | timestamp without time zone |           |          |
 sent_by             | character varying           |           |          |
 updated_at          | timestamp without time zone |           |          |
 reference           | character varying           |           |          |
 template_version    | integer                     |           | not null |
 job_row_number      | integer                     |           |          |
 _personalisation    | character varying           |           |          |
 api_key_id          | uuid                        |           |          |
 key_type            | character varying(255)      |           | not null |
 notification_type   | notification_type           |           | not null |
 billable_units      | integer                     |           | not null |
 client_reference    | character varying           |           |          |
 international       | boolean                     |           |          |
 phone_prefix        | character varying           |           |          |
 rate_multiplier     | numeric                     |           |          |
 notification_status | text                        |           |          |
 normalised_to       | character varying           |           |          |
 created_by_id       | uuid                        |           |          |
 reply_to_text       | character varying           |           |          |
 postage             | character varying           |           |          |
 status_reason       | character varying           |           |          |
 billing_code        | character varying(256)      |           |          |
 sms_sender_id       | uuid                        |           |          |
 segments_count      | integer                     |           | not null | 0
 cost_in_millicents  | double precision            |           | not null | '0'::double precision
 callback_url        | character varying(255)      |           |          |

notification_api=> \d notification_history
                               Table "public.notification_history"
       Column        |            Type             | Collation | Nullable |        Default
---------------------+-----------------------------+-----------+----------+-----------------------
 id                  | uuid                        |           | not null |
 job_id              | uuid                        |           |          |
 job_row_number      | integer                     |           |          |
 service_id          | uuid                        |           |          |
 template_id         | uuid                        |           |          |
 template_version    | integer                     |           | not null |
 api_key_id          | uuid                        |           |          |
 key_type            | character varying           |           | not null |
 notification_type   | notification_type           |           | not null |
 created_at          | timestamp without time zone |           | not null |
 sent_at             | timestamp without time zone |           |          |
 sent_by             | character varying           |           |          |
 updated_at          | timestamp without time zone |           |          |
 reference           | character varying           |           |          |
 billable_units      | integer                     |           | not null |
 client_reference    | character varying           |           |          |
 international       | boolean                     |           |          |
 phone_prefix        | character varying           |           |          |
 rate_multiplier     | numeric                     |           |          |
 notification_status | text                        |           |          |
 created_by_id       | uuid                        |           |          |
 postage             | character varying           |           |          |
 status_reason       | character varying           |           |          |
 billing_code        | character varying(256)      |           |          |
 sms_sender_id       | uuid                        |           |          |
 segments_count      | integer                     |           | not null | 0
 cost_in_millicents  | double precision            |           | not null | '0'::double precision
```
 
## Validate Re-Upgrade in dev

Fields exist and are nullable
```
notification_api=> SELECT version_num FROM alembic_version;
      version_num
-----------------------
 0381_add_retry_fields
(1 row)

notification_api=> \d notifications
                                   Table "public.notifications"
       Column        |            Type             | Collation | Nullable |        Default
---------------------+-----------------------------+-----------+----------+-----------------------
 id                  | uuid                        |           | not null |
 ...
 retry_count         | integer                     |           |          |
 provider_updated_at | timestamp without time zone |           |          |

notification_api=> \d notification_history
                               Table "public.notification_history"
       Column        |            Type             | Collation | Nullable |        Default
---------------------+-----------------------------+-----------+----------+-----------------------
 id                  | uuid                        |           | not null |
 ...
 retry_count         | integer                     |           |          |
 provider_updated_at | timestamp without time zone |           |          |
```

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
