### PR TITLE
HOTFIX - Turn Off notification-api APM

### DIFF
--- a/cd/application-deployment/dev/vaec-api-task-definition.json
+++ b/cd/application-deployment/dev/vaec-api-task-definition.json
@@ -148,7 +148,7 @@
       "environment": [
         {
           "name": "DD_APM_NON_LOCAL_TRAFFIC",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_ENABLED",
@@ -172,7 +172,7 @@
         },
         {
           "name": "DD_APM_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_ENV",

--- a/cd/application-deployment/dev/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/dev/vaec-celery-beat-task-definition.json
@@ -122,7 +122,7 @@
       "environment": [
         {
           "name": "DD_APM_NON_LOCAL_TRAFFIC",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_ENABLED",
@@ -146,7 +146,7 @@
         },
         {
           "name": "DD_APM_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_ENV",

--- a/cd/application-deployment/dev/vaec-celery-task-definition.json
+++ b/cd/application-deployment/dev/vaec-celery-task-definition.json
@@ -156,7 +156,7 @@
       "environment": [
         {
           "name": "DD_APM_NON_LOCAL_TRAFFIC",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_ENABLED",
@@ -180,7 +180,7 @@
         },
         {
           "name": "DD_APM_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_ENV",

--- a/cd/application-deployment/perf/vaec-api-task-definition.json
+++ b/cd/application-deployment/perf/vaec-api-task-definition.json
@@ -131,7 +131,7 @@
       "environment": [
         {
           "name": "DD_APM_NON_LOCAL_TRAFFIC",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_ENABLED",
@@ -155,7 +155,7 @@
         },
         {
           "name": "DD_APM_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_ENV",

--- a/cd/application-deployment/perf/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-beat-task-definition.json
@@ -214,7 +214,7 @@
       "environment": [
         {
           "name": "DD_APM_NON_LOCAL_TRAFFIC",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_ENABLED",
@@ -238,7 +238,7 @@
         },
         {
           "name": "DD_APM_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_ENV",

--- a/cd/application-deployment/perf/vaec-celery-task-definition.json
+++ b/cd/application-deployment/perf/vaec-celery-task-definition.json
@@ -156,7 +156,7 @@
       "environment": [
         {
           "name": "DD_APM_NON_LOCAL_TRAFFIC",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_ENABLED",
@@ -180,7 +180,7 @@
         },
         {
           "name": "DD_APM_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_ENV",

--- a/cd/application-deployment/prod/vaec-api-task-definition.json
+++ b/cd/application-deployment/prod/vaec-api-task-definition.json
@@ -139,7 +139,7 @@
       "environment": [
         {
           "name": "DD_APM_NON_LOCAL_TRAFFIC",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_ENABLED",
@@ -163,7 +163,7 @@
         },
         {
           "name": "DD_APM_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_ENV",

--- a/cd/application-deployment/prod/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/prod/vaec-celery-beat-task-definition.json
@@ -130,7 +130,7 @@
       "environment": [
         {
           "name": "DD_APM_NON_LOCAL_TRAFFIC",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_ENABLED",
@@ -154,7 +154,7 @@
         },
         {
           "name": "DD_APM_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_ENV",

--- a/cd/application-deployment/prod/vaec-celery-task-definition.json
+++ b/cd/application-deployment/prod/vaec-celery-task-definition.json
@@ -23,7 +23,8 @@
         }
       ],
       "environment": [
-        { "name": "CELERY_CONCURRENCY", 
+        {
+          "name": "CELERY_CONCURRENCY",
           "value": "8"
         },
         {
@@ -107,7 +108,7 @@
         {
           "name": "VA_PROFILE_TOKEN",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/va-profile/auth-token"
-        }, 
+        },
         {
           "name": "VETEXT_USERNAME",
           "valueFrom": "arn:aws-us-gov:ssm:us-gov-west-1:171875617347:parameter/prod/notification-api/vetext/user"
@@ -164,7 +165,7 @@
       "environment": [
         {
           "name": "DD_APM_NON_LOCAL_TRAFFIC",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_ENABLED",
@@ -188,7 +189,7 @@
         },
         {
           "name": "DD_APM_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_ENV",

--- a/cd/application-deployment/staging/vaec-api-task-definition.json
+++ b/cd/application-deployment/staging/vaec-api-task-definition.json
@@ -139,7 +139,7 @@
       "environment": [
         {
           "name": "DD_APM_NON_LOCAL_TRAFFIC",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_ENABLED",
@@ -163,7 +163,7 @@
         },
         {
           "name": "DD_APM_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_ENV",

--- a/cd/application-deployment/staging/vaec-celery-beat-task-definition.json
+++ b/cd/application-deployment/staging/vaec-celery-beat-task-definition.json
@@ -130,7 +130,7 @@
       "environment": [
         {
           "name": "DD_APM_NON_LOCAL_TRAFFIC",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_ENABLED",
@@ -154,7 +154,7 @@
         },
         {
           "name": "DD_APM_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_ENV",

--- a/cd/application-deployment/staging/vaec-celery-task-definition.json
+++ b/cd/application-deployment/staging/vaec-celery-task-definition.json
@@ -164,7 +164,7 @@
       "environment": [
         {
           "name": "DD_APM_NON_LOCAL_TRAFFIC",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_LOGS_ENABLED",
@@ -188,7 +188,7 @@
         },
         {
           "name": "DD_APM_ENABLED",
-          "value": "true"
+          "value": "false"
         },
         {
           "name": "DD_ENV",


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This pull request updates the Datadog APM (Application Performance Monitoring) settings across all ECS task definitions for the `vaec-api`, `vaec-celery`, and `vaec-celery-beat` services in every environment (dev, perf, prod, and staging). The main change is that APM is now disabled by setting the relevant environment variables to `"false"` instead of `"true"`. 

issue N/A

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

Deployed to dev and production. APM is no longer available.

Screenshot to show APM no longer receiving data in prod.
<img width="1992" height="876" alt="image" src="https://github.com/user-attachments/assets/e7d2a33b-d834-4dfc-bb9d-b93bb5833000" />



## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change
