### PR TITLE
#1954 - POAM SC-08: Decommission is_processed field in BIP DynamoDB table

### DIFF
--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -2423,23 +2423,10 @@ def dynamodb_mock():
                 'AttributeName': 'payment_id',
                 'AttributeType': 'N',
             },
-            {
-                'AttributeName': 'is_processed',
-                'AttributeType': 'S',
-            },
         ],
         'KeySchema': [
             {'AttributeName': 'participant_id', 'KeyType': 'HASH'},
             {'AttributeName': 'payment_id', 'KeyType': 'RANGE'},
-        ],
-        'GlobalSecondaryIndexes': [
-            {
-                'IndexName': 'is-processed-index',
-                'KeySchema': [{'AttributeName': 'is_processed', 'KeyType': 'HASH'}],
-                'Projection': {
-                    'ProjectionType': 'ALL',
-                },
-            },
         ],
         'BillingMode': 'PAY_PER_REQUEST',
     }


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

issue [#1954](https://github.com/department-of-veterans-affairs/vanotify-team/issues/1954)

Update the BIP DynamoDB bip_dynamodb_participant_table table schema to remove the deprecated is_processed field and its associated index so that we clean up unused infrastructure, and the table is prepared for storing new encrypted PII attributes (encrypted_participant_id and encrypted_va_profile_id) which will be written by application code.

Removed the deprecated `is-processed-index` GSI and `is_processed` attribute from our DynamoDB message_cache table. The table will continue to use participant_id and payment_id as its primary key (both remain as Number types). Later - Application code will write new encrypted attributes (encrypted_participant_id and encrypted_va_profile_id) which don't require schema definitions since they're not used as keys. Please do not create the new encrypted_participant_id and encrypted_va_profile_id in this ticket.

This PR removes related testing in notification-api.

Additional Info and Resources
See Terraform configuration for aws_dynamodb_table.bip_dynamodb_participant_table
[Documentation on Comp and Pen](https://github.com/department-of-veterans-affairs/vanotify-team/tree/main/Architecture/comp%20%26%20pen)

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- Unit Tests (Note: Testing for the changes reflected in the unit test changes will be captured in the PRs found [here](https://github.com/department-of-veterans-affairs/vanotify-commons/pull/229) and [here](https://github.com/department-of-veterans-affairs/vanotify-infra/pull/1154).



## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
