### PR TITLE
#1957 - Support encrypted field comp and pen bypass

### DIFF
--- a/.github/workflows/lambda-functions.yml
+++ b/.github/workflows/lambda-functions.yml
@@ -79,7 +79,18 @@ jobs:
       - name: Package and deploy VA Profile opt-in/out lambda function
         if: ${{ (inputs.lambdaName == 'ProfileOptInOut') || (inputs.lambdaName == 'All') }}
         run: |
-          zip -j va_profile_opt_in_out_lambda va_profile/va_profile_opt_in_out_lambda.py
+          # Stage files for zip packaging, preserving the app/pii/ directory structure
+          mkdir -p tmp/app/pii
+          cp va_profile/va_profile_opt_in_out_lambda.py tmp/
+          # Copy pii_encryption.py file to staging directory
+          cp ../app/pii/pii_encryption.py tmp/app/pii/
+          # Initialize Python packages for lambda import
+          touch tmp/app/__init__.py
+          touch tmp/app/pii/__init__.py
+          # Zip the contents of the staging directory
+          cd tmp && zip -r ../va_profile_opt_in_out_lambda.zip .
+          cd ..
+          # Update function code with the new zip file
           aws lambda update-function-code --function-name project-${{ inputs.environment }}-va-profile-opt-in-out-lambda --zip-file fileb://va_profile_opt_in_out_lambda.zip
 
       - name: Package and deploy VA Profile remove old opt-outs lambda function

--- a/.talismanrc
+++ b/.talismanrc
@@ -101,4 +101,6 @@ fileignoreconfig:
   checksum: 9cdb7bf7610743d061cf653d4292be2a3966d428ae1234da56c8314e7699d096
 - filename: app/pii/pii_base.py
   checksum: 584cb03893d943c5f8504e5951128f17ce26cf9ffdfc51a29992d9e30e9a3d8b
+- filename: app/pii/pii_encryption.py
+  checksum: 990dc841e6143b36c03647d3bee43871e62be8f5535f388878e5f74aeaa0237e
 version: "1.0"

--- a/app/pii/__init__.py
+++ b/app/pii/__init__.py
@@ -4,7 +4,8 @@ This package provides classes and utilities for handling Personally Identifiable
 in a secure manner, including encryption, redaction, and controlled access.
 """
 
-from app.pii.pii_base import PiiEncryption, PiiLevel, Pii
+from app.pii.pii_encryption import PiiEncryption
+from app.pii.pii_base import PiiLevel, Pii
 from app.pii.pii_high import PiiBirlsid, PiiEdipi, PiiIcn
 from app.pii.pii_low import PiiPid, PiiVaProfileID
 from app.va.identifier import IdentifierType

--- a/app/pii/pii_base.py
+++ b/app/pii/pii_base.py
@@ -11,46 +11,11 @@ Classes in this module follow guidance from:
 - VA Documents
 """
 
-import os
 from enum import Enum
 from typing import ClassVar
-from cryptography.fernet import Fernet
 
+from app.pii.pii_encryption import PiiEncryption
 from app.va.identifier import IdentifierType
-
-
-class PiiEncryption:
-    """Singleton to manage encryption for PII data."""
-
-    _instance: 'PiiEncryption | None' = None
-    _key: bytes | None = None
-    _fernet: Fernet | None = None
-
-    def __new__(cls) -> 'PiiEncryption':
-        if cls._instance is None:
-            cls._instance = super(PiiEncryption, cls).__new__(cls)
-        return cls._instance
-
-    @classmethod
-    def get_encryption(cls) -> Fernet:
-        """Get or create a Fernet instance for encryption/decryption.
-
-        Raises:
-            ValueError: If PII_ENCRYPTION_KEY environment variable is not set.
-        """
-        if cls._fernet is None:
-            # Use environment variable - key must be provided in production
-            key_str = os.getenv('PII_ENCRYPTION_KEY')
-            if key_str is None:
-                raise ValueError(
-                    'PII_ENCRYPTION_KEY environment variable is required. '
-                    'This key must be provided through AWS Parameter Store in production environments.'
-                )
-
-            # Key from SSM Parameter Store comes as string, encode to bytes
-            cls._key = key_str.encode()
-            cls._fernet = Fernet(cls._key)
-        return cls._fernet
 
 
 class PiiLevel(Enum):

--- a/app/pii/pii_encryption.py
+++ b/app/pii/pii_encryption.py
@@ -1,0 +1,48 @@
+"""Module for handling PII (Personally Identifiable Information) Encryption logic.
+
+This module provides a class for PII Fernet encryption. It implements encryption
+for PII data.
+
+Classes in this module follow guidance from:
+- NIST 800-122
+- NIST 800-53
+- NIST 800-60
+- VA Documents
+"""
+
+import os
+from cryptography.fernet import Fernet
+
+
+class PiiEncryption:
+    """Singleton to manage encryption for PII data."""
+
+    _instance: 'PiiEncryption | None' = None
+    _key: bytes | None = None
+    _fernet: Fernet | None = None
+
+    def __new__(cls) -> 'PiiEncryption':
+        if cls._instance is None:
+            cls._instance = super(PiiEncryption, cls).__new__(cls)
+        return cls._instance
+
+    @classmethod
+    def get_encryption(cls) -> Fernet:
+        """Get or create a Fernet instance for encryption/decryption.
+
+        Raises:
+            ValueError: If PII_ENCRYPTION_KEY environment variable is not set.
+        """
+        if cls._fernet is None:
+            # Use environment variable - key must be provided in production
+            key_str = os.getenv('PII_ENCRYPTION_KEY')
+            if key_str is None:
+                raise ValueError(
+                    'PII_ENCRYPTION_KEY environment variable is required. '
+                    'This key must be provided through AWS Parameter Store in production environments.'
+                )
+
+            # Key from SSM Parameter Store comes as string, encode to bytes
+            cls._key = key_str.encode()
+            cls._fernet = Fernet(cls._key)
+        return cls._fernet


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->
# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
issue [#TEAM-1957](https://github.com/orgs/department-of-veterans-affairs/projects/1417/views/1?pane=issue&itemId=142912643&issue=department-of-veterans-affairs%7Cvanotify-team%7C1957)

Updates the `comp-and-pen-batch-process` Celery task to handle both encrypted and unencrypted PII from incoming SQS records. The Glue script is transitioning to send encrypted `participant_id` and `vaprofile_id` values, and the system needs to handle both formats during the rollout based on the `PII_ENABLED` feature flag.

### Changes

**`app/celery/process_comp_and_pen.py`**
- Added `encrypted_participant_id` and `encrypted_vaprofile_id` optional fields to `DynamoRecord`
- Added `_resolve_pii_for_comp_and_pen()` to handle the 4 PII scenarios based on feature flag state and field availability:
  1. FF ON + encrypted fields → pass encrypted Pii objects through
  2. FF OFF + encrypted fields → decrypt to plain strings
  3. FF ON + unencrypted fields → encrypt by wrapping in Pii
  4. FF OFF + unencrypted fields → pass plain strings through (existing behavior)
- Updated `_send_comp_and_pen_sms` to use the resolver, with error handling that continues processing remaining records on decryption failure

**`app/notifications/send_notifications.py`**
- Added `isinstance(Pii)` check in `send_notification_bypass_route` to avoid double-wrapping `id_value` when callers (like comp-and-pen) have already resolved PII upstream

... and unit testing ✨ 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- **Unit tests** — All new and existing tests passing locally.
- **DEV environment testing** — Deployed to DEV and dropped messages into the SQS queue for each scenario.
- [Deploy with PII_ENABLED FF OK](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/21961825737)
- [Deploy without PII_ENABLED FF OK](https://github.com/department-of-veterans-affairs/notification-api/actions/runs/21965425616)

### QA Testing Instructions for #1957

#### 1. Create Script Locally to Get Encrypted Values

You need to generate properly encrypted `vaprofile_id` and `participant_id` values using the DEV environment's Fernet key.

1. Copy the following into a Python file (e.g. `encrypt_pii.py`):
    
    ```python
    from cryptography.fernet import Fernet
    
    key = b"pii-encryption-key-value"  # Replace with actual Fernet key from Parameter Store
    f = Fernet(key)
    
    # Replace with the vaprofile_id or participant_id you want to encrypt
    value = b"va_profile_id_value"
    encrypted = f.encrypt(value)
    
    print(encrypted.decode())
    ```
    
2. Get the correct PII encryption key from the [Parameter Store](https://us-gov-west-1.console.amazonaws-us-gov.com/systems-manager/parameters?region=us-gov-west-1&tab=Table#list_parameter_filters=Name:Contains:pii) and paste it into the `key` variable.
    
3. Update `value` with the `vaprofile_id` or `participant_id` you want to encrypt.
    
4. Run the script locally to obtain the encrypted value:
    
    ```bash
    python encrypt_pii.py
    ```
    
5. Repeat for each value you need to encrypt (e.g. one run for `vaprofile_id`, one for `participant_id`).
    

---

#### 2. Update Glue Script to Send Test Records

You need to stub the [Glue Script](https://console.amazonaws-us-gov.com/gluestudio/home?region=us-gov-west-1#/jobs?selectedInterface=source_and_target) to send test body records instead of reading from DynamoDB.

#### 1. Reduce the run duration

Set `MAX_DURATION = 10` so the script exits quickly.

#### 2. Stub the `records` variable in `generate_celery_task`

**Change this** (original):

```python
def generate_celery_task(records: list[DynamoRecord]) -> dict:
    """
    A celery task is created.
    The envelope has a generic schema that can be consumed by before it routes to a task.
    The task is used to route the message to the proper method in the app.
    """
    task = {
        'task': TASK_NAME,
        'id': str(uuid.uuid4()),
        'kwargs': {'records': records},
    }
    ...
```

**To this** (stubbed):

```python
def generate_celery_task(records: list[DynamoRecord]) -> dict:
    """
    A celery task is created.
    The envelope has a generic schema that can be consumed by before it routes to a task.
    The task is used to route the message to the proper method in the app.
    """
    records = [
        {
            'participant_id': '1234',
            'payment_amount': '2500',
            'vaprofile_id': '43627',
            'encrypted_vaprofile_id': 'gAAAAABpjd-zOFguT7ebtmfFRaEv2qBpQBtXgK3v0hAnAdRfFoOzuuGNDLM0UailfPRoUaIkZ_F74wjLks3UmDyE6JE0MsSTng==',
            'encrypted_participant_id': 'gAAAAABpjeCOaMBhR3z0ZksrZb8TfzPjZ0V_m4reqVI-GShdT15TjRjvJgpX_hgNGspjZB4aj-9Eak9kQsMOKX_lIQnGILH3cQ==',
        }
    ]
    task = {
        'task': TASK_NAME,
        'id': str(uuid.uuid4()),
        'kwargs': {'records': records},
    }
    envelope = {
        'body': base64.b64encode(bytes(json.dumps(task), 'utf-8')).decode('utf-8'),
        'content-encoding': 'utf-8',
        'content-type': 'application/json',
        'headers': {},
        'properties': {
            'reply_to': str(uuid.uuid4()),
            'correlation_id': str(uuid.uuid4()),
            'delivery_mode': 2,
            'delivery_info': {'priority': 0, 'exchange': 'default', 'routing_key': QUEUE_NAME},
            'body_encoding': 'base64',
            'delivery_tag': str(uuid.uuid4()),
        },
    }
    return envelope
```

> **Note:** Replace the encrypted values above with the ones you generated in Step 1 using the correct DEV Fernet key.

### 3. Run the Glue script

### 4. Verify

Confirm the records were sent and processed by the `comp_and_pen_batch_process` Celery task. Check:

- **DataDog logs** — Look for `comp_and_pen_batch_process` log entries
- **DataDogs log** — Confirm the text message was delivered
- **Database** — Verify notification records were created with the expected values


### Test Scenarios

#### Scenario 1: PII_ENABLED FF ON + Encrypted Fields
- **SQS Message:** Record with `encrypted_participant_id` and `encrypted_vaprofile_id` populated
   ```
     [
        {
            'participant_id': '1234',
            'payment_amount': '2500',
            'vaprofile_id': '43627',
            'encrypted_vaprofile_id': 'gAAAAABpjjttRznq9hiLL45wv9n0MXnsK9et2vqaFNs3C7l_zMw-VQXS-kkEvhpklFDf2hcwLV_cdtSPDeIcGhnTAYj5g0a8JA==', 
            'encrypted_participant_id': 'gAAAAABpjjuAiYxjSAxYXSd7jdrrVropqwODfEwW48HXkAryy850p4nOLXv8bhhHfWA9iySsNYelbsBmIKKq5kvARdkkQ68h8w=='
        }
    ]
   ```
- **Feature Flag:** `PII_ENABLED=True`
- **Expected:** Encrypted values used through the system, saved encrypted to DB in Notification table, SMS delivered
- [Confirm DataDog Logs show `process_comp_and_pen` celery tasks processed notification](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%20%40requestId%3Ae2c1c199-e779-4f0d-92b5-27b8ae321ec7&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1770929653550&to_ts=1770930553550&live=false)
- [Confirm DataDog Logs show notification as delivered ](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%20%228dba1f45-1166-4e55-a170-8f5dff764630%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1770929653550&to_ts=1770930553550&live=false) - 8dba1f45-1166-4e55-a170-8f5dff764630
- Confirm `vaprofile_id` saved as encrypted in Notification table
 
    <img width="981" height="97" alt="Screenshot 2026-02-12 at 2 12 44 PM" src="https://github.com/user-attachments/assets/8a3c9b00-5798-4918-9aca-319c41b7f83c" />


---

#### Scenario 2: PII_ENABLED  FF OFF + Encrypted Fields
- **SQS Message:** Record with `encrypted_participant_id` and `encrypted_vaprofile_id` populated
    ```
     [
        {
            'participant_id': '1234',
            'payment_amount': '2500',
            'vaprofile_id': '43627',
            'encrypted_vaprofile_id': 'gAAAAABpjjttRznq9hiLL45wv9n0MXnsK9et2vqaFNs3C7l_zMw-VQXS-kkEvhpklFDf2hcwLV_cdtSPDeIcGhnTAYj5g0a8JA==', 
            'encrypted_participant_id': 'gAAAAABpjjuAiYxjSAxYXSd7jdrrVropqwODfEwW48HXkAryy850p4nOLXv8bhhHfWA9iySsNYelbsBmIKKq5kvARdkkQ68h8w=='
        }
    ]
    ```
- **Feature Flag:** `PII_ENABLED=False`
- **Expected:** Values decrypted for downstream use, saved unencrypted to DB under Notification table, SMS delivered
- [Confirm DataDog Logs show `process_comp_and_pen` celery tasks processed notification](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%20%40requestId%3A251c5ef4-5a91-47c4-9f05-712392a07418&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1770933417607&to_ts=1770934317607&live=false)
- [Confirm DataDog Logs show notification as delivered ](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%20%22d34f03ae-bf19-4bfc-83a6-7aa8cd1fb773%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1770933594890&to_ts=1770934494890&live=false)
- Confirm `vaprofile_id` saved as unencrypted in Notification table
    <img width="1123" height="104" alt="Screenshot 2026-02-12 at 3 16 10 PM" src="https://github.com/user-attachments/assets/3f01effa-a686-4174-808e-6cf6c186fba7" />


---

#### Scenario 3: PII_ENABLED FF ON + Unencrypted Fields
- **SQS Message:** Record with only `participant_id` and `vaprofile_id` (no encrypted fields)
    ```
    [
        {
            'participant_id': '1234',
            'payment_amount': '2500',
            'vaprofile_id': '43627',
        }
    ]
    ```
- **Feature Flag:** `PII_ENABLED=True`
- **Expected:** Values encrypted by the system, saved encrypted to DB under Notification table, SMS delivered
- [Confirm DataDog Logs show notification as delivered - 4cbc290f-dbf0-4bb7-8164-40f5a93f9b0b](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%20%224cbc290f-dbf0-4bb7-8164-40f5a93f9b0b%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1770928420553&to_ts=1770929320553&live=false)
- Confirm `vaprofile_id` saved as encrypted in Notification table

    <img width="1126" height="67" alt="Screenshot 2026-02-12 at 2 04 12 PM" src="https://github.com/user-attachments/assets/6c3d6cee-79b4-4b82-972c-b8b45a6cee3e" />


---

#### Scenario 4: PII_ENABLED FF OFF + Unencrypted Fields (existing behavior)
- **SQS Message:** Record with only `participant_id` and `vaprofile_id` (no encrypted fields)
    ```
     [
        {
            'participant_id': '1234',
            'payment_amount': '2500',
            'vaprofile_id': '43627',
        }
    ]
    ```
- **Feature Flag:** `PII_ENABLED=False`
- **Expected:** Values pass through as-is, saved unencrypted to DB, SMS delivered
- [Confirm DataDog Logs show `process_comp_and_pen` celery tasks processed notification](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%20%40requestId%3Aa320c13f-fbba-4490-9475-764ec3b8247f&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1770934116877&to_ts=1770935016877&live=false)
- [Confirm DataDog Logs show notification as delivered - 33dab0cf-66af-4cb5-be33-c53a6ece7d9f ](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%20%2233dab0cf-66af-4cb5-be33-c53a6ece7d9f%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1770934109073&to_ts=1770935009073&live=false)
- Confirm `vaprofile_id` saved as unencrypted in Notification table - 33dab0cf-66af-4cb5-be33-c53a6ece7d9f
    <img width="1029" height="92" alt="Screenshot 2026-02-12 at 3 26 35 PM" src="https://github.com/user-attachments/assets/6f124e9c-3fed-4c0b-90de-18ac1c45b76e" />

---

#### Scenario 5a: Can handle records with mixed encrypted and unencrypted records  - PII_ENABLED FF ON
- **SQS Message:** Records with both encrypted and unencrypted fields populated
    ```
     [
        {
            'participant_id': '1234',
            'payment_amount': '2500',
            'vaprofile_id': '43627',
            'encrypted_vaprofile_id': 'gAAAAABpjjttRznq9hiLL45wv9n0MXnsK9et2vqaFNs3C7l_zMw-VQXS-kkEvhpklFDf2hcwLV_cdtSPDeIcGhnTAYj5g0a8JA==', 
            'encrypted_participant_id': 'gAAAAABpjjuAiYxjSAxYXSd7jdrrVropqwODfEwW48HXkAryy850p4nOLXv8bhhHfWA9iySsNYelbsBmIKKq5kvARdkkQ68h8w=='
        }, 
       {
            'participant_id': '2222',
            'payment_amount': '2500',
            'vaprofile_id': '43627',
        }
    ]
    ```
- **Feature Flag:** `PII_ENABLED=True`
- **Expected:** Encrypted fields used, unencrypted fields ignored, encrypted values saved to DB under Notification table
- [Confirm DataDog Logs show `process_comp_and_pen` celery tasks processed notification - Confirmed both notifications received](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%20%40requestId%3A1681943e-25f8-48e0-8af8-86f11b074e8f&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1770930257145&to_ts=1770931157145&live=false) 
- Confirm DataDog Logs show notification as delivered  - confirm both notifications processed 
    - [eca7c3f5-98e0-4b91-acfa-c5264f26697e - unencrypted vaprofile_id ](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%20%22eca7c3f5-98e0-4b91-acfa-c5264f26697e%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1770930773692&to_ts=1770931673692&live=false)
 
    - [68042712-156a-4ebd-b168-4705d18f751c - encrypted vaprofile_id](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%20%2268042712-156a-4ebd-b168-4705d18f751c%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1770930734346&to_ts=1770931634346&live=false)
 - Confirm va_profile_id are encrypted in DB
     -    **Note** Confirmed decrypted value is original `43627` and encrypted value is correct
     - <img width="1002" height="67" alt="Screenshot 2026-02-12 at 2 31 08 PM" src="https://github.com/user-attachments/assets/e39c4940-2f58-49ca-89da-dedb4ebb0441" /> 
    - <img width="1081" height="82" alt="Screenshot 2026-02-12 at 2 35 18 PM" src="https://github.com/user-attachments/assets/da607fe2-ea33-4be7-aa8b-85e6c4c4040e" />

---

#### Scenario 5b: Can handle records with mixed encrypted and unencrypted records - PII_ENABLED OFF
- **SQS Message:** Records with both encrypted and unencrypted fields populated
    ```
     [
        {
            'participant_id': '1234',
            'payment_amount': '2500',
            'vaprofile_id': '43627',
            'encrypted_vaprofile_id': 'gAAAAABpjjttRznq9hiLL45wv9n0MXnsK9et2vqaFNs3C7l_zMw-VQXS-kkEvhpklFDf2hcwLV_cdtSPDeIcGhnTAYj5g0a8JA==', 
            'encrypted_participant_id': 'gAAAAABpjjuAiYxjSAxYXSd7jdrrVropqwODfEwW48HXkAryy850p4nOLXv8bhhHfWA9iySsNYelbsBmIKKq5kvARdkkQ68h8w=='
        }, 
      {
            'participant_id': '2222,
            'payment_amount': '2500',
            'vaprofile_id': '43627',
        }
    ]
    ```
- **Feature Flag:** `PII_ENABLED=False`
- **Expected:** Encrypted fields used and decrypted, unencrypted fields ignored, decrypted values saved to DB under Notification table
- [Confirm DataDog Logs show `process_comp_and_pen` celery tasks processed notification](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%20%40requestId%3A0d5b7c6c-03eb-498a-bff2-8db62a14da0c&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1770932757345&to_ts=1770933657345&live=false)
- Confirm DataDog Logs show notification as delivered 
    - [9bf64f86-00c9-478d-8c3e-3ab559dfac5f](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%209bf64f86-00c9-478d-8c3e-3ab559dfac5f&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1770932888281&to_ts=1770933788281&live=true)
    - [348d5245-81d9-4752-b329-50dbb98fe185](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%20%22348d5245-81d9-4752-b329-50dbb98fe185%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1770932830812&to_ts=1770933730812&live=true)
- Confirm va_profile_id values NOT encrypted in DB 
    <img width="999" height="213" alt="Screenshot 2026-02-12 at 3 07 58 PM" src="https://github.com/user-attachments/assets/18d4e0b0-f35c-453e-a2fb-3d15b2418669" />

---


#### Sad Path: Invalid encrypted data
- **SQS Message:** Record with malformed `encrypted_participant_id` and `encrypted_vaprofile_id`
    **Note** Removed `==` at end of encryption string
    ```
      {
            'participant_id': '1234',
            'payment_amount': '2500',
            'vaprofile_id': '43627',
            'encrypted_vaprofile_id': 'gAAAAABpjjttRznq9hiLL45wv9n0MXnsK9et2vqaFNs3C7l_zMw-VQXS-kkEvhpklFDf2hcwLV_cdtSPDeIcGhnTAYj5g0a8JA', 
            'encrypted_participant_id': 'gAAAAABpjjuAiYxjSAxYXSd7jdrrVropqwODfEwW48HXkAryy850p4nOLXv8bhhHfWA9iySsNYelbsBmIKKq5kvARdkkQ68h8w'
        }, 
      ```
- **Expected:** Error logged, record skipped
- [Confirm DataDog Logs show `process_comp_and_pen` celery tasks DOES NOT process notification](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%20%2233dab0cf-66af-4cb5-be33-c53a6ece7d9f%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1770934109073&to_ts=1770935009073&live=false)
    <img width="1119" height="266" alt="Screenshot 2026-02-12 at 3 31 37 PM" src="https://github.com/user-attachments/assets/4326b880-d4e0-4e5e-aaac-a42c122be200" />
    


---

#### Sad Path: Missing required fields
- **SQS Message:** Record with no participant_id or encrypted_participant_id
    **Note**: Comment out both `encrypted_vaprofile_id` and `vaprofile_id`
    ```
        {
            'participant_id': '1234',
            'payment_amount': '2500',
            # 'vaprofile_id': '43627',
            # 'encrypted_vaprofile_id': 'gAAAAABpjjttRznq9hiLL45wv9n0MXnsK9et2vqaFNs3C7l_zMw-VQXS-kkEvhpklFDf2hcwLV_cdtSPDeIcGhnTAYj5g0a8JA==', 
            'encrypted_participant_id': 'gAAAAABpjjuAiYxjSAxYXSd7jdrrVropqwODfEwW48HXkAryy850p4nOLXv8bhhHfWA9iySsNYelbsBmIKKq5kvARdkkQ68h8w=='
        }, 
    ```
- **Expected:** Error logged, record skipped
- [Confirm DataDog Logs show `process_comp_and_pen` celery tasks DOES NOT processed notification](https://vanotify.ddog-gov.com/logs?query=host%3A%22dev-notification-api-log-group%22%20%40requestId%3A52b9a0b4-57bf-4a62-801a-d1df83498946&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1770936145611&to_ts=1770937045611&live=true)

    <img width="911" height="243" alt="Screenshot 2026-02-12 at 3 58 08 PM" src="https://github.com/user-attachments/assets/c3688cc8-f422-4592-81bd-e890a3917bfd" />



## Checklist
- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
