### PR TITLE
HOTFIX - Update Inbound-sms Lambda to Support PH Numbers

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -109,4 +109,6 @@ fileignoreconfig:
   checksum: baa13dfa1eca2dc966f65bc8efe1ca64c768472dadb801ae168ba33a948f5abe
 - filename: tests/lambda_functions/va_profile/test_va_profile_integration.py
   checksum: d2615670e4a594e06cfe5a2fc2d2dad0567e33a059aeaae68e346b3da2532750
+- filename: tests/lambda_functions/two_way_sms/test_two_way_sms_v2.py
+  checksum: 295c93e5a929ea3d7afbea720dd5edcf435b0a96fe260b7538951f1f5c25a648
 version: "1.0"

--- a/lambda_functions/two_way_sms/two_way_sms_v2.py
+++ b/lambda_functions/two_way_sms/two_way_sms_v2.py
@@ -52,7 +52,7 @@ except (TypeError, ValueError):
 ################################################################################################
 if os.getenv('NOTIFY_ENVIRONMENT') == 'test':
     sqlalchemy_database_uri = os.getenv('SQLALCHEMY_DATABASE_URI')
-    client_auth_token = 'test'
+    client_auth_token = 'test'  # nosec: only used for testing
 else:
     database_uri_path = os.getenv('DATABASE_URI_PATH')
     if database_uri_path is None:
@@ -115,8 +115,9 @@ else:
             db_connection.close()
 
     # Create the mapping table with a generator expression.
+    # lstrip('+') to normalize numbers that may or may not have a leading '+'.
     two_way_sms_table_dict = {
-        n: {
+        n.lstrip('+'): {
             'service_id': s,
             'url_endpoint': u,
             'self_managed': sm,
@@ -190,7 +191,8 @@ def notify_incoming_sms_handler(
         # Else, the message has all the required fields.
 
         # destinationNumber is the 10DLC Pinpoint number to which the end user responded.
-        two_way_record = two_way_sms_table_dict.get(inbound_sms['destinationNumber'])
+        # lstrip('+') to normalize the Pinpoint number for lookup.
+        two_way_record = two_way_sms_table_dict.get(inbound_sms['destinationNumber'].lstrip('+'))
         if two_way_record is None:
             # Dead letter
             logger.error('Unable to find a two_way_record for %s.', inbound_sms.get('destinationNumber', 'unknown'))
@@ -266,7 +268,7 @@ def forward_to_service(
 
     global client_auth_token
 
-    if client_auth_token != 'test':
+    if client_auth_token != 'test':  # nosec: used to determine whether or not to use testing value
         try:
             client_auth_token = get_ssm_param_info(client_api_auth_ssm_path=auth_parameter)
         except Exception as e:

--- a/tests/lambda_functions/two_way_sms/test_two_way_sms_v2.py
+++ b/tests/lambda_functions/two_way_sms/test_two_way_sms_v2.py
@@ -13,6 +13,7 @@ import boto3
 
 LAMBDA_MODULE = 'lambda_functions.two_way_sms.two_way_sms_v2'
 DESTINATION_NUMBER = '+12222222222'
+DESTINATION_NUMBER_NORMALIZED = '12222222222'
 INVALID_EVENT = {}
 INVALID_EVENT_BODY = {'Records': [{'no_body': {}}]}
 VALID_EVENT = {
@@ -21,6 +22,26 @@ VALID_EVENT = {
             'messageId': 'c5fd0ef6-1145-4ba3-9612-1d8fa7ec6e73',
             'receiptHandle': 'handlesig==',
             'body': '{\n "Type" : "Notification",\n "MessageId" : "guid",\n "TopicArn" : "notify-incoming-sms",\n "Message" : "{\\"originationNumber\\":\\"+11111111111\\",\\"destinationNumber\\":\\"+12222222222\\",\\"messageKeyword\\":\\"KEYWORD_171875617347\\",\\"messageBody\\":\\"Test message\\",\\"inboundMessageId\\":\\"messageid\\"}",\n "Timestamp" : "2022-12-02T04:16:59.606Z",\n "SignatureVersion" : "1",\n "Signature" : "somesig==",\n "SigningCertURL" : "https://someurl/some.pem",\n "UnsubscribeURL" : "https://someurl/?Action=Unsubscribe&SubscriptionArn=notify-incoming-sms"\n}',
+            'attributes': {
+                'ApproximateReceiveCount': '1',
+                'SentTimestamp': '1669954619628',
+                'SenderId': '280946605409',
+                'ApproximateFirstReceiveTimestamp': '1669954619630',
+            },
+            'messageAttributes': {},
+            'md5OfBody': 'somevalue',
+            'eventSource': 'aws:sqs',
+            'eventSourceARN': 'notify-incoming-sms',
+            'awsRegion': 'some-region',  # noqa
+        }
+    ]
+}
+VALID_EVENT_NO_PLUS = {
+    'Records': [
+        {
+            'messageId': 'c5fd0ef6-1145-4ba3-9612-1d8fa7ec6e73',
+            'receiptHandle': 'handlesig==',
+            'body': '{\n "Type" : "Notification",\n "MessageId" : "guid",\n "TopicArn" : "notify-incoming-sms",\n "Message" : "{\\"originationNumber\\":\\"+11111111111\\",\\"destinationNumber\\":\\"12222222222\\",\\"messageKeyword\\":\\"KEYWORD_171875617347\\",\\"messageBody\\":\\"Test message\\",\\"inboundMessageId\\":\\"messageid\\"}",\n "Timestamp" : "2022-12-02T04:16:59.606Z",\n "SignatureVersion" : "1",\n "Signature" : "somesig==",\n "SigningCertURL" : "https://someurl/some.pem",\n "UnsubscribeURL" : "https://someurl/?Action=Unsubscribe&SubscriptionArn=notify-incoming-sms"\n}',
             'attributes': {
                 'ApproximateReceiveCount': '1',
                 'SentTimestamp': '1669954619628',
@@ -192,11 +213,12 @@ def test_notify_incoming_sms_handler_failed_request(mocker):
     )
     mocker.patch(
         f'{LAMBDA_MODULE}.two_way_sms_table_dict',
-        return_value={
-            DESTINATION_NUMBER: {
+        {
+            DESTINATION_NUMBER_NORMALIZED: {
                 'service_id': 'someserviceid',
                 'url_endpoint': 'https://someurl.com',
                 'self_managed': False,
+                'auth_parameter': 'auth_param',
             }
         },
     )
@@ -213,7 +235,7 @@ def test_notify_incoming_sms_handler_phonenumber_not_found_keyerror(mocker):
     # trigger the key not existing
     mocker.patch(
         f'{LAMBDA_MODULE}.two_way_sms_table_dict',
-        {'+123': {'service_id': 'someserviceid', 'url_endpoint': 'https://someurl.com', 'self_managed': False}},
+        {'123': {'service_id': 'someserviceid', 'url_endpoint': 'https://someurl.com', 'self_managed': False}},
     )
 
     response = notify_incoming_sms_handler(VALID_EVENT, None)
@@ -228,10 +250,11 @@ def test_notify_incoming_sms_handler_phonenumber_not_found_exception(mocker):
     mocker.patch(
         f'{LAMBDA_MODULE}.two_way_sms_table_dict',
         {
-            DESTINATION_NUMBER: {
+            DESTINATION_NUMBER_NORMALIZED: {
                 'service_id': 'someserviceid',
                 'url_endpoint': 'https://someurl.com',
                 'self_managed': False,
+                'auth_parameter': 'auth_param',
             }
         },
     )
@@ -243,3 +266,32 @@ def test_notify_incoming_sms_handler_phonenumber_not_found_exception(mocker):
 
     assert response['statusCode'] == 200
     sqs_mock.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    'event',
+    [VALID_EVENT, VALID_EVENT_NO_PLUS],
+    ids=['destination_with_plus', 'destination_without_plus'],
+)
+def test_notify_incoming_sms_handler_matches_number_regardless_of_plus(mocker, event):
+    """Verify the handler matches destination numbers with or without a leading '+' prefix."""
+
+    sqs_mock = mocker.patch(f'{LAMBDA_MODULE}.push_to_sqs')
+    forward_mock = mocker.patch(f'{LAMBDA_MODULE}.forward_to_service', return_value=True)
+    mocker.patch(
+        f'{LAMBDA_MODULE}.two_way_sms_table_dict',
+        {
+            DESTINATION_NUMBER_NORMALIZED: {
+                'service_id': 'someserviceid',
+                'url_endpoint': 'https://someurl.com',
+                'self_managed': False,
+                'auth_parameter': 'auth_param',
+            }
+        },
+    )
+
+    response = notify_incoming_sms_handler(event, None)
+
+    assert response['statusCode'] == 200
+    forward_mock.assert_called_once()
+    sqs_mock.assert_not_called()


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This pull request improves the handling and normalization of phone numbers in the two-way SMS Lambda function to ensure consistent processing regardless of whether numbers include a leading '+'. This is necessary to support PH inbound numbers because we restrict the DB column to 12 characters. That should probably be updated, but that will come later.

issue N/A

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- [x] added new tests for this use-case
- [x] existing unit tests pass

Before and after logs in prod:
<img width="1898" height="198" alt="image" src="https://github.com/user-attachments/assets/f5f11da4-cfea-449a-a658-615486a19daf" />



## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The ticket was moved into the DEV test column when I began testing this change
