### PR TITLE
#2705 - Export active user lists

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -111,8 +111,4 @@ fileignoreconfig:
   checksum: d2615670e4a594e06cfe5a2fc2d2dad0567e33a059aeaae68e346b3da2532750
 - filename: tests/lambda_functions/two_way_sms/test_two_way_sms_v2.py
   checksum: 295c93e5a929ea3d7afbea720dd5edcf435b0a96fe260b7538951f1f5c25a648
-- filename: app/celery/nightly_tasks.py
-  checksum: ecafceaba59ef27575a09026f4d89b3ae706368e3bea6a5b7a91704cbfc092d1
-- filename: tests/app/celery/test_nightly_tasks.py
-  checksum: 84d71b68c76f444f9233b3de0567b66429f823104ef8bd5056d15f84ae8ffabf
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -5,6 +5,8 @@ fileignoreconfig:
   checksum: 44272d736424a12a9b8f5c23fb0b9cbba4befb91612fb793230329261bb369f9
 - filename: app/authentication/auth.py
   checksum: 25c56ecb421ad6aab9a803fccd981a7c019a3a8682447dd1a2a8f349e5d3b464
+- filename: app/celery/nightly_tasks.py
+  checksum: a8463db80924625300fc84970974e506ff378fedd268c3173d4a19a01e716f16
 - filename: app/clients/sms/aws_pinpoint.py
   checksum: 37e90b46758c38621f6cc4a41830e14ac6895526033c66b60383cd3586e12da5
 - filename: app/config.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -111,4 +111,8 @@ fileignoreconfig:
   checksum: d2615670e4a594e06cfe5a2fc2d2dad0567e33a059aeaae68e346b3da2532750
 - filename: tests/lambda_functions/two_way_sms/test_two_way_sms_v2.py
   checksum: 295c93e5a929ea3d7afbea720dd5edcf435b0a96fe260b7538951f1f5c25a648
+- filename: app/celery/nightly_tasks.py
+  checksum: ecafceaba59ef27575a09026f4d89b3ae706368e3bea6a5b7a91704cbfc092d1
+- filename: tests/app/celery/test_nightly_tasks.py
+  checksum: 84d71b68c76f444f9233b3de0567b66429f823104ef8bd5056d15f84ae8ffabf
 version: "1.0"

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -30,8 +30,8 @@ from app.utils import get_local_timezone_midnight_in_utc
 
 
 def _format_export_email_list(emails: list[str]) -> str:
-    """Return a deterministic comma-separated list of email addresses for copy/paste usage."""
-    return ','.join(sorted(emails))
+    """Return a deterministic semicolon-separated list of email addresses for copy/paste usage."""
+    return ';'.join(sorted(emails))
 
 
 @notify_celery.task(name='remove_sms_email_jobs')

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 import boto3
+from botocore.exceptions import ClientError
 import pytz
 from flask import current_app
 from notifications_utils.statsd_decorators import statsd
@@ -32,6 +33,20 @@ from app.utils import get_local_timezone_midnight_in_utc
 def _format_export_email_list(emails: list[str]) -> str:
     """Return a deterministic semicolon-separated list of email addresses for copy/paste usage."""
     return ';'.join(sorted(emails))
+
+
+def _upload_user_export_files_to_s3(export_files: dict[str, str]) -> None:
+    client = boto3.client('s3', endpoint_url=current_app.config['AWS_S3_ENDPOINT_URL'])
+
+    try:
+        for txt_key, body in export_files.items():
+            client.put_object(Body=body, Bucket=current_app.config['USER_EXPORT_BUCKET_NAME'], Key=txt_key)
+    except ClientError:
+        current_app.logger.exception(
+            'export-active-user-email-lists failed uploading files to bucket %s',
+            current_app.config['USER_EXPORT_BUCKET_NAME'],
+        )
+        raise
 
 
 @notify_celery.task(name='remove_sms_email_jobs')
@@ -173,10 +188,7 @@ def export_active_user_email_lists():
         f'user-exports/{today_string}/all_active_users.txt': _format_export_email_list(get_all_active_user_emails()),
     }
 
-    client = boto3.client('s3', endpoint_url=current_app.config['AWS_S3_ENDPOINT_URL'])
-
-    for key, body in export_files.items():
-        client.put_object(Body=body, Bucket=current_app.config['USER_EXPORT_BUCKET_NAME'], Key=key)
+    _upload_user_export_files_to_s3(export_files)
 
     current_app.logger.info(
         'export-active-user-email-lists complete: %s files uploaded for %s',

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+import boto3
 import pytz
 from flask import current_app
 from notifications_utils.statsd_decorators import statsd
@@ -16,11 +17,21 @@ from app.dao.notifications_dao import (
     dao_timeout_notifications,
     delete_notifications_older_than_retention_by_type,
 )
+from app.dao.active_user_emails_dao import (
+    get_active_business_contact_emails,
+    get_active_technical_contact_emails,
+    get_all_active_user_emails,
+)
 from app.exceptions import NotificationTechnicalFailureException
 from app.models import Notification
 from app.performance_platform import total_sent_notifications, processing_time
 from app.cronitor import cronitor
 from app.utils import get_local_timezone_midnight_in_utc
+
+
+def _format_export_email_list(emails: list[str]) -> str:
+    """Return a deterministic comma-separated list of email addresses for copy/paste usage."""
+    return ','.join(sorted(emails))
 
 
 @notify_celery.task(name='remove_sms_email_jobs')
@@ -139,6 +150,39 @@ def send_daily_performance_platform_stats(date=None):
     if performance_platform_client.active:
         send_total_sent_notifications_to_performance_platform(bst_date=date)
         processing_time.send_processing_time_to_performance_platform(bst_date=date)
+
+
+@notify_celery.task(name='export-active-user-email-lists')
+@cronitor('export-active-user-email-lists')
+@statsd(namespace='tasks')
+def export_active_user_email_lists():
+    """Export active business, technical, and all-user email lists to S3 once per day in staging."""
+    if current_app.config['NOTIFY_ENVIRONMENT'] != 'staging':
+        current_app.logger.info('Skipping export-active-user-email-lists task outside staging environment')
+        return
+
+    today_string = datetime.utcnow().date().isoformat()
+
+    export_files = {
+        f'user-exports/{today_string}/business_contacts.txt': _format_export_email_list(
+            get_active_business_contact_emails()
+        ),
+        f'user-exports/{today_string}/technical_contacts.txt': _format_export_email_list(
+            get_active_technical_contact_emails()
+        ),
+        f'user-exports/{today_string}/all_active_users.txt': _format_export_email_list(get_all_active_user_emails()),
+    }
+
+    client = boto3.client('s3', endpoint_url=current_app.config['AWS_S3_ENDPOINT_URL'])
+
+    for key, body in export_files.items():
+        client.put_object(Body=body, Bucket=current_app.config['USER_EXPORT_BUCKET_NAME'], Key=key)
+
+    current_app.logger.info(
+        'export-active-user-email-lists complete: %s files uploaded for %s',
+        len(export_files),
+        today_string,
+    )
 
 
 def send_total_sent_notifications_to_performance_platform(bst_date):

--- a/app/config.py
+++ b/app/config.py
@@ -312,7 +312,7 @@ class Config(object):
             },
             'export-active-user-email-lists': {
                 'task': 'export-active-user-email-lists',
-                'schedule': crontab(minute='*/30'),
+                'schedule': crontab(hour=3, minute=0),
                 'options': {'queue': QueueNames.PERIODIC},
             },
             'remove_transformed_dvla_files': {

--- a/app/config.py
+++ b/app/config.py
@@ -160,6 +160,7 @@ class Config(object):
     CSV_UPLOAD_BUCKET_NAME = os.getenv(
         'CSV_UPLOAD_BUCKET_NAME', f'{env_name_map[NOTIFY_ENVIRONMENT]}-notifications-csv-upload'
     )
+    USER_EXPORT_BUCKET_NAME = os.getenv('USER_EXPORT_BUCKET_NAME', f'vanotify-{NOTIFY_ENVIRONMENT}-users-export')
     ASSET_UPLOAD_BUCKET_NAME = os.getenv('ASSET_UPLOAD_BUCKET_NAME', 'dev-notifications-va-gov-assets')
     ASSET_DOMAIN = os.getenv('ASSET_DOMAIN', 's3.amazonaws.com')
     INVITATION_EXPIRATION_DAYS = 2
@@ -305,6 +306,11 @@ class Config(object):
             'send-daily-performance-platform-stats': {
                 'task': 'send-daily-performance-platform-stats',
                 'schedule': crontab(hour=2, minute=0),
+                'options': {'queue': QueueNames.PERIODIC},
+            },
+            'export-active-user-email-lists': {
+                'task': 'export-active-user-email-lists',
+                'schedule': crontab(hour=3, minute=00),
                 'options': {'queue': QueueNames.PERIODIC},
             },
             'remove_transformed_dvla_files': {

--- a/app/config.py
+++ b/app/config.py
@@ -160,7 +160,9 @@ class Config(object):
     CSV_UPLOAD_BUCKET_NAME = os.getenv(
         'CSV_UPLOAD_BUCKET_NAME', f'{env_name_map[NOTIFY_ENVIRONMENT]}-notifications-csv-upload'
     )
-    USER_EXPORT_BUCKET_NAME = os.getenv('USER_EXPORT_BUCKET_NAME', f'vanotify-{NOTIFY_ENVIRONMENT}-users-export')
+    USER_EXPORT_BUCKET_NAME = os.getenv(
+        'USER_EXPORT_BUCKET_NAME', f'vanotify-{env_name_map[NOTIFY_ENVIRONMENT]}-users-export'
+    )
     ASSET_UPLOAD_BUCKET_NAME = os.getenv('ASSET_UPLOAD_BUCKET_NAME', 'dev-notifications-va-gov-assets')
     ASSET_DOMAIN = os.getenv('ASSET_DOMAIN', 's3.amazonaws.com')
     INVITATION_EXPIRATION_DAYS = 2
@@ -310,7 +312,7 @@ class Config(object):
             },
             'export-active-user-email-lists': {
                 'task': 'export-active-user-email-lists',
-                'schedule': crontab(hour=3, minute=00),
+                'schedule': crontab(hour=3, minute=0),
                 'options': {'queue': QueueNames.PERIODIC},
             },
             'remove_transformed_dvla_files': {

--- a/app/config.py
+++ b/app/config.py
@@ -312,7 +312,7 @@ class Config(object):
             },
             'export-active-user-email-lists': {
                 'task': 'export-active-user-email-lists',
-                'schedule': crontab(hour=16, minute=30),
+                'schedule': crontab(minute='*/30'),
                 'options': {'queue': QueueNames.PERIODIC},
             },
             'remove_transformed_dvla_files': {

--- a/app/config.py
+++ b/app/config.py
@@ -312,7 +312,7 @@ class Config(object):
             },
             'export-active-user-email-lists': {
                 'task': 'export-active-user-email-lists',
-                'schedule': crontab(hour=3, minute=0),
+                'schedule': crontab(hour=16, minute=30),
                 'options': {'queue': QueueNames.PERIODIC},
             },
             'remove_transformed_dvla_files': {

--- a/app/dao/active_user_emails_dao.py
+++ b/app/dao/active_user_emails_dao.py
@@ -1,0 +1,45 @@
+from sqlalchemy import select
+
+from app import db
+from app.models import UserServiceRoles
+from app.model import User
+
+
+def get_active_business_contact_emails():
+    stmt = (
+        select(User.email_address)
+        .join(UserServiceRoles)
+        .where(
+            UserServiceRoles.role == 'business_contact',
+            User.state == 'active',
+        )
+        .distinct()
+    )
+
+    return db.session.scalars(stmt).all()
+
+
+def get_active_technical_contact_emails():
+    stmt = (
+        select(User.email_address)
+        .join(UserServiceRoles)
+        .where(
+            UserServiceRoles.role == 'technical_contact',
+            User.state == 'active',
+        )
+        .distinct()
+    )
+
+    return db.session.scalars(stmt).all()
+
+
+def get_all_active_user_emails():
+    stmt = (
+        select(User.email_address)
+        .where(
+            User.state == 'active',
+        )
+        .distinct()
+    )
+
+    return db.session.scalars(stmt).all()

--- a/app/dao/active_user_emails_dao.py
+++ b/app/dao/active_user_emails_dao.py
@@ -6,6 +6,7 @@ from app.model import User
 
 
 def get_active_business_contact_emails():
+    """Return distinct email addresses for users with active business_contact role assignments."""
     stmt = (
         select(User.email_address)
         .join(UserServiceRoles)
@@ -20,6 +21,7 @@ def get_active_business_contact_emails():
 
 
 def get_active_technical_contact_emails():
+    """Return distinct email addresses for users with active technical_contact role assignments."""
     stmt = (
         select(User.email_address)
         .join(UserServiceRoles)
@@ -34,6 +36,7 @@ def get_active_technical_contact_emails():
 
 
 def get_all_active_user_emails():
+    """Return distinct email addresses for all active users regardless of role assignment."""
     stmt = (
         select(User.email_address)
         .where(

--- a/app/dao/active_user_emails_dao.py
+++ b/app/dao/active_user_emails_dao.py
@@ -1,48 +1,56 @@
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from app import db
 from app.models import UserServiceRoles
 from app.model import User
 
 
+def _lowercase_deduplicate(emails: list[str]) -> list[str]:
+    unique_emails = {email.lower() for email in emails}
+    return sorted(list(unique_emails))
+
+
 def get_active_business_contact_emails():
-    """Return distinct email addresses for users with active business_contact role assignments."""
+    """Return lowercase distinct email addresses for users with active business_contact role assignments."""
     stmt = (
         select(User.email_address)
         .join(UserServiceRoles)
         .where(
             UserServiceRoles.role == 'business_contact',
             User.state == 'active',
+            func.lower(User.email_address).notlike('_archived%'),
         )
         .distinct()
     )
 
-    return db.session.scalars(stmt).all()
+    return _lowercase_deduplicate(db.session.scalars(stmt).all())
 
 
 def get_active_technical_contact_emails():
-    """Return distinct email addresses for users with active technical_contact role assignments."""
+    """Return lowercase distinct email addresses for users with active technical_contact role assignments."""
     stmt = (
         select(User.email_address)
         .join(UserServiceRoles)
         .where(
             UserServiceRoles.role == 'technical_contact',
             User.state == 'active',
+            func.lower(User.email_address).notlike('_archived%'),
         )
         .distinct()
     )
 
-    return db.session.scalars(stmt).all()
+    return _lowercase_deduplicate(db.session.scalars(stmt).all())
 
 
 def get_all_active_user_emails():
-    """Return distinct email addresses for all active users regardless of role assignment."""
+    """Return lowercase distinct email addresses for all active users regardless of role assignment."""
     stmt = (
         select(User.email_address)
         .where(
             User.state == 'active',
+            func.lower(User.email_address).notlike('_archived%'),
         )
         .distinct()
     )
 
-    return db.session.scalars(stmt).all()
+    return _lowercase_deduplicate(db.session.scalars(stmt).all())

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, date
 
+from botocore.exceptions import ClientError
 import pytest
 import pytz
 from sqlalchemy import delete
@@ -256,6 +257,21 @@ def test_export_active_user_email_lists_uploads_empty_bodies_when_lists_empty(no
     assert mock_boto.client.return_value.put_object.call_count == 3
     for _, kwargs in mock_boto.client.return_value.put_object.call_args_list:
         assert kwargs['Body'] == ''
+
+
+@freeze_time('2026-03-03T08:00:00')
+def test_export_active_user_email_lists_raises_when_s3_upload_fails(notify_api, mocker):
+    mocker.patch('app.celery.nightly_tasks.get_active_business_contact_emails', return_value=['business@va.gov'])
+    mocker.patch('app.celery.nightly_tasks.get_active_technical_contact_emails', return_value=['tech@va.gov'])
+    mocker.patch('app.celery.nightly_tasks.get_all_active_user_emails', return_value=['all@va.gov'])
+
+    error_response = {'Error': {'Code': '500', 'Message': 'boom'}}
+    mock_boto = mocker.patch('app.celery.nightly_tasks.boto3')
+    mock_boto.client.return_value.put_object.side_effect = ClientError(error_response, 'PutObject')
+
+    with set_config_values(notify_api, {'NOTIFY_ENVIRONMENT': 'staging', 'USER_EXPORT_BUCKET_NAME': 'bucket-name'}):
+        with pytest.raises(ClientError):
+            export_active_user_email_lists()
 
 
 @pytest.mark.serial

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -216,32 +216,14 @@ def test_export_active_user_email_lists_uploads_expected_files_in_staging(notify
         export_active_user_email_lists()
 
     assert mock_boto.client.return_value.put_object.call_count == 3
-    assert mock_boto.client.return_value.put_object.call_args_list == [
-        (
-            (),
-            {
-                'Body': 'business1@va.gov,business2@va.gov',
-                'Bucket': 'bucket-name',
-                'Key': 'user-exports/2026-03-03/business_contacts.txt',
-            },
-        ),
-        (
-            (),
-            {
-                'Body': 'tech1@va.gov,tech2@va.gov',
-                'Bucket': 'bucket-name',
-                'Key': 'user-exports/2026-03-03/technical_contacts.txt',
-            },
-        ),
-        (
-            (),
-            {
-                'Body': 'a@va.gov,z@va.gov',
-                'Bucket': 'bucket-name',
-                'Key': 'user-exports/2026-03-03/all_active_users.txt',
-            },
-        ),
-    ]
+    expected_bodies = {
+        'user-exports/2026-03-03/business_contacts.txt': 'business1@va.gov,business2@va.gov',
+        'user-exports/2026-03-03/technical_contacts.txt': 'tech1@va.gov,tech2@va.gov',
+        'user-exports/2026-03-03/all_active_users.txt': 'a@va.gov,z@va.gov',
+    }
+    for _, kwargs in mock_boto.client.return_value.put_object.call_args_list:
+        assert kwargs['Bucket'] == 'bucket-name'
+        assert kwargs['Body'] == expected_bodies[kwargs['Key']]
 
 
 def test_export_active_user_email_lists_noops_outside_staging(notify_api, mocker):

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -200,7 +200,7 @@ def test_should_call_delete_letter_notifications_more_than_week_in_task(notify_a
 
 @freeze_time('2026-03-03T08:00:00')
 def test_export_active_user_email_lists_uploads_expected_files_in_staging(notify_api, mocker):
-    """Export task uploads all three role-based files with sorted comma-separated content in staging."""
+    """Export task uploads all three role-based files with sorted semicolon-separated content in staging."""
     mocker.patch(
         'app.celery.nightly_tasks.get_active_business_contact_emails',
         return_value=['business2@va.gov', 'business1@va.gov'],
@@ -217,9 +217,9 @@ def test_export_active_user_email_lists_uploads_expected_files_in_staging(notify
 
     assert mock_boto.client.return_value.put_object.call_count == 3
     expected_bodies = {
-        'user-exports/2026-03-03/business_contacts.txt': 'business1@va.gov,business2@va.gov',
-        'user-exports/2026-03-03/technical_contacts.txt': 'tech1@va.gov,tech2@va.gov',
-        'user-exports/2026-03-03/all_active_users.txt': 'a@va.gov,z@va.gov',
+        'user-exports/2026-03-03/business_contacts.txt': 'business1@va.gov;business2@va.gov',
+        'user-exports/2026-03-03/technical_contacts.txt': 'tech1@va.gov;tech2@va.gov',
+        'user-exports/2026-03-03/all_active_users.txt': 'a@va.gov;z@va.gov',
     }
     for _, kwargs in mock_boto.client.return_value.put_object.call_args_list:
         assert kwargs['Bucket'] == 'bucket-name'

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -16,6 +16,7 @@ from app.celery.nightly_tasks import (
     delete_inbound_sms,
     delete_letter_notifications_older_than_retention,
     delete_sms_notifications_older_than_retention,
+    export_active_user_email_lists,
     raise_alert_if_letter_notifications_still_sending,
     remove_letter_csv_files,
     remove_sms_email_csv_files,
@@ -47,6 +48,7 @@ from tests.app.db import (
 from app.models import FactNotificationStatus
 
 from tests.app.conftest import datetime_in_past
+from tests.conftest import set_config_values
 
 
 def mock_s3_get_list_match(bucket_name, subfolder='', suffix='', last_modified=None):
@@ -194,6 +196,84 @@ def test_should_call_delete_letter_notifications_more_than_week_in_task(notify_a
     mocked = mocker.patch('app.celery.nightly_tasks.delete_notifications_older_than_retention_by_type')
     delete_letter_notifications_older_than_retention()
     mocked.assert_called_once_with(LETTER_TYPE)
+
+
+@freeze_time('2026-03-03T08:00:00')
+def test_export_active_user_email_lists_uploads_expected_files_in_staging(notify_api, mocker):
+    """Export task uploads all three role-based files with sorted comma-separated content in staging."""
+    mocker.patch(
+        'app.celery.nightly_tasks.get_active_business_contact_emails',
+        return_value=['business2@va.gov', 'business1@va.gov'],
+    )
+    mocker.patch(
+        'app.celery.nightly_tasks.get_active_technical_contact_emails',
+        return_value=['tech2@va.gov', 'tech1@va.gov'],
+    )
+    mocker.patch('app.celery.nightly_tasks.get_all_active_user_emails', return_value=['z@va.gov', 'a@va.gov'])
+    mock_boto = mocker.patch('app.celery.nightly_tasks.boto3')
+
+    with set_config_values(notify_api, {'NOTIFY_ENVIRONMENT': 'staging', 'USER_EXPORT_BUCKET_NAME': 'bucket-name'}):
+        export_active_user_email_lists()
+
+    assert mock_boto.client.return_value.put_object.call_count == 3
+    assert mock_boto.client.return_value.put_object.call_args_list == [
+        (
+            (),
+            {
+                'Body': 'business1@va.gov,business2@va.gov',
+                'Bucket': 'bucket-name',
+                'Key': 'user-exports/2026-03-03/business_contacts.txt',
+            },
+        ),
+        (
+            (),
+            {
+                'Body': 'tech1@va.gov,tech2@va.gov',
+                'Bucket': 'bucket-name',
+                'Key': 'user-exports/2026-03-03/technical_contacts.txt',
+            },
+        ),
+        (
+            (),
+            {
+                'Body': 'a@va.gov,z@va.gov',
+                'Bucket': 'bucket-name',
+                'Key': 'user-exports/2026-03-03/all_active_users.txt',
+            },
+        ),
+    ]
+
+
+def test_export_active_user_email_lists_noops_outside_staging(notify_api, mocker):
+    """Export task exits without DAO or S3 calls when environment is not staging."""
+    mock_business = mocker.patch('app.celery.nightly_tasks.get_active_business_contact_emails')
+    mock_tech = mocker.patch('app.celery.nightly_tasks.get_active_technical_contact_emails')
+    mock_all = mocker.patch('app.celery.nightly_tasks.get_all_active_user_emails')
+    mock_boto = mocker.patch('app.celery.nightly_tasks.boto3')
+
+    with set_config_values(notify_api, {'NOTIFY_ENVIRONMENT': 'development'}):
+        export_active_user_email_lists()
+
+    mock_business.assert_not_called()
+    mock_tech.assert_not_called()
+    mock_all.assert_not_called()
+    mock_boto.client.return_value.put_object.assert_not_called()
+
+
+@freeze_time('2026-03-03T08:00:00')
+def test_export_active_user_email_lists_uploads_empty_bodies_when_lists_empty(notify_api, mocker):
+    """Export task still uploads expected files with empty bodies when no emails are returned."""
+    mocker.patch('app.celery.nightly_tasks.get_active_business_contact_emails', return_value=[])
+    mocker.patch('app.celery.nightly_tasks.get_active_technical_contact_emails', return_value=[])
+    mocker.patch('app.celery.nightly_tasks.get_all_active_user_emails', return_value=[])
+    mock_boto = mocker.patch('app.celery.nightly_tasks.boto3')
+
+    with set_config_values(notify_api, {'NOTIFY_ENVIRONMENT': 'staging', 'USER_EXPORT_BUCKET_NAME': 'bucket-name'}):
+        export_active_user_email_lists()
+
+    assert mock_boto.client.return_value.put_object.call_count == 3
+    for _, kwargs in mock_boto.client.return_value.put_object.call_args_list:
+        assert kwargs['Body'] == ''
 
 
 @pytest.mark.serial

--- a/tests/app/dao/test_active_user_emails_dao.py
+++ b/tests/app/dao/test_active_user_emails_dao.py
@@ -228,3 +228,126 @@ def test_email_values_are_returned_as_is_for_invalid_email_strings(
         assert 'not-an-email' in all_active_emails
     finally:
         _cleanup_user_service_roles(notify_db_session, role_ids)
+
+
+@pytest.mark.serial
+def test_get_active_business_contact_emails_lowercases_and_deduplicates_mixed_case_addresses(
+    notify_db_session,
+    sample_service,
+    sample_user,
+):
+    role_ids = []
+    service = sample_service()
+    lower_user = sample_user(email='john@va.gov')
+    mixed_user = sample_user(email='John@VA.gov')
+
+    role_ids.append(_add_user_service_role(notify_db_session, lower_user.id, service.id, 'business_contact').id)
+    role_ids.append(_add_user_service_role(notify_db_session, mixed_user.id, service.id, 'business_contact').id)
+
+    try:
+        emails = get_active_business_contact_emails()
+        assert emails == ['john@va.gov']
+    finally:
+        _cleanup_user_service_roles(notify_db_session, role_ids)
+
+
+@pytest.mark.serial
+def test_get_active_technical_contact_emails_lowercases_and_deduplicates_mixed_case_addresses(
+    notify_db_session,
+    sample_service,
+    sample_user,
+):
+    role_ids = []
+    service = sample_service()
+    upper_user = sample_user(email='JANE@VA.GOV')
+    mixed_user = sample_user(email='Jane@va.gov')
+
+    role_ids.append(_add_user_service_role(notify_db_session, upper_user.id, service.id, 'technical_contact').id)
+    role_ids.append(_add_user_service_role(notify_db_session, mixed_user.id, service.id, 'technical_contact').id)
+
+    try:
+        emails = get_active_technical_contact_emails()
+        assert emails == ['jane@va.gov']
+    finally:
+        _cleanup_user_service_roles(notify_db_session, role_ids)
+
+
+@pytest.mark.serial
+def test_get_all_active_user_emails_lowercases_and_deduplicates_mixed_case_addresses(
+    sample_user,
+):
+    sample_user(email='ALICE@VA.GOV', state='active')
+    sample_user(email='Alice@va.gov', state='active')
+
+    emails = get_all_active_user_emails()
+
+    assert emails.count('alice@va.gov') == 1
+
+
+@pytest.mark.serial
+def test_user_email_appears_in_role_specific_and_all_active_lists(
+    notify_db_session,
+    sample_service,
+    sample_user,
+):
+    role_ids = []
+    user = sample_user(email='unique@va.gov', state='active')
+    service = sample_service()
+
+    role_ids.append(_add_user_service_role(notify_db_session, user.id, service.id, 'business_contact').id)
+
+    try:
+        business_emails = get_active_business_contact_emails()
+        all_active_emails = get_all_active_user_emails()
+
+        assert 'unique@va.gov' in business_emails
+        assert 'unique@va.gov' in all_active_emails
+    finally:
+        _cleanup_user_service_roles(notify_db_session, role_ids)
+
+
+@pytest.mark.serial
+def test_get_active_user_email_queries_exclude_archived_prefixed_emails(
+    notify_db_session,
+    sample_service,
+    sample_user,
+):
+    role_ids = []
+    service = sample_service()
+
+    active_business_user = sample_user(email='business-ok@va.gov', state='active')
+    active_technical_user = sample_user(email='technical-ok@va.gov', state='active')
+    archived_business_user = sample_user(email='_archived-business@va.gov', state='active')
+    archived_technical_user = sample_user(email='_ARCHIVED-technical@va.gov', state='active')
+
+    role_ids.append(
+        _add_user_service_role(notify_db_session, active_business_user.id, service.id, 'business_contact').id
+    )
+    role_ids.append(
+        _add_user_service_role(notify_db_session, active_technical_user.id, service.id, 'technical_contact').id
+    )
+    role_ids.append(
+        _add_user_service_role(notify_db_session, archived_business_user.id, service.id, 'business_contact').id
+    )
+    role_ids.append(
+        _add_user_service_role(notify_db_session, archived_technical_user.id, service.id, 'technical_contact').id
+    )
+
+    try:
+        business_emails = get_active_business_contact_emails()
+        technical_emails = get_active_technical_contact_emails()
+        all_active_emails = get_all_active_user_emails()
+
+        assert 'business-ok@va.gov' in business_emails
+        assert '_archived-business@va.gov' not in business_emails
+
+        assert 'technical-ok@va.gov' in technical_emails
+        assert '_archived-technical@va.gov' not in technical_emails
+
+        assert 'business-ok@va.gov' in all_active_emails
+        assert 'technical-ok@va.gov' in all_active_emails
+        assert '_archived-business@va.gov' not in all_active_emails
+        assert '_archived-technical@va.gov' not in all_active_emails
+        assert '_archived-all@va.gov' not in all_active_emails
+    finally:
+        _cleanup_user_service_roles(notify_db_session, role_ids)

--- a/tests/app/dao/test_active_user_emails_dao.py
+++ b/tests/app/dao/test_active_user_emails_dao.py
@@ -1,0 +1,230 @@
+import pytest
+
+from app.dao.active_user_emails_dao import (
+    get_active_business_contact_emails,
+    get_active_technical_contact_emails,
+    get_all_active_user_emails,
+)
+from app.models import UserServiceRoles
+from sqlalchemy import delete
+
+
+def _add_user_service_role(notify_db_session, user_id, service_id, role):
+    user_service_role = UserServiceRoles(
+        user_id=user_id,
+        service_id=service_id,
+        role=role,
+    )
+    notify_db_session.session.add(user_service_role)
+    notify_db_session.session.commit()
+    return user_service_role
+
+
+def _cleanup_user_service_roles(notify_db_session, role_ids):
+    stmt = delete(UserServiceRoles).where(UserServiceRoles.id.in_(role_ids))
+    notify_db_session.session.execute(stmt)
+    notify_db_session.session.commit()
+
+
+@pytest.mark.serial
+def test_get_active_business_contact_emails_returns_active_business_contacts_only(
+    notify_db_session,
+    sample_service,
+    sample_user,
+):
+    role_ids = []
+    service = sample_service()
+
+    active_business_user = sample_user(email='business-contact@va.gov')
+    active_technical_user = sample_user(email='technical-contact@va.gov')
+    inactive_business_user = sample_user(email='inactive-business@va.gov', state='inactive')
+
+    role_ids.append(
+        _add_user_service_role(notify_db_session, active_business_user.id, service.id, 'business_contact').id
+    )
+    role_ids.append(
+        _add_user_service_role(notify_db_session, active_technical_user.id, service.id, 'technical_contact').id
+    )
+    role_ids.append(
+        _add_user_service_role(notify_db_session, inactive_business_user.id, service.id, 'business_contact').id
+    )
+
+    try:
+        emails = get_active_business_contact_emails()
+        assert set(emails) == {'business-contact@va.gov'}
+    finally:
+        _cleanup_user_service_roles(notify_db_session, role_ids)
+
+
+@pytest.mark.serial
+def test_get_active_technical_contact_emails_returns_active_technical_contacts_only(
+    notify_db_session,
+    sample_service,
+    sample_user,
+):
+    role_ids = []
+    service = sample_service()
+
+    active_business_user = sample_user(email='business-contact-2@va.gov')
+    active_technical_user = sample_user(email='technical-contact-2@va.gov')
+    inactive_technical_user = sample_user(email='inactive-technical@va.gov', state='inactive')
+
+    role_ids.append(
+        _add_user_service_role(notify_db_session, active_business_user.id, service.id, 'business_contact').id
+    )
+    role_ids.append(
+        _add_user_service_role(notify_db_session, active_technical_user.id, service.id, 'technical_contact').id
+    )
+    role_ids.append(
+        _add_user_service_role(notify_db_session, inactive_technical_user.id, service.id, 'technical_contact').id
+    )
+
+    try:
+        emails = get_active_technical_contact_emails()
+        assert set(emails) == {'technical-contact-2@va.gov'}
+    finally:
+        _cleanup_user_service_roles(notify_db_session, role_ids)
+
+
+@pytest.mark.serial
+def test_get_all_active_user_emails_returns_all_active_users(
+    notify_db_session,
+    sample_service,
+    sample_user,
+):
+    role_ids = []
+    service = sample_service()
+
+    active_business_user = sample_user(email='all-active-business@va.gov')
+    sample_user(email='all-active-no-role@va.gov')
+    sample_user(email='all-active-inactive@va.gov', state='inactive')
+
+    role_ids.append(
+        _add_user_service_role(notify_db_session, active_business_user.id, service.id, 'business_contact').id
+    )
+
+    try:
+        emails = get_all_active_user_emails()
+        assert 'all-active-business@va.gov' in emails
+        assert 'all-active-no-role@va.gov' in emails
+        assert 'all-active-inactive@va.gov' not in emails
+    finally:
+        _cleanup_user_service_roles(notify_db_session, role_ids)
+
+
+@pytest.mark.serial
+def test_get_active_business_contact_emails_returns_empty_when_no_business_contacts(
+    notify_db_session,
+    sample_service,
+    sample_user,
+):
+    role_ids = []
+    service = sample_service()
+    active_technical_user = sample_user(email='no-business-tech@va.gov')
+
+    role_ids.append(
+        _add_user_service_role(notify_db_session, active_technical_user.id, service.id, 'technical_contact').id
+    )
+
+    try:
+        emails = get_active_business_contact_emails()
+        assert emails == []
+    finally:
+        _cleanup_user_service_roles(notify_db_session, role_ids)
+
+
+@pytest.mark.serial
+def test_get_active_technical_contact_emails_returns_empty_when_no_technical_contacts(
+    notify_db_session,
+    sample_service,
+    sample_user,
+):
+    role_ids = []
+    service = sample_service()
+    active_business_user = sample_user(email='no-technical-business@va.gov')
+
+    role_ids.append(
+        _add_user_service_role(notify_db_session, active_business_user.id, service.id, 'business_contact').id
+    )
+
+    try:
+        emails = get_active_technical_contact_emails()
+        assert emails == []
+    finally:
+        _cleanup_user_service_roles(notify_db_session, role_ids)
+
+
+@pytest.mark.serial
+def test_get_all_active_user_emails_returns_empty_when_no_active_users(
+    sample_user,
+):
+    sample_user(email='inactive-only-1@va.gov', state='inactive')
+    sample_user(email='inactive-only-2@va.gov', state='pending')
+
+    emails = get_all_active_user_emails()
+
+    assert emails == []
+
+
+@pytest.mark.serial
+def test_get_active_business_contact_emails_deduplicates_multiple_role_rows_for_same_user(
+    notify_db_session,
+    sample_service,
+    sample_user,
+):
+    role_ids = []
+    user = sample_user(email='duplicate-business@va.gov')
+    service_1 = sample_service(user=user)
+    service_2 = sample_service(user=user)
+
+    role_ids.append(_add_user_service_role(notify_db_session, user.id, service_1.id, 'business_contact').id)
+    role_ids.append(_add_user_service_role(notify_db_session, user.id, service_2.id, 'business_contact').id)
+
+    try:
+        emails = get_active_business_contact_emails()
+        assert emails.count('duplicate-business@va.gov') == 1
+    finally:
+        _cleanup_user_service_roles(notify_db_session, role_ids)
+
+
+@pytest.mark.serial
+def test_get_active_technical_contact_emails_deduplicates_multiple_role_rows_for_same_user(
+    notify_db_session,
+    sample_service,
+    sample_user,
+):
+    role_ids = []
+    user = sample_user(email='duplicate-technical@va.gov')
+    service_1 = sample_service(user=user)
+    service_2 = sample_service(user=user)
+
+    role_ids.append(_add_user_service_role(notify_db_session, user.id, service_1.id, 'technical_contact').id)
+    role_ids.append(_add_user_service_role(notify_db_session, user.id, service_2.id, 'technical_contact').id)
+
+    try:
+        emails = get_active_technical_contact_emails()
+        assert emails.count('duplicate-technical@va.gov') == 1
+    finally:
+        _cleanup_user_service_roles(notify_db_session, role_ids)
+
+
+@pytest.mark.serial
+def test_email_values_are_returned_as_is_for_invalid_email_strings(
+    notify_db_session,
+    sample_service,
+    sample_user,
+):
+    role_ids = []
+    service = sample_service()
+    invalid_email_user = sample_user(email='not-an-email', state='active')
+
+    role_ids.append(_add_user_service_role(notify_db_session, invalid_email_user.id, service.id, 'business_contact').id)
+
+    try:
+        business_emails = get_active_business_contact_emails()
+        all_active_emails = get_all_active_user_emails()
+
+        assert 'not-an-email' in business_emails
+        assert 'not-an-email' in all_active_emails
+    finally:
+        _cleanup_user_service_roles(notify_db_session, role_ids)


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This pull request adds a new nightly task to export lists of active user emails by role to S3, along with the necessary database access functions and tests. The export is currently restricted to the staging environment and includes business contacts, technical contacts, and all active users. The implementation includes configuration changes, new DAO functions, and testing to ensure correctness and coverage of edge cases.

**New nightly user email export feature:**

* Added a new Celery task `export_active_user_email_lists` in `app/celery/nightly_tasks.py` that uploads three files (business contacts, technical contacts, all active users) to S3 once per day, but only in the staging environment. Files are named with the current date and contain semicolon-separated, sorted email addresses.
* Added the new task to the periodic Celery schedule in `app/config.py`, set to run daily at 3:00 AM.
* Introduced a new configuration variable `USER_EXPORT_BUCKET_NAME` to specify the S3 bucket for exports.

**Database access and logic:**

* Implemented `get_active_business_contact_emails`, `get_active_technical_contact_emails`, and `get_all_active_user_emails` in `app/dao/active_user_emails_dao.py` to efficiently fetch distinct email addresses for each group, ensuring only active users are included and deduplicated.

**Testing and validation:**

* Added unit tests for the DAO functions in `tests/app/dao/test_active_user_emails_dao.py`, covering normal cases, empty results, deduplication, and invalid email values.
* Added tests for the new export task in `tests/app/celery/test_nightly_tasks.py`, verifying correct S3 uploads, environment restrictions, and handling of empty lists.

**Other:**

* S3 bucket was created in https://github.com/department-of-veterans-affairs/vanotify-infra/pull/1172. 

issue #2705 

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

* Added unit tests

* Log for task skipped as expected on dev. <img width="811" height="303" alt="Screenshot 2026-03-04 at 1 20 21 PM" src="https://github.com/user-attachments/assets/213bdb83-8be4-47c6-b928-16811b2e320c" />

* Testing on staging: Ensured that logs appeared as expected; files were uploaded correctly; file format is correct; file can be downloaded and emails copy pasted into Outlook.

<img width="805" height="308" alt="Screenshot 2026-03-04 at 2 15 45 PM" src="https://github.com/user-attachments/assets/63d6096e-4999-4a97-a2ce-442f513657a3" />
<img width="1635" height="465" alt="Screenshot 2026-03-04 at 2 02 00 PM" src="https://github.com/user-attachments/assets/93ffa451-6feb-4091-affd-c3285c313b35" />
<img width="1632" height="342" alt="Screenshot 2026-03-04 at 2 01 54 PM" src="https://github.com/user-attachments/assets/fdfef032-35f7-4ac4-a363-02f557931cd6" /> 

## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
