### PR TITLE
#2657 - Disallow updating created_by

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -113,4 +113,6 @@ fileignoreconfig:
   checksum: d2615670e4a594e06cfe5a2fc2d2dad0567e33a059aeaae68e346b3da2532750
 - filename: tests/lambda_functions/two_way_sms/test_two_way_sms_v2.py
   checksum: 295c93e5a929ea3d7afbea720dd5edcf435b0a96fe260b7538951f1f5c25a648
+- filename: app/provider_details/rest.py
+  checksum: 8473597858c316403d7c09d710680014bbe3d0a9ecef9aa703e287f83360adfe
 version: "1.0"

--- a/.talismanrc
+++ b/.talismanrc
@@ -115,4 +115,6 @@ fileignoreconfig:
   checksum: 295c93e5a929ea3d7afbea720dd5edcf435b0a96fe260b7538951f1f5c25a648
 - filename: app/provider_details/rest.py
   checksum: 8473597858c316403d7c09d710680014bbe3d0a9ecef9aa703e287f83360adfe
+- filename: app/schemas.py
+  checksum: 8e8f944477f7eeab1fe8f94dbfcfd12cd657225096d53aedd3440217290a37a7
 version: "1.0"

--- a/app/provider_details/rest.py
+++ b/app/provider_details/rest.py
@@ -6,7 +6,6 @@ from app.dao.provider_details_dao import (
     dao_get_provider_stats,
     dao_get_provider_versions,
 )
-from app.dao.users_dao import get_user_by_id
 from app.db import db
 from app.errors import register_errors, InvalidRequest
 from app.models import ProviderDetails
@@ -55,7 +54,7 @@ def get_provider_versions(provider_details_id):
 
 @provider_details.route('/<uuid:provider_details_id>', methods=['POST'])
 def update_provider_details(provider_details_id):
-    valid_keys = {'priority', 'created_by', 'active', 'load_balancing_weight'}
+    valid_keys = {'priority', 'active', 'load_balancing_weight'}
     req_json = request.get_json()
 
     invalid_keys = req_json.keys() - valid_keys
@@ -65,12 +64,6 @@ def update_provider_details(provider_details_id):
         raise InvalidRequest(errors, status_code=400)
 
     provider = db.session.get(ProviderDetails, provider_details_id)
-
-    # Handle created_by differently due to how history entry is created
-    if 'created_by' in req_json:
-        user = get_user_by_id(req_json['created_by'])
-        provider.created_by_id = user.id
-        req_json.pop('created_by')
 
     for key in req_json:
         setattr(provider, key, req_json[key])

--- a/app/provider_details/rest.py
+++ b/app/provider_details/rest.py
@@ -1,6 +1,11 @@
 from flask import Blueprint, jsonify, request
+from marshmallow import ValidationError
 
-from app.schemas import provider_details_schema, provider_details_history_schema
+from app.schemas import (
+    provider_details_schema,
+    provider_details_history_schema,
+    provider_details_update_request_schema,
+)
 from app.dao.provider_details_dao import (
     dao_update_provider_details,
     dao_get_provider_stats,
@@ -54,18 +59,11 @@ def get_provider_versions(provider_details_id):
 
 @provider_details.route('/<uuid:provider_details_id>', methods=['POST'])
 def update_provider_details(provider_details_id):
-    valid_keys = {'priority', 'active', 'load_balancing_weight'}
     req_json = request.get_json(silent=True)
-
-    if not isinstance(req_json, dict):
-        errors = {'request': ['JSON payload must be an object']}
-        raise InvalidRequest(errors, status_code=400)
-
-    invalid_keys = req_json.keys() - valid_keys
-    if invalid_keys:
-        message = 'Not permitted to be updated'
-        errors = {key: [message] for key in invalid_keys}
-        raise InvalidRequest(errors, status_code=400)
+    try:
+        provider_details_update_request_schema.load(req_json)
+    except ValidationError as exc:
+        raise InvalidRequest(exc.messages, status_code=400)
 
     provider = db.session.get(ProviderDetails, provider_details_id)
 

--- a/app/provider_details/rest.py
+++ b/app/provider_details/rest.py
@@ -55,7 +55,11 @@ def get_provider_versions(provider_details_id):
 @provider_details.route('/<uuid:provider_details_id>', methods=['POST'])
 def update_provider_details(provider_details_id):
     valid_keys = {'priority', 'active', 'load_balancing_weight'}
-    req_json = request.get_json()
+    req_json = request.get_json(silent=True)
+
+    if not isinstance(req_json, dict):
+        errors = {'request': ['JSON payload must be an object']}
+        raise InvalidRequest(errors, status_code=400)
 
     invalid_keys = req_json.keys() - valid_keys
     if invalid_keys:

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -28,6 +28,7 @@ from app.utils import get_template_instance
 from datetime import date, datetime, timedelta
 from flask_marshmallow.fields import fields
 from marshmallow import (
+    INCLUDE,
     post_load,
     ValidationError,
     validates,
@@ -1059,6 +1060,58 @@ class CommunicationItemSchema(BaseSchema):
         strict = True
 
 
+class ServiceUpdateRequestSchema(ma.Schema):
+    class Meta:
+        unknown = INCLUDE
+
+    @pre_load
+    def validate_request_payload(self, in_data, **kwargs):
+        if not isinstance(in_data, dict):
+            raise ValidationError({'request': ['JSON payload must be an object']})
+        return in_data
+
+    @validates_schema(pass_original=True)
+    def validate_immutable_fields(self, data, original_data, **kwargs):
+        if 'created_by' in original_data:
+            raise ValidationError({'created_by': ['Not permitted to be updated']})
+
+
+class TemplateUpdateRequestSchema(ma.Schema):
+    class Meta:
+        unknown = INCLUDE
+
+    @pre_load
+    def validate_request_payload(self, in_data, **kwargs):
+        if not isinstance(in_data, dict):
+            raise ValidationError({'request': ['JSON payload must be an object']})
+        return in_data
+
+    @validates_schema(pass_original=True)
+    def validate_immutable_fields(self, data, original_data, **kwargs):
+        is_redact_request = original_data.get('redact_personalisation') is True
+        if 'created_by' in original_data and not is_redact_request:
+            raise ValidationError({'created_by': ['Not permitted to be updated']})
+
+
+class ProviderDetailsUpdateRequestSchema(ma.Schema):
+    class Meta:
+        unknown = INCLUDE
+
+    _allowed_fields = {'priority', 'active', 'load_balancing_weight'}
+
+    @pre_load
+    def validate_request_payload(self, in_data, **kwargs):
+        if not isinstance(in_data, dict):
+            raise ValidationError({'request': ['JSON payload must be an object']})
+        return in_data
+
+    @validates_schema(pass_original=True)
+    def validate_allowed_fields(self, data, original_data, **kwargs):
+        invalid_keys = original_data.keys() - self._allowed_fields
+        if invalid_keys:
+            raise ValidationError({key: ['Not permitted to be updated'] for key in invalid_keys})
+
+
 # should not be used on its own for dumping - only for loading
 create_user_schema = UserSchema()
 user_update_schema_load_json = UserUpdateAttributeSchema(load_json=True, partial=True)
@@ -1092,3 +1145,6 @@ day_schema = DaySchema()
 unarchived_template_schema = UnarchivedTemplateSchema()
 service_callback_api_schema = ServiceCallbackSchema()
 communication_item_schema = CommunicationItemSchema()
+service_update_request_schema = ServiceUpdateRequestSchema()
+template_update_request_schema = TemplateUpdateRequestSchema()
+provider_details_update_request_schema = ProviderDetailsUpdateRequestSchema()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -130,7 +130,11 @@ def get_service_notification_statistics(service_id):
 @service_blueprint.route('/<uuid:service_id>', methods=['POST'])
 @requires_admin_basic_auth()
 def update_service(service_id):
-    req_json = request.get_json()
+    req_json = request.get_json(silent=True)
+
+    if not isinstance(req_json, dict):
+        errors = {'request': ['JSON payload must be an object']}
+        raise InvalidRequest(errors, status_code=400)
 
     if 'created_by' in req_json:
         message = 'Not permitted to be updated'
@@ -141,7 +145,7 @@ def update_service(service_id):
     # Capture the status change here as Marshmallow changes this later
     service_going_live = fetched_service.restricted and not req_json.get('restricted', True)
     current_data = service_schema.dump(fetched_service)
-    current_data.update(request.get_json())
+    current_data.update(req_json)
 
     service = service_schema.load(current_data)
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -132,6 +132,11 @@ def get_service_notification_statistics(service_id):
 def update_service(service_id):
     req_json = request.get_json()
 
+    if 'created_by' in req_json:
+        message = 'Not permitted to be updated'
+        errors = {'created_by': [message]}
+        raise InvalidRequest(errors, status_code=400)
+
     fetched_service = dao_fetch_service_by_id(service_id)
     # Capture the status change here as Marshmallow changes this later
     service_going_live = fetched_service.restricted and not req_json.get('restricted', True)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -8,6 +8,7 @@ from flask.wrappers import Response
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, DataError
 from sqlalchemy.orm.exc import NoResultFound
+from marshmallow import ValidationError
 
 from app import db
 from app.authentication.auth import requires_admin_basic_auth, requires_admin_auth_or_user_in_service
@@ -45,6 +46,7 @@ from app.schemas import (
     service_schema,
     api_key_schema,
     detailed_service_schema,
+    service_update_request_schema,
 )
 from app.service.utils import validate_expiry_date
 
@@ -131,15 +133,10 @@ def get_service_notification_statistics(service_id):
 @requires_admin_basic_auth()
 def update_service(service_id):
     req_json = request.get_json(silent=True)
-
-    if not isinstance(req_json, dict):
-        errors = {'request': ['JSON payload must be an object']}
-        raise InvalidRequest(errors, status_code=400)
-
-    if 'created_by' in req_json:
-        message = 'Not permitted to be updated'
-        errors = {'created_by': [message]}
-        raise InvalidRequest(errors, status_code=400)
+    try:
+        service_update_request_schema.load(req_json)
+    except ValidationError as exc:
+        raise InvalidRequest(exc.messages, status_code=400)
 
     fetched_service = dao_fetch_service_by_id(service_id)
     # Capture the status change here as Marshmallow changes this later

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -142,6 +142,11 @@ def update_template(
         # Don't update anything else.
         return redact_template(fetched_template, data)
 
+    if 'created_by' in data:
+        message = 'Not permitted to be updated'
+        errors = {'created_by': [message]}
+        raise InvalidRequest(errors, status_code=400)
+
     if 'reply_to' in data:
         check_reply_to(service_id, data.get('reply_to'), fetched_template.template_type)
         updated = dao_update_template_reply_to(template_id=template_id, reply_to=data.get('reply_to'))

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -136,7 +136,11 @@ def update_template(
 
         raise InvalidRequest(errors, 403)
 
-    data = request.get_json()
+    data = request.get_json(silent=True)
+
+    if not isinstance(data, dict):
+        errors = {'request': ['JSON payload must be an object']}
+        raise InvalidRequest(errors, status_code=400)
 
     if data.get('redact_personalisation') is True:
         # Don't update anything else.

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -8,6 +8,7 @@ from flask import (
     request,
 )
 from flask_jwt_extended import current_user
+from marshmallow import ValidationError
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.template import HTMLEmailTemplate, SMSMessageTemplate
 from notifications_utils.template2 import render_html_email, render_notify_markdown
@@ -35,7 +36,7 @@ from app.models import Template
 from app.notifications.validators import service_has_permission, check_reply_to, template_name_already_exists_on_service
 from app.provider_details import validate_providers
 from app.schema_validation import validate
-from app.schemas import template_schema, template_history_schema
+from app.schemas import template_schema, template_history_schema, template_update_request_schema
 from app.template.template_schemas import post_create_template_schema, template_stats_request
 from app.utils import get_public_notify_type_text
 
@@ -138,18 +139,14 @@ def update_template(
 
     data = request.get_json(silent=True)
 
-    if not isinstance(data, dict):
-        errors = {'request': ['JSON payload must be an object']}
-        raise InvalidRequest(errors, status_code=400)
+    try:
+        template_update_request_schema.load(data)
+    except ValidationError as exc:
+        raise InvalidRequest(exc.messages, status_code=400)
 
     if data.get('redact_personalisation') is True:
         # Don't update anything else.
         return redact_template(fetched_template, data)
-
-    if 'created_by' in data:
-        message = 'Not permitted to be updated'
-        errors = {'created_by': [message]}
-        raise InvalidRequest(errors, status_code=400)
 
     if 'reply_to' in data:
         check_reply_to(service_id, data.get('reply_to'), fetched_template.template_type)

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -544,7 +544,7 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
+              anyOf:
                 - $ref: "#/components/schemas/UpdateTemplateRequest"
                 - $ref: "#/components/schemas/RedactTemplateRequest"
       responses:

--- a/documents/openapi/openapi.yaml
+++ b/documents/openapi/openapi.yaml
@@ -139,7 +139,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Service"
+              $ref: "#/components/schemas/UpdateServiceRequest"
       responses:
         "200":
           description: OK
@@ -536,6 +536,7 @@ paths:
           $ref: "#/components/responses/InternalServerError"
     post:
       summary: Update a template
+      description: created_by is immutable for standard updates and only accepted for redact_personalisation requests.
       tags:
         - template
       requestBody:
@@ -543,7 +544,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateTemplateRequest"
+              oneOf:
+                - $ref: "#/components/schemas/UpdateTemplateRequest"
+                - $ref: "#/components/schemas/RedactTemplateRequest"
       responses:
         "200":
           description: OK
@@ -2049,6 +2052,103 @@ components:
         - template_type
         - content
         - service
+        - created_by
+    UpdateServiceRequest:
+      type: object
+      properties:
+        active:
+          type: boolean
+        consent_to_research:
+          type: boolean
+          nullable: true
+        count_as_live:
+          type: boolean
+        crown:
+          type: boolean
+          nullable: true
+        email_branding:
+          $ref: "#/components/schemas/Id"
+        email_from:
+          type: string
+          format: email
+        email_provider_id:
+          type: string
+          nullable: true
+        message_limit:
+          type: integer
+        name:
+          type: string
+        organisation_id:
+          type: string
+          format: uuid
+          nullable: true
+        organisation_type:
+          type: string
+        permissions:
+          type: array
+          items:
+            type: string
+        prefix_sms:
+          type: boolean
+        purchase_order_number:
+          type: string
+          nullable: true
+        rate_limit:
+          type: number
+          nullable: true
+        research_mode:
+          type: boolean
+        restricted:
+          type: boolean
+        sms_provider_id:
+          type: string
+          nullable: true
+        volume_email:
+          type: integer
+          nullable: true
+        volume_letter:
+          type: integer
+          nullable: true
+        volume_sms:
+          type: integer
+          nullable: true
+    UpdateTemplateRequest:
+      type: object
+      properties:
+        archived:
+          type: boolean
+        communication_item_id:
+          type: string
+          nullable: true
+        content:
+          type: string
+        name:
+          type: string
+        postage:
+          type: string
+        process_type:
+          type: string
+          enum:
+            - normal
+            - priority
+        provider_id:
+          type: string
+          nullable: true
+        reply_to:
+          $ref: "#/components/schemas/Id"
+        subject:
+          type: string
+    RedactTemplateRequest:
+      type: object
+      properties:
+        redact_personalisation:
+          type: boolean
+          enum:
+            - true
+        created_by:
+          $ref: "#/components/schemas/Id"
+      required:
+        - redact_personalisation
         - created_by
     CreateTemplateRequestSms:
       type: object

--- a/documents/postman/internal_api_developers/notification-api.postman_collection.json
+++ b/documents/postman/internal_api_developers/notification-api.postman_collection.json
@@ -3216,7 +3216,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\": \"main service for Govdelivery\",\n    \"user_id\": \"{{user-id}}\",\n    \"organisation_id\": \"{{organization-id}}\",\n    \"message_limit\": 1000,\n    \"restricted\": false,\n    \"active\": true,\n    \"email-from\": \"{{email-from}}\",\n    \"created_by\": \"{{user-id}}\"\n}"
+							"raw": "{\n    \"name\": \"main service for Govdelivery\",\n    \"user_id\": \"{{user-id}}\",\n    \"organisation_id\": \"{{organization-id}}\",\n    \"message_limit\": 1000,\n    \"restricted\": false,\n    \"active\": true,\n    \"email_from\": \"{{email-from}}\"\n}"
 						},
 						"url": {
 							"raw": "{{notification-api-url}}/service/{{service-id}}",

--- a/documents/postman/internal_api_developers/notification-api.postman_collection.json
+++ b/documents/postman/internal_api_developers/notification-api.postman_collection.json
@@ -3216,7 +3216,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\": \"main service for Govdelivery\",\n    \"user_id\": \"{{user-id}}\",\n    \"organisation_id\": \"{{organization-id}}\",\n    \"message_limit\": 1000,\n    \"restricted\": false,\n    \"active\": true,\n    \"email_from\": \"{{email-from}}\"\n}"
+							"raw": "{\n    \"name\": \"main service for Govdelivery\",\n    \"organisation_id\": \"{{organization-id}}\",\n    \"message_limit\": 1000,\n    \"restricted\": false,\n    \"active\": true,\n    \"email_from\": \"{{email-from}}\"\n}"
 						},
 						"url": {
 							"raw": "{{notification-api-url}}/service/{{service-id}}",

--- a/tests/app/provider_details/test_rest.py
+++ b/tests/app/provider_details/test_rest.py
@@ -133,7 +133,7 @@ class TestUpdate:
         assert resp_json['result'] == 'error'
         assert resp.status_code == 400
 
-    def test_update_provider_should_store_user_id(
+    def test_update_provider_should_not_allow_created_by_update(
         self,
         client,
         sample_provider,
@@ -148,11 +148,11 @@ class TestUpdate:
             headers=[('Content-Type', 'application/json'), create_admin_authorization_header()],
             data=json.dumps({'created_by': user_update.id, 'active': False}),
         )
-        assert update_resp_1.status_code == 200
-        update_resp_1 = update_resp_1.get_json()['provider_details']
-        assert update_resp_1['identifier'] == provider.identifier
-        assert not update_resp_1['active']
-        assert not provider.active
+        assert update_resp_1.status_code == 400
+        update_resp_1 = update_resp_1.get_json()
+        assert update_resp_1 == {'result': 'error', 'message': {'created_by': ['Not permitted to be updated']}}
+        assert provider.active
+        assert provider.created_by_id == user_start.id
 
     def test_should_be_able_to_update_load_balancing_weight(
         self,

--- a/tests/app/provider_details/test_rest.py
+++ b/tests/app/provider_details/test_rest.py
@@ -154,6 +154,24 @@ class TestUpdate:
         assert provider.active
         assert provider.created_by_id == user_start.id
 
+    @pytest.mark.parametrize('payload', ['null', '[]'])
+    def test_update_provider_returns_400_for_non_object_json_payload(
+        self,
+        client,
+        sample_provider,
+        payload,
+    ):
+        provider = sample_provider()
+
+        resp = client.post(
+            '/provider-details/{}'.format(provider.id),
+            headers=[('Content-Type', 'application/json'), create_admin_authorization_header()],
+            data=payload,
+        )
+
+        assert resp.status_code == 400
+        assert resp.get_json() == {'result': 'error', 'message': {'request': ['JSON payload must be an object']}}
+
     def test_should_be_able_to_update_load_balancing_weight(
         self,
         client,

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -256,6 +256,21 @@ def test_should_not_allow_updating_service_created_by(admin_request, sample_serv
     assert response == {'result': 'error', 'message': {'created_by': ['Not permitted to be updated']}}
 
 
+@pytest.mark.parametrize('payload', ['null', '[]'])
+def test_update_service_returns_400_for_non_object_json_payload(client, sample_service, payload):
+    service = sample_service()
+    auth_header = create_admin_authorization_header()
+
+    resp = client.post(
+        f'/service/{service.id}',
+        data=payload,
+        headers=[('Content-Type', 'application/json'), auth_header],
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {'result': 'error', 'message': {'request': ['JSON payload must be an object']}}
+
+
 def test_update_service_with_valid_provider(
     notify_api,
     admin_request,

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -224,7 +224,6 @@ def test_update_service(
     data = {
         'name': f'updated service name {uuid4()}',
         'email_from': 'updated.service.name',
-        'created_by': str(service.created_by.id),
         'organisation_type': 'other',
     }
 
@@ -241,6 +240,20 @@ def test_update_service(
     assert result['data']['email_from'] == 'updated.service.name'
     assert result['data']['organisation_type'] == 'other'
     assert result['data']['email_branding'] is None
+
+
+def test_should_not_allow_updating_service_created_by(admin_request, sample_service, sample_user):
+    service = sample_service()
+    new_user = sample_user()
+
+    response = admin_request.post(
+        'service.update_service',
+        service_id=service.id,
+        _data={'created_by': str(new_user.id)},
+        _expected_status=400,
+    )
+
+    assert response == {'result': 'error', 'message': {'created_by': ['Not permitted to be updated']}}
 
 
 def test_update_service_with_valid_provider(
@@ -332,7 +345,6 @@ def test_cant_update_service_org_type_to_random_value(client, sample_service):
     data = {
         'name': 'updated service name',
         'email_from': 'updated.service.name',
-        'created_by': str(service.created_by.id),
         'organisation_type': 'foo',
     }
 

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -715,6 +715,21 @@ def test_update_400_if_created_by_is_in_payload(client, sample_template, sample_
     assert resp.get_json() == {'result': 'error', 'message': {'created_by': ['Not permitted to be updated']}}
 
 
+@pytest.mark.parametrize('payload', ['null', '[]'])
+def test_update_template_returns_400_for_non_object_json_payload(client, sample_template, payload):
+    template = sample_template()
+    auth_header = create_admin_authorization_header()
+
+    resp = client.post(
+        f'/service/{template.service.id}/template/{template.id}',
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=payload,
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {'result': 'error', 'message': {'request': ['JSON payload must be an object']}}
+
+
 def test_should_return_all_template_versions_for_service_and_template_id(client, notify_db_session, sample_template):
     template = sample_template()
     original_content = template.content

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -394,7 +394,7 @@ def test_should_be_error_on_update_if_no_permission(
     service = sample_service(user=user, service_permissions=permissions)
     template = sample_template(service=service, template_type=template_type)
 
-    data = {'content': 'new template content', 'created_by': str(user.id)}
+    data = {'content': 'new template content'}
 
     data = json.dumps(data)
     auth_header = create_admin_authorization_header()
@@ -470,7 +470,7 @@ def test_must_have_a_subject_on_an_email_or_letter_template(client, sample_user,
     assert json_resp['errors'][0]['message'] == 'subject is a required property'
 
 
-def test_update_should_update_a_template(client, sample_user, sample_service, sample_template):
+def test_update_should_update_a_template(client, sample_service, sample_template):
     service = sample_service(service_permissions=[SMS_TYPE])
     template = sample_template(service=service, template_type=SMS_TYPE)
 
@@ -478,7 +478,6 @@ def test_update_should_update_a_template(client, sample_user, sample_service, sa
     data = json.dumps(
         {
             'content': new_content,
-            'created_by': str(sample_user().id),
         }
     )
 
@@ -507,7 +506,6 @@ def test_should_be_able_to_archive_template(notify_db_session, client, sample_te
         'content': template.content,
         'archived': True,
         'service': str(template.service.id),
-        'created_by': str(template.created_by.id),
     }
 
     json_data = json.dumps(data)
@@ -687,7 +685,6 @@ def test_update_400_for_over_limit_content(client, sample_template):
                 random.choice(string.ascii_uppercase + string.digits)
                 for _ in range(SMS_CHAR_COUNT_LIMIT + 1)  # nosec
             ),
-            'created_by': str(template.created_by_id),
         }
     )
     auth_header = create_admin_authorization_header()
@@ -701,6 +698,21 @@ def test_update_400_for_over_limit_content(client, sample_template):
     assert ('Content has a character count greater than the limit of {}').format(SMS_CHAR_COUNT_LIMIT) in json_resp[
         'message'
     ]['content']
+
+
+def test_update_400_if_created_by_is_in_payload(client, sample_template, sample_user):
+    template = sample_template()
+    other_user = sample_user()
+
+    auth_header = create_admin_authorization_header()
+    resp = client.post(
+        f'/service/{template.service.id}/template/{template.id}',
+        headers=[('Content-Type', 'application/json'), auth_header],
+        data=json.dumps({'content': 'new content', 'created_by': str(other_user.id)}),
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {'result': 'error', 'message': {'created_by': ['Not permitted to be updated']}}
 
 
 def test_should_return_all_template_versions_for_service_and_template_id(client, notify_db_session, sample_template):


### PR DESCRIPTION
<!--
Before you open this PR, make sure that you review and are taking steps to follow [the Definition of Mergeable in our team agreement](https://docs.google.com/document/d/1nwZIF_lydPWfvixxZlQLNt4nqy3Qp13pHQnMcYJjTqE/edit#heading=h.6mnhaqm79e12). You may need to scroll down to that subheader.
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

issue #2657 

This pull request introduces stricter validation and schema enforcement for update endpoints across services, templates, and provider details. It centralizes request validation logic using Marshmallow schemas, ensuring immutable fields like `created_by` cannot be updated via standard requests. The OpenAPI documentation and Postman collections are updated to reflect these API changes. Tests have been updated and expanded to cover the new validation behavior.

**Validation and Schema Enforcement Improvements:**

* Introduced Marshmallow schemas (`ServiceUpdateRequestSchema`, `TemplateUpdateRequestSchema`, `ProviderDetailsUpdateRequestSchema`) to validate update requests for services, templates, and provider details, ensuring only allowed fields can be updated and that payloads are JSON objects. ([[1]](diffhunk://#diff-743c8db0af830ae358f828cadf2faa7caaa075029cdce9bd4650ed51ca80038fR1063-R1114), [[2]](diffhunk://#diff-743c8db0af830ae358f828cadf2faa7caaa075029cdce9bd4650ed51ca80038fR1148-R1150))
* Updated endpoint implementations in `app/service/rest.py`, `app/template/rest.py`, and `app/provider_details/rest.py` to use these schemas for validation, raising errors for disallowed fields (like `created_by`) and invalid payloads. ([[1]](diffhunk://#diff-02a4832ab85a57344c4179cf331c533fa2bf4367833127a54e479dcf986a66d3L133-R145), [[2]](diffhunk://#diff-bda89c7cb0b4c7bc98a8e1661a4c26854c0588f71dd62ef9aecb04e3905c90fdL139-R145), [[3]](diffhunk://#diff-b6136dad2db44c5ff68ba603e8edb6c25f780debf496da2b0dc02434b04f59ceL58-L74))

**API Documentation and Example Updates:**

* Updated OpenAPI spec to define new request schemas (`UpdateServiceRequest`, `UpdateTemplateRequest`, `RedactTemplateRequest`) and clarified that `created_by` is immutable except for redact requests. ([[1]](diffhunk://#diff-8d9baec3af9d669f884d1bdbccc99c4aa7194372625342c96fa33188941071c6R2056-R2152), [[2]](diffhunk://#diff-8d9baec3af9d669f884d1bdbccc99c4aa7194372625342c96fa33188941071c6R539-R549), [[3]](diffhunk://#diff-8d9baec3af9d669f884d1bdbccc99c4aa7194372625342c96fa33188941071c6L142-R142))
* Adjusted the Postman collection example to remove `created_by` from service update requests. ([documents/postman/internal_api_developers/notification-api.postman_collection.jsonL3219-R3219](diffhunk://#diff-4de8b603a00392bd9841bdfb380fc0fa4bb63306d296003298d47b8908966d4eL3219-R3219))

**Test Suite Enhancements:**

* Updated and added tests to ensure that attempts to update immutable fields like `created_by` return 400 errors, and that non-object JSON payloads are rejected for update endpoints. ([[1]](diffhunk://#diff-7bf752221363ca0b2a2614d4c296d86e3d7b81b010fde7491340d7729a489db7L136-R136), [[2]](diffhunk://#diff-7bf752221363ca0b2a2614d4c296d86e3d7b81b010fde7491340d7729a489db7L151-R173), [[3]](diffhunk://#diff-86688977a89b4089fa4a10492ec27faa0685c3c45d2f10d47096ab77303c914bR245-R273), [[4]](diffhunk://#diff-86688977a89b4089fa4a10492ec27faa0685c3c45d2f10d47096ab77303c914bL335), [[5]](diffhunk://#diff-f2bd2df1cd6d5469a622d100bc0811a577ed042b839b5db51132107a254d376bL397-R397), [[6]](diffhunk://#diff-f2bd2df1cd6d5469a622d100bc0811a577ed042b839b5db51132107a254d376bL473-L481), [[7]](diffhunk://#diff-f2bd2df1cd6d5469a622d100bc0811a577ed042b839b5db51132107a254d376bL510), [[8]](diffhunk://#diff-f2bd2df1cd6d5469a622d100bc0811a577ed042b839b5db51132107a254d376bL690))

**Internal Configuration:**

* Updated `.talismanrc` to ignore new files for provider details and schemas. ([.talismanrcR116-R119](diffhunk://#diff-efcd051724f24a743f7e1d572b337b61f6a1137ea138173c59346095eedd972aR116-R119))

**Dependency Imports:**

* Added missing imports for `ValidationError` where schema validation is now enforced. ([[1]](diffhunk://#diff-b6136dad2db44c5ff68ba603e8edb6c25f780debf496da2b0dc02434b04f59ceR2-L9), [[2]](diffhunk://#diff-02a4832ab85a57344c4179cf331c533fa2bf4367833127a54e479dcf986a66d3R11), [[3]](diffhunk://#diff-bda89c7cb0b4c7bc98a8e1661a4c26854c0588f71dd62ef9aecb04e3905c90fdR11))

These changes ensure more robust, predictable, and secure update operations across the API.

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
How has this been tested? (e.g. Unit tests, Tested locally, Tested as a GitHub action, Depoyed to dev, etc)  
Please provide relevant information and / or links to demonstrate the functionality or fix. (e.g. screenshots, link to deployment, regression test results, etc)
-->

- Updated `rest` tests
- Tested in dev and ensured correct response was returned when attempting to updated service `created_by`, template `created_by`, and provider_details `created_by`

<img width="1183" height="778" alt="Screenshot 2026-03-06 at 2 24 56 PM" src="https://github.com/user-attachments/assets/423d514a-6646-4950-8983-17d910889e4c" />
<img width="1095" height="624" alt="Screenshot 2026-03-06 at 5 07 56 PM" src="https://github.com/user-attachments/assets/5a5f4d88-24c9-49d2-911e-d0f46f82e748" />
<img width="1088" height="640" alt="Screenshot 2026-03-06 at 5 08 43 PM" src="https://github.com/user-attachments/assets/e5a02826-ff3e-4831-9870-775f9282f662" />
<img width="1087" height="628" alt="Screenshot 2026-03-06 at 5 12 35 PM" src="https://github.com/user-attachments/assets/d842256c-2f17-45f9-9976-1fecc4d53489" />


## Checklist

- [x] I have assigned myself to this PR
- [x] PR has an [appropriate title](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/team_agreement.md#naming-prs): #9999 - What the thing does
- [x] PR has a detailed description, including links to specific documentation
- [x] I have added the [appropriate labels](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Engineering/pull_request_labels.md#vanotify-labels) to the PR.
- [x] I did not remove any parts of the template, such as checkboxes even if they are not used
- [x] My code follows the [style guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/style_guide.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to any documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. [Testing guidelines](https://github.com/department-of-veterans-affairs/vanotify-team/blob/main/Process/testing_guide.md)
- [x] I have ensured the latest main is merged into my branch and all checks are green prior to review
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The ticket was moved into the DEV test column when I began testing this change
